### PR TITLE
E2 cog fix

### DIFF
--- a/lua/weapons/gmod_tool/stools/wire_expression2.lua
+++ b/lua/weapons/gmod_tool/stools/wire_expression2.lua
@@ -1102,7 +1102,7 @@ elseif CLIENT then
 			local BonePos, BoneAng = ply:GetBonePosition( BoneIndx )
 			local particle = emitter:Add("expression 2/cog_world", BonePos+Vector(0,0,16))
 			if particle then
-				particle:SetColor12(150,34,34,255)
+				particle:SetColor(150,34,34)
 				particle:SetVelocity(Vector(0,0,17))
 
 				particle:SetDieTime(3)


### PR DESCRIPTION
Fixes the cog particle which caused a lot of error spam. 
Set/GetColor for CLuaParticle is unchanged in gmod13 and it doesn't have an alpha arg.
