### PR TITLE
Fixed missing anti-spam checks on certain remoteSetCode functions.

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/remoteupload.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/remoteupload.lua
@@ -29,6 +29,7 @@ __e2setcost(250)
 e2function void entity:remoteSetCode( string code )
 	if not this or not this:IsValid() or this:GetClass() ~= "gmod_wire_expression2" then return end
 	if not E2Lib.isOwner( self, this ) then return end
+	if not check(self.player) then return end
 	
 	this:Setup( code, {} )
 end
@@ -36,6 +37,7 @@ end
 e2function void entity:remoteSetCode( string main, table includes )
 	if not this or not this:IsValid() or this:GetClass() ~= "gmod_wire_expression2" then return end
 	if not E2Lib.isOwner( self, this ) then return end
+	if not check(self.player) then return end
 
 	local luatable = {}
 	


### PR DESCRIPTION
Fixed missing anti-spam checks on certain remoteSetCode functions.

This will fix players from locking up the server. (see http://hastebin.com/darecoguha.lua).
