### PR TITLE
Updated wire light to new GMod light

### DIFF
--- a/lua/entities/gmod_wire_light/cl_init.lua
+++ b/lua/entities/gmod_wire_light/cl_init.lua
@@ -18,22 +18,31 @@ end
 ---------------------------------------------------------*/
 function ENT:DrawTranslucent()
 
-	local LightNrm = self:GetAngles():Up()*(-1)
-	local ViewDot = EyeVector():Dot( LightNrm )
-	local LightPos = self:GetPos() + LightNrm * -10
-
-	// glow sprite
-
-	if ( ViewDot < 0 ) then return end
-
-	render.SetMaterial( matLight )
-	local Visible	= util.PixelVisible( LightPos, 16, self.PixVis )
-	local Size = math.Clamp( 512 * (1 - Visible*ViewDot),128, 512 )
+	local up = self:GetAngles():Up()
 	
-	local c = self:GetColor()
-	c.a = 200*Visible*ViewDot
+	local LightPos = self:GetPos()
+	render.SetMaterial( matLight )
+	
+	local ViewNormal = self:GetPos() - EyePos()
+	local Distance = ViewNormal:Length()
+	ViewNormal:Normalize()
+		
+	local Visibile	= util.PixelVisible( LightPos, 4, self.PixVis )	
+	
+	if ( !Visibile || Visibile < 0.1 ) then return end
 
-	render.DrawSprite( LightPos, Size, Size, c, Visible * ViewDot )
+	local c = self:GetColor()
+	c.a = 255 * Visibile
+	
+	if self:GetModel() == "models/maxofs2d/light_tubular.mdl" then
+		render.DrawSprite( LightPos - up * 2, 8, 8, c, Visibile )
+		render.DrawSprite( LightPos - up * 4, 8, 8, c, Visibile )
+		render.DrawSprite( LightPos - up * 6, 8, 8, c, Visibile )
+		render.DrawSprite( LightPos - up * 5, 64, 64, c, Visibile )
+	else
+		if self:GetModel() == "models/jaanus/wiretool/wiretool_siren.mdl" then c.a = 255 * -Visibile end
+		render.DrawSprite( LightPos + up * ( self:OBBMaxs() - self:OBBMins() ) / 2, 128, 128, c, Visibile )
+	end
 
 end
 
@@ -44,9 +53,7 @@ function ENT:Think()
 
 		local dlight = DynamicLight( self:EntIndex() )
 		if ( dlight ) then
-			local LightNrm = self:GetAngles():Up()*(-1)
-
-			dlight.Pos = self:GetPos() + LightNrm * -10
+			dlight.Pos = self:GetPos()
 			
 			local c = self:GetColor()
 			dlight.r = c.r

--- a/lua/entities/gmod_wire_light/init.lua
+++ b/lua/entities/gmod_wire_light/init.lua
@@ -10,8 +10,7 @@ function ENT:Initialize()
 	self:SetMoveType( MOVETYPE_VPHYSICS )
 	self:SetSolid( SOLID_VPHYSICS )
 
-	self.R, self.G, self.B = 0, 0, 0
-	self:SetColor(Color(0, 0, 0, 255))
+	self.R, self.G, self.B = 0,0,0
 
 	self.Inputs = WireLib.CreateInputs(self, {"Red", "Green", "Blue", "RGB [VECTOR]"})
 end
@@ -94,6 +93,9 @@ function ENT:GlowOn()
 	self:SetGlow(true)
 
 	self.GlowState = true
+	self.brightness = self:GetBrightness()
+	self.decay = self:GetDecay()
+	self.size = self:GetSize()
 end
 
 function ENT:GlowOff()
@@ -155,7 +157,6 @@ function ENT:Setup(directional, radiant, glow)
 			self:GlowOff()
 		end
 	end
-	self:ShowOutput( 0,0,0 )
 end
 
 function ENT:ShowOutput( R, G, B )
@@ -183,7 +184,7 @@ function ENT:ShowOutput( R, G, B )
 	end
 end
 
-function MakeWireLight( pl, Pos, Ang, model, directional, radiant, glow, nocollide, frozen)
+function MakeWireLight( pl, Pos, Ang, model, directional, radiant, glow, brightness, size, decay, r, g, b, nocollide, frozen )
 	if ( !pl:CheckLimit( "wire_lights" ) ) then return false end
 
 	local wire_light = ents.Create( "gmod_wire_light" )
@@ -193,6 +194,14 @@ function MakeWireLight( pl, Pos, Ang, model, directional, radiant, glow, nocolli
 	wire_light:SetPos( Pos )
 	wire_light:SetModel( model )
 	wire_light:Spawn()
+
+	r, g, b = r or 0, g or 0, b or 0
+	wire_light:ShowOutput( r, g, b )
+	
+	wire_light:SetColor( Color( r, g, b ) )
+	wire_light:SetBrightness( brightness or 2 )
+	wire_light:SetDecay( decay or 1280 )
+	wire_light:SetSize( size or 256 )
 
 	wire_light:Setup(directional, radiant, glow)
 	wire_light:SetPlayer(pl)
@@ -215,4 +224,4 @@ function MakeWireLight( pl, Pos, Ang, model, directional, radiant, glow, nocolli
 
 	return wire_light
 end
-duplicator.RegisterEntityClass("gmod_wire_light", MakeWireLight, "Pos", "Ang", "Model", "directional", "radiant", "glow", "nocollide", "frozen")
+duplicator.RegisterEntityClass("gmod_wire_light", MakeWireLight, "Pos", "Ang", "Model", "directional", "radiant", "glow", "brightness", "size", "decay", "R", "G", "B", "nocollide", "frozen")

--- a/lua/wire/stools/light.lua
+++ b/lua/wire/stools/light.lua
@@ -5,9 +5,15 @@ if CLIENT then
 	language.Add( "tool.wire_light.name", "Light Tool (Wire)" )
 	language.Add( "tool.wire_light.desc", "Spawns a Light for use with the wire system." )
 	language.Add( "tool.wire_light.0", "Primary: Create Light" )
+	language.Add( "WireLightTool_RopeLength", "Rope Length:")
+	language.Add( "WireLightTool_bright", "Glow brightness:")
+	language.Add( "WireLightTool_size", "Glow size:" )
+	language.Add( "WireLightTool_decay", "Glow decay:" )
 	language.Add( "WireLightTool_directional", "Directional Component" )
 	language.Add( "WireLightTool_radiant", "Radiant Component" )
 	language.Add( "WireLightTool_glow", "Glow Component" )
+	language.Add( "WireLightTool_const", "Constraint:" )
+	language.Add( "WireLightTool_color", "Color:" )
 end
 WireToolSetup.BaseLang()
 
@@ -18,26 +24,117 @@ if SERVER then
 		return
 			self:GetClientNumber("directional") ~= 0,
 			self:GetClientNumber("radiant") ~= 0,
-			self:GetClientNumber("glow") ~= 0
+			self:GetClientNumber("glow") ~= 0,
+			self:GetClientNumber("brightness"),
+			self:GetClientNumber("size"),
+			self:GetClientNumber("decay"),
+			self:GetClientNumber("r"),
+			self:GetClientNumber("g"),
+			self:GetClientNumber("b")
 	end
 
 	function TOOL:MakeEnt( ply, model, Ang, trace )
 		return MakeWireLight( ply, trace.HitPos, Ang, model, self:GetConVars() )
 	end
+	
+	function TOOL:LeftClick_PostMake( ent, ply, trace )
+		if ent == true then return true end
+		if ent == nil or ent == false or not ent:IsValid() then return false end
+
+		local const = self:GetClientInfo( "const" )
+
+		if const == "weld" then
+			local const = WireLib.Weld( ent, trace.Entity, trace.PhysicsBone, true )
+			undo.Create( self.WireClass )
+				undo.AddEntity( ent )
+				undo.AddEntity( const )
+				undo.SetPlayer( ply )
+			undo.Finish()
+		elseif const == "rope" then
+
+			local length   = self:GetClientNumber( "ropelength" )
+			local material = "cable/rope"
+			
+			local LPos1 = Vector( 0, 0, 0 )
+			if ent:GetModel() == "models/maxofs2d/light_tubular.mdl" then LPos1 = Vector( 0, 0, 5 ) end
+
+			local LPos2 = trace.Entity:WorldToLocal( trace.HitPos )
+
+			if trace.Entity:IsValid() then
+				local phys = trace.Entity:GetPhysicsObjectNum( trace.PhysicsBone )
+				if phys:IsValid() then
+					LPos2 = phys:WorldToLocal( trace.HitPos )
+				end
+			end
+
+			local constraint, rope = constraint.Rope( ent, trace.Entity, 0, trace.PhysicsBone, LPos1, LPos2, 0, length, 0, 1.5, material, nil )
+
+			undo.Create( self.WireClass )
+				undo.AddEntity( ent )
+				undo.AddEntity( rope )
+				undo.AddEntity( constraint )
+				undo.SetPlayer( ply )
+			undo.Finish()
+
+		else --none
+			ent:GetPhysicsObject():EnableMotion(false) -- freeze
+
+			undo.Create( self.WireClass )
+				undo.AddEntity( ent )
+				undo.SetPlayer( ply )
+			undo.Finish()
+		end
+
+		ply:AddCleanup( self.WireClass, ent )
+
+		return true
+	end
 end
 
 TOOL.ClientConVar = {
-	model       = "models/jaanus/wiretool/wiretool_siren.mdl",
-	directional = 0,
-	radiant     = 0,
-	glow        = 0,
-	weld        = 1,
+	model        = "models/jaanus/wiretool/wiretool_siren.mdl",
+	directional  = 0,
+	radiant      = 0,
+	glow         = 0,
+	ropelength   = 64,
+	brightness	 = 2,
+	size		 = 256,
+	decay		 = 1280,
+	const		 = "weld",
+	r			 = 0,
+	g 			 = 0,
+	b			 = 0
 }
 
 function TOOL.BuildCPanel(panel)
-	WireDermaExts.ModelSelect(panel, "wire_light_model", list.Get( "Wire_Misc_Tools_Models" ), 1)
+	local Models = list.Get( "Wire_Misc_Tools_Models" ) -- default wire models
+	Models["models/MaxOfS2D/light_tubular.mdl"] = true -- GMod light
+
+	WireDermaExts.ModelSelect(panel, "wire_light_model", Models, 1)
 	panel:CheckBox("#WireLightTool_directional", "wire_light_directional")
 	panel:CheckBox("#WireLightTool_radiant", "wire_light_radiant")
 	panel:CheckBox("#WireLightTool_glow", "wire_light_glow")
-	panel:CheckBox("Weld", "wire_light_weld")
+	panel:NumSlider("#WireLightTool_bright", "wire_light_brightness", 0, 10, 0)
+	panel:NumSlider("#WireLightTool_decay", "wire_light_decay", 0, 5120, 0)
+	panel:NumSlider("#WireLightTool_size", "wire_light_size", 0, 1024, 0)
+	panel:AddControl("ComboBox", {
+		Label = "#WireLightTool_Const",
+		Options = {
+			["Weld"] = { wire_light_const = "weld" },
+			["None"] = { wire_light_const = "none" },
+			["Rope"] = { wire_light_const = "rope" }
+		}
+	})
+	panel:NumSlider("#WireLightTool_RopeLength", "wire_light_ropelength", 0, 256, 0)
+	panel:AddControl("Color", {
+		Label = "#WireLightTool_color",
+		Red	= "wire_light_r",
+		Green = "wire_light_g",
+		Blue = "wire_light_b",
+		ShowAlpha = "0",
+		ShowHSV = "1",
+		ShowRGB = "1",
+		Multiplier = "255"
+	})
+
 end


### PR DESCRIPTION
-added new light model
-updated the wire light code to match GMod light
-light is now always emited from the center of prop instead of fixed position above prop, making custom light models usable aswell
-added option to create light on rope, and specify rope length instead of just weld
-added option to select color before the light is spawned
-if Glow component is allowed, it's possible to set Brightness, Size and Decay before light is spawned.

Before:
![2013-08-03_00006](https://f.cloud.github.com/assets/332791/905946/52d3073c-fc60-11e2-88ac-27948f44eee6.jpg)
![2013-08-03_00002](https://f.cloud.github.com/assets/332791/905948/6859507a-fc60-11e2-9ada-7b23e543aa8c.jpg)

After:
![2013-08-03_00005](https://f.cloud.github.com/assets/332791/905949/768fac5c-fc60-11e2-9f98-ae61506ca865.jpg)
