### PR TITLE
E2 log2 fix (sort of)

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/number.lua
+++ b/lua/entities/gmod_wire_expression2/core/number.lua
@@ -390,11 +390,11 @@ registerFunction("ln", "n", "n", function(self, args)
 	return log(rv1)
 end)
 
-local const_invlog2 = 1 / log(2)
+local const_log2 = log(2)
 registerFunction("log2", "n", "n", function(self, args)
 	local op1 = args[2]
 	local rv1 = op1[1](self, op1)
-	return log(rv1) * const_invlog2
+	return log(rv1) / const_log2
 end)
 
 registerFunction("log10", "n", "n", function(self, args)


### PR DESCRIPTION
Workaround for ancient float issue where for example floor( log2(128) )
would return 6, should be 7.

http://www.wiremod.com/forum/bug-reports-archive/30030-floor-7-6-a.html
