### PR TITLE
fixed typo which caused missing vector = positive(vector)

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/vector.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector.lua
@@ -312,7 +312,7 @@ e2function vector2 vector:dehomogenized()
 	return { this[1]/w, this[2]/w }
 end
 
-e2function vector vector(vector rv1)
+e2function vector positive(vector rv1)
 	return {
 		rv1[1] >= 0 and rv1[1] or -rv1[1],
 		rv1[2] >= 0 and rv1[2] or -rv1[2],


### PR DESCRIPTION
by http://www.wiremod.com/forum/expression-2-discussion-help/32252-positive-function-vec-3-a.html
ping @Divran 

fixes #325
