### PR TITLE
Fixed deprecated use of GetWorldEntity() on Grabber entity

### DIFF
--- a/lua/entities/gmod_wire_grabber/init.lua
+++ b/lua/entities/gmod_wire_grabber/init.lua
@@ -85,7 +85,7 @@ function ENT:TriggerInput(iname, value)
 			local trace = util.TraceLine( trace )
 
 			-- Bail if we hit world or a player
-			if (not trace.Entity:IsValid() and trace.Entity ~= GetWorldEntity())  or trace.Entity:IsPlayer() then return end
+			if (not trace.Entity:IsValid() and trace.Entity ~= game.GetWorld())  or trace.Entity:IsPlayer() then return end
 			-- If there's no physics object then we can't constraint it!
 			if not util.IsValidPhysicsObject( trace.Entity, trace.PhysicsBone ) then return end
 


### PR DESCRIPTION
It's now game.GetWorld()

Wire grabbers would fail to grab upon receiving a signal to their "Grab" input.
