### PR TITLE
Update gmod_wire_grabber.lua

### DIFF
--- a/lua/entities/gmod_wire_grabber.lua
+++ b/lua/entities/gmod_wire_grabber.lua
@@ -82,7 +82,7 @@ function ENT:TriggerInput(iname, value)
 				endpos = vStart + (vForward * self:GetBeamLength()),
 				filter = { self }
 			}
-			if not CanGrab(trace) then return end
+			if not self:CanGrab(trace) then return end
 
 			-- Weld them!
 			local const = constraint.Weld(self, trace.Entity, 0, 0, self.WeldStrength)


### PR DESCRIPTION
Wire error (Entity [455][gmod_wire_grabber]): lua/entities/gmod_wire_grabber.lua:85: attempt to call global 'CanGrab' (a nil value)
