### PR TITLE
Fixed CPU/GPU documentation

### DIFF
--- a/lua/wire/CPULib.lua
+++ b/lua/wire/CPULib.lua
@@ -423,9 +423,25 @@ if CLIENT then
   ------------------------------------------------------------------------------
   -- Show ZCPU/ZGPU documentation
   CPULib.HandbookWindow = nil
-
+  
   function CPULib.ShowDocumentation(platform)
-    gui.OpenURL("http://brain.wireos.com/wiremod/zcpudoc.html")
+    local w = ScrW() * 2/3
+  	local h = ScrH() * 2/3
+    local browserWindow = vgui.Create("DFrame")
+    browserWindow:SetTitle("Documentation")
+  	browserWindow:SetPos((ScrW() - w)/2, (ScrH() - h)/2)
+  	browserWindow:SetSize(w,h)
+  	browserWindow.OnClose = function()
+  		browser = nil
+  		browserWindow = nil
+	  end
+    browserWindow:MakePopup()
+	
+  	local browser = vgui.Create("DHTML",browserWindow)
+  	browser:SetPos(10, 25)
+  	browser:SetSize(w - 20, h - 35)
+  
+  	browser:OpenURL("http://brain.wireos.com/wiremod/zcpudoc.html")
   end
 end
 


### PR DESCRIPTION
There was a nil error while trying to open CPU/GPU documentation.
That was fixed. Also, the documentation now uses awesomium instead of the steam browser.
