### PR TITLE
Change various e2 round functions to use garry's

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/angle.lua
+++ b/lua/entities/gmod_wire_expression2/core/angle.lua
@@ -201,17 +201,16 @@ end
 __e2setcost(5)
 
 e2function angle round(angle rv1)
-	local p = rv1[1] - (rv1[1] + 0.5) % 1 + 0.5
-	local y = rv1[2] - (rv1[2] + 0.5) % 1 + 0.5
-	local r = rv1[3] - (rv1[3] + 0.5) % 1 + 0.5
+	local p = math.Round(rv1[1])
+	local y = math.Round(rv1[2])
+	local r = math.Round(rv1[3])
 	return {p, y, r}
 end
 
-e2function angle round(angle rv1, rv2)
-	local shf = 10 ^ rv2
-	local p = rv1[1] - ((rv1[1] * shf + 0.5) % 1 + 0.5) / shf
-	local y = rv1[2] - ((rv1[2] * shf + 0.5) % 1 + 0.5) / shf
-	local r = rv1[3] - ((rv1[3] * shf + 0.5) % 1 + 0.5) / shf
+e2function angle round(angle rv1, angle rv2)
+	local p = math.Round(rv1[1], rv2[1])
+	local y = math.Round(rv1[2], rv2[2])
+	local r = math.Round(rv1[3], rv2[3])
 	return {p, y, r}
 end
 

--- a/lua/entities/gmod_wire_expression2/core/number.lua
+++ b/lua/entities/gmod_wire_expression2/core/number.lua
@@ -257,16 +257,12 @@ end)
 
 --- rounds to the nearest integer
 e2function number round(rv1)
-	return rv1 - (rv1 + 0.5) % 1 + 0.5
+	return math.Round(rv1)
 end
 
-registerFunction("round", "nn", "n", function(self, args)
-	local op1, op2 = args[2], args[3]
-	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
-
-	local shf = 10 ^ floor(rv2 + 0.5)
-	return floor(rv1*shf+0.5)/shf
-end)
+e2function number round(value, decimals)
+	return math.Round(value, decimals)
+end
 
 --- rounds towards zero
 e2function number int(rv1)

--- a/lua/entities/gmod_wire_expression2/core/vector.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector.lua
@@ -392,20 +392,17 @@ __e2setcost(7)
 
 e2function vector round(vector rv1)
 	return {
-		rv1[1] - (rv1[1] + 0.5) % 1 + 0.5,
-		rv1[2] - (rv1[2] + 0.5) % 1 + 0.5,
-		rv1[3] - (rv1[3] + 0.5) % 1 + 0.5,
+		math.Round(rv1[1]),
+		math.Round(rv1[2]),
+		math.Round(rv1[3]),
 	}
 end
 
-e2function vector round(vector rv1, decimals )
-	local shf = 10 ^ decimals
-	local x,y,z = rv1[1], rv1[2], rv1[3]
-
+e2function vector round(vector rv1, decimals)
 	return {
-		floor(x*shf+0.5)/shf,
-		floor(y*shf+0.5)/shf,
-		floor(z*shf+0.5)/shf,
+		math.Round(rv1[1], decimals),
+		math.Round(rv1[2], decimals),
+		math.Round(rv1[3], decimals),
 	}
 end
 

--- a/lua/entities/gmod_wire_expression2/core/vector2.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector2.lua
@@ -310,26 +310,19 @@ end)
 
 __e2setcost(5)
 
-registerFunction("round", "xv2", "xv2", function(self, args)
-	local op1 = args[2]
-	local rv1 = op1[1](self, op1)
-	local x = rv1[1] - (rv1[1] + 0.5) % 1 + 0.5
-	local y = rv1[2] - (rv1[2] + 0.5) % 1 + 0.5
-	return { x, y }
-end)
-
-registerFunction("round", "xv2n", "xv2", function(self, args)
-	local op1, op2 = args[2], args[3]
-	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
-
-	local shf = 10 ^ rv2
-	local x,y = unpack(rv1)
-
+e2function vector round(vector2 rv1)
 	return {
-		floor(x*shf+0.5)/shf,
-		floor(y*shf+0.5)/shf,
+		math.Round(rv1[1]),
+		math.Round(rv1[2]),
 	}
-end)
+end
+
+e2function vector round(vector2 rv1, decimals)
+	return {
+		math.Round(rv1[1], decimals),
+		math.Round(rv1[2], decimals),
+	}
+end
 
 registerFunction("ceil", "xv2", "xv2", function(self, args)
 	local op1 = args[2]


### PR DESCRIPTION
Change the round functions for numbers, angles, vectors and vector2s to use garry's round function instead of computing it.
On my machine it's even faster this way, for Nebual it appears to be slower.

Either way, the way it was computed was erroneous and sometimes gave strange results.

Fixes #446
