### PR TITLE
Fixed reference to nil value (self.player to ply)

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/debug.lua
+++ b/lua/entities/gmod_wire_expression2/core/debug.lua
@@ -211,7 +211,7 @@ local printColor_typeids = {
 
 local function printColorVarArg(chip, ply, typeids, ...)
 	if not IsValid(ply) then return end
-	if not check_delay( self.player ) then return end
+	if not check_delay(ply) then return end
 	local send_array = { ... }
 
 	for i,tp in ipairs(typeids) do


### PR DESCRIPTION
Fixed error referencing nil value self.player.

Changed to "ply" supplied by the printColorVarArg function.
