### PR TITLE
Fix #504. Wire buttons in non-wire button tool no longer causes error

### DIFF
--- a/lua/wire/client/cl_modelplug.lua
+++ b/lua/wire/client/cl_modelplug.lua
@@ -131,7 +131,7 @@ local CheezesButtons = {
 }
 for k,v in ipairs(CheezesButtons) do
 	if file.Exists(v,"GAME") then
-		list.Set( "ButtonModels", v, true )
+		list.Set( "ButtonModels", v, {} )
 		list.Set( "Wire_button_Models", v, true )
 	end
 end
@@ -149,7 +149,7 @@ local CheezesSmallButtons = {
 }
 for k,v in ipairs(CheezesSmallButtons) do
 	if file.Exists(v,"GAME") then
-		list.Set( "ButtonModels", v, true )
+		list.Set( "ButtonModels", v, {} )
 		list.Set( "Wire_button_small_Models", v, true )
 	end
 end


### PR DESCRIPTION
The table seems to be an extra list of convar-value pairs. Just went ahead and mimicked garry's code:

```
list.Set( "ButtonModels", "models/MaxOfS2D/button_01.mdl", {} )
```
