### PR TITLE
Halo optimization

### DIFF
--- a/lua/entities/base_wire_entity/cl_init.lua
+++ b/lua/entities/base_wire_entity/cl_init.lua
@@ -57,6 +57,7 @@ function ENT:DrawEntityOutline()
 end
 
 hook.Add("PreDrawHalos", "Wiremod_overlay_halos", function()
+	if #halos == 0 then return end
 	halo.Add(halos, Color(100,100,255), 3, 3, 1, true, true)
 	halos = {}
 	halos_inv = {}


### PR DESCRIPTION
Added check to avoid callling halo.Add when no entity halos need to be drawn.

Garry's halo.Render function will perform a whole load of rendering operations even when halo.Add has been given an empty table of entities.
