### PR TITLE
Fix holograms causing render glitches by restoring the previous clipping state

### DIFF
--- a/lua/entities/gmod_wire_hologram/cl_init.lua
+++ b/lua/entities/gmod_wire_hologram/cl_init.lua
@@ -32,9 +32,10 @@ function ENT:SetupClipping()
 
 		clip_buffer[eidx] = nil
 	end
+	
 
 	if next(self.clips) then
-		render.EnableClipping( true )
+		self.oldClipState = render.EnableClipping( true )
 
 		for _,clip in pairs( self.clips ) do
 			if clip.enabled and clip.normal and clip.origin then
@@ -58,7 +59,7 @@ function ENT:FinishClipping()
 			render.PopCustomClipPlane()
 		end
 
-		render.EnableClipping( false )
+		render.EnableClipping( self.oldClipState )
 	end
 end
 


### PR DESCRIPTION
Since a good while render.EnableClipping returns the previous clipping state.

Clipping should always be restored to the previous state otherwise water reflections are may displayed incorrectly.
