### PR TITLE
Fixed "create flat to surface"

### DIFF
--- a/lua/wire/stools/egp.lua
+++ b/lua/wire/stools/egp.lua
@@ -84,19 +84,22 @@ if (SERVER) then
 
 			local flat = self:GetClientNumber("createflat")
 			local ang
-			if (flat == 0) then
+			local isPHX = ( string.find( model, "cheeze" ) || string.find( model, "hunter" ) ) && !string.find( model, "cube" )
+			if isPHX then isPHX = 1 else isPHX = 0 end
+			
+			if (flat == isPHX) then
 				ang = trace.HitNormal:Angle() + Angle(90,0,0)
 			else
-				ang = trace.HitNormal:Angle()
+				ang = trace.HitNormal:Angle() + Angle(180*isPHX,0,0)
 			end
 
 			ent = SpawnEGP( ply, trace.HitPos, ang, model )
 			if (!ent or !ent:IsValid()) then return end
 
-			if (flat == 0) then
+			if (flat == isPHX) then
 				ent:SetPos( trace.HitPos - trace.HitNormal * ent:OBBMins().z )
 			else
-				ent:SetPos( trace.HitPos - trace.HitNormal * ent:OBBMins().x )
+				ent:SetPos( trace.HitPos + trace.HitNormal * ent:OBBMaxs().x )
 			end
 		elseif (Type == 2) then -- HUD
 			ent = SpawnHUD( ply, trace.HitPos + trace.HitNormal * 0.25, trace.HitNormal:Angle() + Angle(90,0,0) )
@@ -377,13 +380,16 @@ function TOOL:UpdateGhost( ent, ply )
 
 	local flat = self:GetClientNumber("createflat")
 	local Type = self:GetClientNumber("type")
+	local isPHX = ( string.find( self:GetModel(), "cheeze" ) || string.find( self:GetModel(), "hunter" ) ) && !string.find( self:GetModel(), "cube" )
+	if isPHX then isPHX = 1 else isPHX = 0 end
+	
 	if (Type == 1) then
-		if (flat == 0) then
+		if (flat == isPHX) then
 			ent:SetAngles( trace.HitNormal:Angle() + Angle(90,0,0) )
 			ent:SetPos( trace.HitPos - trace.HitNormal * ent:OBBMins().z )
 		else
-			ent:SetAngles( trace.HitNormal:Angle() )
-			ent:SetPos( trace.HitPos - trace.HitNormal * ent:OBBMins().x )
+			ent:SetAngles( trace.HitNormal:Angle() + Angle(180*isPHX,0,0) )
+			ent:SetPos( trace.HitPos + trace.HitNormal * ent:OBBMaxs().x )
 		end
 	elseif (Type == 2 or Type == 3) then
 		ent:SetPos( trace.HitPos + trace.HitNormal * 0.25 )

--- a/lua/wire/tool_loader.lua
+++ b/lua/wire/tool_loader.lua
@@ -235,7 +235,16 @@ function WireToolObj:GetAngle( trace )
 	elseif self.GhostAngle then -- the tool gives a fixed angle to add
 		Ang = Ang + self.GhostAngle
 	end
-	if not self.ClientConVar.createflat or self:GetClientNumber("createflat") == 0 then
+	if self.ClientConVar.createflat then
+		local isPHX = ( string.find( self:GetModel(), "cheeze" ) || string.find( self:GetModel(), "hunter" ) ) && !string.find( self:GetModel(), "cube" )
+		if isPHX then isPHX = 1 else isPHX = 0 end
+		
+		if self:GetClientNumber("createflat") == isPHX then
+			Ang.pitch = Ang.pitch + 90
+		else
+			Ang.pitch = Ang.pitch + 180 * isPHX
+		end
+	else
 		Ang.pitch = Ang.pitch + 90
 	end
 	return Ang
@@ -249,7 +258,18 @@ function WireToolObj:SetPos( ent, trace )
 	elseif self.GhostMin then -- tool gives the axis for the OBBmin to use
 		ent:SetPos( trace.HitPos - trace.HitNormal * min[self.GhostMin] )
 	else -- default to the z OBBmin
-		ent:SetPos( trace.HitPos - trace.HitNormal * min.z )
+		if self.ClientConVar.createflat then
+			local isPHX = ( string.find( ent:GetModel(), "cheeze" ) || string.find( ent:GetModel(), "hunter" ) ) && !string.find( ent:GetModel(), "cube" )
+			if isPHX then isPHX = 1 else isPHX = 0 end
+			
+			if self:GetClientNumber("createflat") == isPHX then
+				ent:SetPos( trace.HitPos - trace.HitNormal * min.z )
+			else
+				ent:SetPos( trace.HitPos + trace.HitNormal * ent:OBBMaxs().x )
+			end
+		else
+			ent:SetPos( trace.HitPos - trace.HitNormal * min.z )
+		end
 	end
 end
 if SERVER then WireToolObj.PostMake_SetPos = WireToolObj.SetPos end


### PR DESCRIPTION
#371 - all screens now spawn properly according to "create flat to surface" setting regardless of their model, PHX models are rotated properly and are not sunk inside ground/prop on which they were created.
