### PR TITLE
[E2] remote upload undefined fix

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/remoteupload.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/remoteupload.lua
@@ -1,5 +1,7 @@
 E2Lib.RegisterExtension("remoteupload", false)
 
+local antispam = {}
+
 local function check(ply)
 	if antispam[ply] and antispam[ply] > CurTime() then
 		return false


### PR DESCRIPTION
sv: Expression 2 (generic): entities/gmod_wire_expression2/core/custom/remoteupload.lua:4: attempt to index global 'antispam' (a nil value)
