### PR TITLE
Added entity:attachments()

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -734,7 +734,7 @@ e2function array entity:attachments()
 	local tmp = {}
 	local atc = this:GetAttachments()
 	for i=1, #atc do
-		tmp[i] = v.name
+		tmp[i] = atc[i].name
 	end
 	return tmp
 end


### PR DESCRIPTION
returns an array containing all of the attachment names pertaining to the given entity.
