### PR TITLE
Fix E2 editor renaming

### DIFF
--- a/lua/wire/client/wire_expression2_browser.lua
+++ b/lua/wire/client/wire_expression2_browser.lua
@@ -64,7 +64,8 @@ function PANEL:Init()
 	end)
 	self:AddRightClick(self.filemenu, nil, "*SPACER*")
 	self:AddRightClick(self.filemenu, nil, "Rename to..", function()
-		local fname = fileName(self.File:GetFileName())
+		local prefname = fileName(self.File:GetFileName())
+		local fname = string.sub(prefname, 1, #prefname - 4)
 		Derma_StringRequestNoBlur("Rename File \"" .. fname .. "\"", "Rename file " .. fname, fname,
 			function(strTextOut)
 			-- Renaming starts in the garrysmod folder now, in comparison to other commands that start in the data folder.


### PR DESCRIPTION
It added ".txt" to the end of the file name. If you just opened the rename dialog and clicked ok without changing anything, it added another extension (resulting in .txt.txt)
