### PR TITLE
Fixed prop spawner trying to add cleanup entry for NULL player

### DIFF
--- a/lua/entities/gmod_wire_spawner/init.lua
+++ b/lua/entities/gmod_wire_spawner/init.lua
@@ -1,4 +1,3 @@
-
 AddCSLuaFile( "cl_init.lua" )
 AddCSLuaFile( "shared.lua" )
 
@@ -96,9 +95,12 @@ function ENT:DoSpawn( pl, down )
 		undo.AddEntity( nocollide )
 		undo.SetPlayer( pl )
 	undo.Finish()
-
+	
+	-- Check if the player is NULL (ab0mbs)
+	if IsValid(pl) then
 	pl:AddCleanup( "props", prop )
 	pl:AddCleanup( "props", nocollide )
+	end
 
 	table.insert( self.UndoList, 1, prop )
 	GlobalUndoList[prop] = self


### PR DESCRIPTION
If a player disconnects and someone tries to use the prop spawner,
the spawner will try to add a cleanup entry for a NULL player, throwing an error
No need to add a cleanup entry for a player if they don't exist.
