### PR TITLE
Line 86 and the checkbox statement on Camera Controller

### DIFF
--- a/lua/entities/gmod_wire_cameracontroller.lua
+++ b/lua/entities/gmod_wire_cameracontroller.lua
@@ -83,7 +83,6 @@ if CLIENT then
 		if HasParent and ValidParent then
 			if LocalMove then
 				curpos = parent:LocalToWorld( curpos - curang:Forward() * smoothdistance )
-				curang = parent:LocalToWorldAngles( curang )
 			else
 				curpos = parent:LocalToWorld( curpos ) - curang:Forward() * smoothdistance
 			end


### PR DESCRIPTION
The tool states:
"Determines wether the client side movement is local to the parent or not"
I don't actually see a reason why the angles should be parented too, it's supposed that only the camera position gets parented when it states movement. I'd rather suggest that there should be two options in the tool, one that allows you to parent the camera angles to the parent entity and another one that parents the camera position to the entity, so you will be able to have constant angles and parented position in the camera.
