### PR TITLE
E2: Block pp/copy exploit

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -350,6 +350,7 @@ end
 e2function void entity:setMaterial(string material)
 	if not IsValid(this) then return end
 	if not isOwner(self, this) then return end
+	if string.lower(material) == "pp/copy" then return end
 	this:SetMaterial(material)
 end
 


### PR DESCRIPTION
I've only modified the E:setMaterial function here, I don't think the exploit is possible with holograms so I did not add any checks in the hologram functions.
