### PR TITLE
Fix #385. Use only stock prop protection.

### DIFF
--- a/lua/entities/gmod_wire_clutch.lua
+++ b/lua/entities/gmod_wire_clutch.lua
@@ -245,14 +245,11 @@ function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
 		Ent1 = GetEntByID(v.Ent1)
 		Ent2 = GetEntByID(v.Ent2, game.GetWorld())
 
-		if IsValid(Ent1) and Ent1 ~= Ent2 then
-			if CPPI then
-				if Ent1:CPPICanTool( ply, "ballsocket_adv" ) and Ent2:CPPICanTool( ply, "ballsocket_adv" ) then
-					self:AddClutch( Ent1, Ent2 )
-				end
-			else
-				self:AddClutch( Ent1, Ent2 )
-			end
+		if IsValid(Ent1) and
+		   Ent1 ~= Ent2 and
+		   hook.Run( "CanTool", ply, WireLib.dummytrace(Ent1), "ballsocket_adv" ) and
+		   hook.Run( "CanTool", ply, WireLib.dummytrace(Ent2), "ballsocket_adv" ) then
+			self:AddClutch( Ent1, Ent2 )
 		end
 	end
 end

--- a/lua/entities/gmod_wire_colorer.lua
+++ b/lua/entities/gmod_wire_colorer.lua
@@ -34,35 +34,24 @@ function ENT:Setup(outColor,Range)
 	self:ShowOutput()
 end
 
-local function CheckPP(ply, ent)
-	if !IsValid(ply) or !IsValid(ent) then return false end
-	if CPPI then
-		-- Temporary, done this way due to certain PP implementations not always returning a value for CPPICanTool
-		if ent == ply then return true end
-		if ent:CPPICanTool( ply, "colour" ) == false then return false end
-	end
-	return true
-end
-
 function ENT:TriggerInput(iname, value)
-	if iname == "Fire" then
-		if value ~= 0 then
-			local vStart = self:GetPos()
-			local vForward = self:GetUp()
+	if iname == "Fire" and value ~= 0 then
+		local vStart = self:GetPos()
+		local vForward = self:GetUp()
 
-			local trace = {}
-				trace.start = vStart
-				trace.endpos = vStart + (vForward * self:GetBeamLength())
-				trace.filter = { self }
-			local trace = util.TraceLine( trace )
-
-			if !CheckPP( self:GetPlayer(), trace.Entity ) then return end
-			if trace.Entity:IsPlayer() then
-				trace.Entity:SetColor(Color(self.InColor.r, self.InColor.g, self.InColor.b, 255))
-			else
-				trace.Entity:SetColor(Color(self.InColor.r, self.InColor.g, self.InColor.b, self.InColor.a))
-				trace.Entity:SetRenderMode(self.InColor.a == 255 and RENDERMODE_NORMAL or RENDERMODE_TRANSALPHA )
-			end
+		local trace = util.TraceLine {
+			start = vStart,
+			endpos = vStart + (vForward * self:GetBeamLength()),
+			filter = { self }
+		}
+		if not IsValid(trace.Entity) then return end
+		if not hook.Run( "CanTool", self:GetOwner(), trace, "colour" ) then return end
+			
+		if trace.Entity:IsPlayer() then
+			trace.Entity:SetColor(Color(self.InColor.r, self.InColor.g, self.InColor.b, 255))
+		else
+			trace.Entity:SetColor(Color(self.InColor.r, self.InColor.g, self.InColor.b, self.InColor.a))
+			trace.Entity:SetRenderMode(self.InColor.a == 255 and RENDERMODE_NORMAL or RENDERMODE_TRANSALPHA )
 		end
 	elseif iname == "R" then
 		self.InColor.r = math.Clamp(value, 0, 255)

--- a/lua/entities/gmod_wire_nailer.lua
+++ b/lua/entities/gmod_wire_nailer.lua
@@ -26,109 +26,50 @@ function ENT:Setup(flim, Range, ShowBeam)
 	self:ShowOutput()
 end
 
+function ENT:CanNail(trace)
+	-- Bail if we hit world or a player
+	if not IsValid(trace.Entity) or trace.Entity:IsPlayer() then return false end
+	-- If there's no physics object then we can't constraint it!
+	if not util.IsValidPhysicsObject(trace.Entity, trace.PhysicsBone) then return false end
+	-- The nailer tool no longer exists, but we ask for permission under its name anyway
+	if not hook.Run( "CanTool", self:GetOwner(), trace, "nailer" ) then return false end
+	return true
+end
+
 function ENT:TriggerInput(iname, value)
-	if iname == "A" then
-		if value ~= 0 then
-			 local vStart = self:GetPos()
-			 local vForward = self:GetUp()
+	if iname == "A" and value ~= 0 then
+		local vStart = self:GetPos()
+		local vForward = self:GetUp()
+		
+		local trace1 = util.TraceLine {
+			start = vStart,
+			endpos = vStart + (vForward * self:GetBeamLength()),
+			filter = { self }
+		}
+		if not CanNail(trace1) then return end
+			
+		local trace2 = util.TraceLine {
+			start = trace1.HitPos,
+			endpos = trace1.HitPos + (vForward * 50.0),
+			filter = { trace1.Entity, self }
+		}
+		if not CanNail(trace2) then return end
 
-			 local trace = {}
-				 trace.start = vStart
-				 trace.endpos = vStart + (vForward * self:GetBeamLength())
-				 trace.filter = { self }
-			 local trace = util.TraceLine( trace )
+		local constraint = constraint.Weld( trace1.Entity, trace2.Entity, trace1.PhysicsBone, trace2.PhysicsBone, self.Flim )
 
-			-- Bail if we hit world or a player
-			if not trace.Entity:IsValid() or trace.Entity:IsPlayer() then return end
-			-- If there's no physics object then we can't constraint it!
-			if not util.IsValidPhysicsObject(trace.Entity, trace.PhysicsBone) then return end
-
-			local tr = {}
-				tr.start = trace.HitPos
-				tr.endpos = trace.HitPos + (self:GetUp() * 50.0)
-				tr.filter = { trace.Entity, self }
-			local trTwo = util.TraceLine( tr )
-
-			if trTwo.Hit and not trTwo.Entity:IsPlayer() then
-				if (trace.Entity:GetOwner() ~= self:GetOwner() and not self:CheckOwner(trace.Entity)) or (trTwo.Entity:GetOwner() ~= self:GetOwner() and not self:CheckOwner(trTwo.Entity)) then return end
-				-- Weld them!
-				local constraint = constraint.Weld( trace.Entity, trTwo.Entity, trace.PhysicsBone, trTwo.PhysicsBone, self.Flim )
-
-				-- effect on weld (tomb332)
-				local effectdata = EffectData()
-					effectdata:SetOrigin( trTwo.HitPos )
-					effectdata:SetNormal( trTwo.HitNormal )
-					effectdata:SetMagnitude( 5 )
-					effectdata:SetScale( 1 )
-					effectdata:SetRadius( 10 )
-				util.Effect( "Sparks", effectdata )
-			end
-		end
+		-- effect on weld (tomb332)
+		local effectdata = EffectData()
+			effectdata:SetOrigin( trace2.HitPos )
+			effectdata:SetNormal( trace1.HitNormal )
+			effectdata:SetMagnitude( 5 )
+			effectdata:SetScale( 1 )
+			effectdata:SetRadius( 10 )
+		util.Effect( "Sparks", effectdata )
 	end
 end
 
 function ENT:ShowOutput()
 	self:SetOverlayText("Force Limit: " .. self.Flim )
-end
-
--- Free Fall's Owner Check Code
-function ENT:CheckOwner(ent)
-	ply = self:GetPlayer()
-
-	hasCPPI = istable( CPPI )
-	hasEPS = istable( eps )
-	hasPropSecure = istable( PropSecure )
-	hasProtector = istable( Protector )
-
-	if not hasCPPI and not hasPropProtection and not hasSPropProtection and not hasEPS and not hasPropSecure and not hasProtector then return true end
-
-	local t = hook.GetTable()
-
-	local fn = t.CanTool.PropProtection
-	hasPropProtection = isfunction( fn )
-	if hasPropProtection then
-		-- We're going to get the function we need now. It's local so this is a bit dirty
-		local gi = debug.getinfo( fn )
-		for i=1, gi.nups do
-			local k, v = debug.getupvalue( fn, i )
-			if k == "Appartient" then
-				propProtectionFn = v
-			end
-		end
-	end
-
-	local fn = t.CanTool[ "SPropProtection.EntityRemoved" ]
-	hasSPropProtection = isfunction( fn )
-	if hasSPropProtection then
-		local gi = debug.getinfo( fn )
-		for i=1, gi.nups do
-			local k, v = debug.getupvalue( fn, i )
-			if k == "SPropProtection" then
-				SPropProtectionFn = v.PlayerCanTouch
-			end
-		end
-	end
-
-	local owns
-	if hasCPPI then
-		owns = ent:CPPICanPhysgun( ply )
-	elseif hasPropProtection then -- Chaussette's Prop Protection (preferred over PropSecure)
-		owns = propProtectionFn( ply, ent )
-	elseif hasSPropProtection then -- Simple Prop Protection by Spacetech
-		if ent:GetNetworkedString( "Owner" ) ~= "" then -- So it doesn't give an unowned prop
-			owns = SPropProtectionFn( ply, ent )
-		else
-			owns = false
-		end
-	elseif hasEPS then -- EPS
-		owns = eps.CanPlayerTouch( ply, ent )
-	elseif hasPropSecure then -- PropSecure
-		owns = PropSecure.IsPlayers( ply, ent )
-	elseif hasProtector then -- Protector
-		owns = Protector.Owner( ent ) == ply:UniqueID()
-	end
-
-	return owns
 end
 
 duplicator.RegisterEntityClass("gmod_wire_nailer", WireLib.MakeWireEnt, "Data", "Flim")

--- a/lua/entities/gmod_wire_target_finder.lua
+++ b/lua/entities/gmod_wire_target_finder.lua
@@ -218,28 +218,14 @@ function ENT:FindColor(contact)
 	end
 end
 
-//Prop Protection Buddy List Support (EXPERIMENTAL!!!)
-function ENT:CheckTheBuddyList(Ami)
-	if (!self.CheckBuddyList) then return true end
-
-	local info = Ami:GetInfo( "propprotection_ami"..self:GetPlayer():EntIndex() ) --am I on their list
-	if ( info == "0" ) then
-		return !self.OnBuddyList
+function ENT:CheckTheBuddyList(friend)
+	if not self.CheckBuddyList or not CPPI then return true end
+	
+	for _, v in pairs(self:GetPlayer():CPPIGetFriends()) do
+		if v == friend then return self.OnBuddyList end
 	end
-	return self.OnBuddyList
+	return not self.OnBuddyList
 end
-
-/*function ENT:BelongsToBuddy(contact)
-	if (!self.CheckBuddyList) then return true end
-
-	local info = self:GetOwner():GetInfo( "propprotection_ami"..contact:GetPlayer():EntIndex() )
-	if ( info == "0" ) then
-		return false
-	else
-		return true
-	end
-end*/
-
 
 function ENT:Think()
 	self.BaseClass.Think(self)


### PR DESCRIPTION
Wherever possible, use the CanTool hook to determine whether tools are allowed.
When a full friend list is needed, use CPPI as that's the closest thing we have to a standard.

This could do with some testing in multiplayer - I can't test particularly well at the moment as I'm having trouble with mouse input in Garry's Mod.
