### PR TITLE
Adv Input - allow external prop protection to dictate On/Off

### DIFF
--- a/lua/entities/gmod_wire_adv_input.lua
+++ b/lua/entities/gmod_wire_adv_input.lua
@@ -89,11 +89,13 @@ end
 
 local function On( pl, ent, mul )
 	if (!ent:IsValid()) then return false end
+	if not gamemode.Call("PlayerUse", pl, ent) then return end
 	return ent:InputActivate( mul )
 end
 
 local function Off( pl, ent, mul )
 	if (!ent:IsValid()) then return false end
+	if not gamemode.Call("PlayerUse", pl, ent) then return end
 	return ent:InputDeactivate( mul )
 end
 numpad.Register( "WireAdvInput_On",On)


### PR DESCRIPTION
There is currently no way to prevent players from messing with the owner's Adv Input without directly modifying this file.

Since the On/Off functions act like that of a Button, I chose PlayerUse as the hook. This will allow any custom or public prop protections to handle it instead. I believe Wiremod is using gamemode.Call for hooks included in the base gamemode, so I am using that instead of hook.Run.

There may be a better hook available for handling this, but I can't think of one at the moment. If this isn't merged, please at least look into adding a way to let external prop protections to handle this.
