### PR TITLE
Fixed pod error while bot using it

### DIFF
--- a/lua/entities/gmod_wire_pod.lua
+++ b/lua/entities/gmod_wire_pod.lua
@@ -410,7 +410,7 @@ function ENT:Think()
 		WireLib.TriggerOutput(self, "Armor", ply:Armor())
 		if self:HasPod() then WireLib.TriggerOutput(self, "ThirdPerson", pod:GetThirdPersonMode() and 1 or 0) end
 		
-		WireLib.TriggerOutput(self, "Light", ply.keystate[KEY_F] and 1 or 0)
+		if not ply:IsBot() then WireLib.TriggerOutput(self, "Light", ply.keystate[KEY_F] and 1 or 0) end
 	end
 
 	self:NextThink( CurTime() )


### PR DESCRIPTION
This was spamming my server console while bot was sitting in seat.

```
[ERROR] addons/wire/lua/entities/gmod_wire_adv_pod/init.lua:358: attempt to index field 'keystate' (a nil value)
  1. unknown - addons/wire/lua/entities/gmod_wire_adv_pod/init.lua:358
```
