### PR TITLE
E2: wiring - allow entity:wirelink() on other ENTS

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/wiring.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/wiring.lua
@@ -113,7 +113,6 @@ end
 e2function number entity:removeWirelink()
 	if not IsValid(this) then return 0 end
 	if not isOwner(self, this) then return 0 end
-	if not this.Inputs and not this.Outputs then return 0 end
 	if !this.extended then return 0 end
 	this.extended = false
 	RefreshSpecialOutputs(this)


### PR DESCRIPTION
E2: wiring - allow entity:wirelink() on other ENTS that have outputs or inputs
- fixes CAF wirelink problem

E2 wiring: dont need inputs and outputs on dewiring
- fixes being not able to dewire when ENT removes inputs/outputs
