### PR TITLE
Fixed reference to nil value causing errors when players disconnect.

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/debug.lua
+++ b/lua/entities/gmod_wire_expression2/core/debug.lua
@@ -31,7 +31,7 @@ hook.Add( "Think", "e2_printcolor_delays", function()
 				delays.count = print_max
 			end
 		else
-			print_delays[k] = nil
+			print_delays[ply] = nil
 		end
 	end
 end)


### PR DESCRIPTION
Fixed the following:
```
[ERROR] entities/gmod_wire_expression2/core/debug.lua:34: table index is nil
  1. v - entities/gmod_wire_expression2/core/debug.lua:34
   2. unknown - lua/includes/modules/hook.lua:84
```
Caused by k being nil. Error happens when leaving a server while E2 is printing.