### PR TITLE
Changed the method for scaling bones

### DIFF
--- a/lua/entities/gmod_wire_hologram.lua
+++ b/lua/entities/gmod_wire_hologram.lua
@@ -154,6 +154,7 @@ if CLIENT then
 		local ent = Entity(entindex)
 
 		if ent and ent.DoScale then
+			ent.bone_flag = nil
 			ent:DoScale()
 		end
 	end
@@ -171,6 +172,7 @@ if CLIENT then
 
 		if ent and ent.DoScale then
 			if bindex == -1 then ent.bone_scale = {} end -- reset bone scale
+			ent.bone_flag = true
 			ent:DoScale()
 		end
 	end
@@ -194,10 +196,13 @@ if CLIENT then
 
 		local count = self:GetBoneCount() or -1
 		if count > 1 then
-			for i = count, 0, -1 do
-				self:ManipulateBoneScale(i, self.bone_scale[i] or scale)
+			if self.bone_flag then
+				for i = count, 0, -1 do
+					self:ManipulateBoneScale(i, self.bone_scale[i] or scale)
+				end
+			else
+				self:SetModelScale((scale.x + scale.y + scale.z) / 3, 0)
 			end
-			self:SetModelScale((scale.x + scale.y + scale.z) / 3, 0)
 		elseif self.EnableMatrix then
 			local mat = Matrix()
 			mat:Scale(Vector(scale.y, scale.x, scale.z)) -- Note: We're swapping X and Y because RenderMultiply isn't consistant with the rest of source


### PR DESCRIPTION
Lines 196-200, the for loop has been reversed, starting from the back and working forward. The bone scale method prefers scaling in reverse order.

I am not sure about the efficiency of adding "self:SetModelScale((scale.x + scale.y + scale.z) / 3, 0)" directly after the bone scaling. When you set a hologram model to a ragdoll, it does not reach the "else self:SetModelScale((scale.x + scale.y + scale.z) / 3, 0) end" statement, and therefore only scales the bones and not the whole thing.

The issue that I have with the current method is that when you scale it normally, ie: holoScale( 1, vec(2,2,2) ), it does not only scale the entire model, but each bone as well. When this method is used, you have to loop through all of the bones if you want them reset to normal scale, after re-scaling the model it's self.

![gm_carcon_ws0003](https://f.cloud.github.com/assets/3125314/2103410/f682ce00-8f6b-11e3-980f-5f0a5d984e91.jpg)

![gm_carcon_ws0004](https://f.cloud.github.com/assets/3125314/2103415/051bec76-8f6c-11e3-96c1-0e1d0a5bc94a.jpg)
