### PR TITLE
Gate output trigger fix

### DIFF
--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -520,7 +520,7 @@ function Wire_TriggerOutput(ent, oname, value, iter)
 
 		for _,dst in ipairs(output.Connected) do
 			if (IsValid(dst.Entity)) then
-				WireLib.TriggerInput(dst.Entity, dst.Name, value)
+				WireLib.TriggerInput(dst.Entity, dst.Name, value, iter)
 			end
 		end
 


### PR DESCRIPTION
Gates should now update properly by evaluating each of a gate's children before it's children's children. Strangely the iterator was being created but not passed in the function, so it wasn't fulfilling its purpose, but everything was setup for this.
