### PR TITLE
ZVM Bugfix

### DIFF
--- a/lua/wire/zvm/zvm_opcodes.lua
+++ b/lua/wire/zvm/zvm_opcodes.lua
@@ -455,6 +455,8 @@ end
 --------------------------------------------------------------------------------
 ZVM.OpcodeTable[70] = function(self)  --EXTINT
   self:Dyn_EmitState()
+  self:Emit("VM.IP = "..(self.PrecompileIP or 0))
+  self:Emit("VM.XEIP = "..(self.PrecompileTrueXEIP or 0))
   self:Dyn_Emit("VM:ExternalInterrupt(math.floor($1))")
   self:Dyn_EmitBreak()
   self.PrecompileBreak = true


### PR DESCRIPTION
Fixes the EXTINT instruction not properly updating VM IP/XEIP, and by extension, not pushing the correct return address.
