### PR TITLE
Expression2 bone.lua, fixed isInvalidBone always returning true.

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/bone.lua
+++ b/lua/entities/gmod_wire_expression2/core/bone.lua
@@ -78,7 +78,7 @@ E2Lib.isValidBone2 = isValidBone2
 
 -- checks whether the bone is valid. if yes, returns false; otherwise, returns true.
 local function isInvalidBone(b)
-	if not IsValid(b) then return true end
+	if type(b) ~= "PhysObj" or not b:IsValid() then return true end
 	if not IsValid(bone2entity[b]) then
 		removeBone(b)
 		return true


### PR DESCRIPTION
Line 81. isentity(b) always returns false.
