### PR TITLE
Update ZCPU documentation URL

### DIFF
--- a/lua/wire/CPULib.lua
+++ b/lua/wire/CPULib.lua
@@ -441,7 +441,7 @@ if CLIENT then
   	browser:SetPos(10, 25)
   	browser:SetSize(w - 20, h - 35)
   
-  	browser:OpenURL("http://brain.wireos.com/wiremod/zcpudoc.html")
+  	browser:OpenURL("http://wiki.wiremod.com/wiki/Category:ZCPU_Handbook")
   end
 end
 


### PR DESCRIPTION
As described in issue #123 the documentation URL is out of date, this fixes that.
