### PR TITLE
Fix Keyboard Stool

### DIFF
--- a/lua/weapons/gmod_tool/stools/wire_keyboard.lua
+++ b/lua/weapons/gmod_tool/stools/wire_keyboard.lua
@@ -188,7 +188,7 @@ function TOOL.BuildCPanel(panel)
 	txt:SetToolTip("If you would like to contribute your keyboard layout, so that it may be added, go post on the wiremod forums.")
 	panel:AddItem(txt)
 
-	local list = vgui.Create("DMultiChoice")
+	local list = vgui.Create("DComboBox")
 	for k,v in pairs( Wire_Keyboard_Remap ) do
 		list:AddChoice( k )
 		list:SetConVar( "wire_keyboard_layout" )


### PR DESCRIPTION
This just renames the DMultiChoice to DComboBox for gmod13.
This makes the stool actually usable, but I cannot figure a way to prevent it from displaying "0" in the box initially.
