### PR TITLE
Fix for issue  #797

### DIFF
--- a/lua/entities/gmod_wire_keyboard/init.lua
+++ b/lua/entities/gmod_wire_keyboard/init.lua
@@ -40,8 +40,7 @@ end
 
 function ENT:TriggerInput( name, value )
 	if name == "Kick the bastard out of keyboard" then
-		self.Locked = (value ~= 0)
-		self:PlayerDetach()
+		timer.Simple(0.1, function() self.Locked = (value ~= 0) self:PlayerDetach() end ) --It was kicking at the same time as giving output - added tiny delay fixing that race condition
 	end
 end
 


### PR DESCRIPTION
Fixes the race condition I actually confirmed with Workshop version, tiny delay should be added between reading input and actual action