### PR TITLE
Clean up and update text editor UI.

### DIFF
--- a/lua/wire/client/wire_expression2_editor.lua
+++ b/lua/wire/client/wire_expression2_editor.lua
@@ -442,7 +442,7 @@ function Editor:SetActiveTab(val)
 		self.C.TabHolder:SetActiveTab(val)
 		val:GetPanel():RequestFocus()
 	end
-
+	if self.E2 then self:Validate() end
 
 	-- Editor subtitle and tab text
 	local title, tabtext = getPreferredTitles(self:GetChosenFile(), self:GetCode())

--- a/lua/wire/client/wire_expression2_editor.lua
+++ b/lua/wire/client/wire_expression2_editor.lua
@@ -809,7 +809,8 @@ function Editor:InitComponents()
 
 	self.C.TabHolder:SetPadding(1)
 
-	self.C.Menu:SetHeight(22)
+	self.C.Menu:SetHeight(24)
+	self.C.Menu:DockPadding(2,2,2,2)
 	self.C.Val:SetHeight(22)
 
 	self.C.SaE:SetSize(80, 20)
@@ -1786,7 +1787,7 @@ function Editor:Validate(gotoerror)
 	if self.EditorType == "E2" then
 		local errors = wire_expression2_validate(self:GetCode())
 		if not errors then
-			self.C.Val:SetBGColor(0, 128, 0, 180)
+			self.C.Val:SetBGColor(0, 110, 20, 255)
 			self.C.Val:SetText("   Validation successful")
 			return true
 		end
@@ -1797,7 +1798,7 @@ function Editor:Validate(gotoerror)
 			end
 			if row then self:GetCurrentEditor():SetCaret({ tonumber(row), tonumber(col) }) end
 		end
-		self.C.Val:SetBGColor(128, 0, 0, 180)
+		self.C.Val:SetBGColor(110, 0, 20, 255)
 		self.C.Val:SetText("   " .. errors)
 	elseif self.EditorType == "CPU" or self.EditorType == "GPU" or self.EditorType == "SPU" then
 		self.C.Val:SetBGColor(64, 64, 64, 180)

--- a/lua/wire/client/wire_expression2_editor.lua
+++ b/lua/wire/client/wire_expression2_editor.lua
@@ -812,14 +812,9 @@ function Editor:OnTabClosed(sheet) end
 -- This function is made to be overwritten
 
 -- initialization commands
-
-local wire_expression2_editor_browserwidth = CreateClientConVar("wire_expression2_editor_browserwidth", "200", true, false)
-
 function Editor:InitComponents()
 	self.Components = {}
 	self.C = {}
-
-	local bw = wire_expression2_editor_browserwidth:GetInt()
 
 	local DMenuButton = vgui.RegisterTable({
 		Init = function(panel)
@@ -844,7 +839,15 @@ function Editor:InitComponents()
 	self.C.Inf = self:addComponent(vgui.CreateFromTable(DMenuButton, self), -45-8-24, 2, 22, 20) -- Info button
 	self.C.ConBut = self:addComponent(vgui.CreateFromTable(DMenuButton, self), -45-8-24-24, 2, 22, 20) -- Control panel open/close
 
-	self.C.Menu = self:addComponent(vgui.Create("DPanel", self), bw + 20, 30, -8, 20)
+	self.C.Divider = vgui.Create("DHorizontalDivider", self)
+
+	self.C.Browser = vgui.Create("wire_expression2_browser", self.C.Divider) -- Expression browser
+
+	self.C.MainPane = vgui.Create("DPanel", self.C.Divider)
+	self.C.Menu = vgui.Create("DPanel", self.C.MainPane)
+	self.C.Val = vgui.Create("Button", self.C.MainPane) -- Validation line
+	self.C.TabHolder = vgui.Create("DPropertySheet", self.C.MainPane)
+
 	self.C.Btoggle = vgui.CreateFromTable(DMenuButton, self.C.Menu) -- Toggle Browser being shown
 	self.C.Sav = vgui.CreateFromTable(DMenuButton, self.C.Menu) -- Save button
 	self.C.NewTab = vgui.CreateFromTable(DMenuButton, self.C.Menu, "NewTab") -- New tab button
@@ -853,19 +856,33 @@ function Editor:InitComponents()
 	self.C.SaE = vgui.CreateFromTable(DMenuButton, self.C.Menu) -- Save & Exit button
 	self.C.SavAs = vgui.CreateFromTable(DMenuButton, self.C.Menu) -- Save As button
 
-	self.C.Browser = self:addComponent(vgui.Create("wire_expression2_browser", self), 10, 30, bw + 7, -10) -- Expression browser
-	self.C.TabHolder = self:addComponent(vgui.Create("DPropertySheet", self), bw + 15, 52, -5, -27) -- TabHolder
-	self:CreateTab("generic")
-	self.C.Val = self:addComponent(vgui.Create("Button", self), bw + 20, -30, -10, 20) -- Validation line
-
 	self.C.Control = self:addComponent(vgui.Create("Panel", self), -350, 52, 342, -32) -- Control Panel
 	self.C.Credit = self:addComponent(vgui.Create("DTextEntry", self), -160, 52, 150, 150) -- Credit box
 
+	self:CreateTab("generic")
+
 	-- extra component options
+
+	self:DockPadding(10, 30, 10, 10)
+
+	self.C.Divider:SetLeft(self.C.Browser)
+	self.C.Divider:SetRight(self.C.MainPane)
+	self.C.Divider:Dock(FILL)
+	self.C.Divider:SetDividerWidth(4)
+	self.C.Divider:SetCookieName("wire_expression2_editor_divider")
 
 	local DoNothing = function() end
 	self.C.TabHolder.Paint = DoNothing
+	self.C.MainPane.Paint = DoNothing
 	self.C.Menu.Paint = DoNothing
+
+	self.C.Menu:Dock(TOP)
+	self.C.TabHolder:Dock(FILL)
+	self.C.Val:Dock(BOTTOM)
+
+	self.C.Menu:SetHeight(20)
+	self.C.Val:SetHeight(20)
+	self.C.TabHolder:DockMargin(-10, 0, -8, -5)
 
 	self.C.SaE:SetSize(80, 20)
 	self.C.SaE:Dock(RIGHT)
@@ -1411,27 +1428,6 @@ function Editor:InitControlPanel(frame)
 	HighlightOnDoubleClick:SetText("Highlight copies of selected word")
 	HighlightOnDoubleClick:SizeToContents()
 	HighlightOnDoubleClick:SetTooltip("Find all identical words and highlight them after a double-click.")
-
-	-- Browser width
-	local BrowserWidthSlider = vgui.Create("DNumSlider")
-	dlist:AddItem(BrowserWidthSlider)
-	BrowserWidthSlider:SetText("Browser Width")
-	BrowserWidthSlider:SetMinMax(150, 325)
-	BrowserWidthSlider:SetDecimals(0)
-	BrowserWidthSlider:SetDark(false)
-	BrowserWidthSlider:SetConVar("wire_expression2_editor_browserwidth")
-	local btoggle = self.C.Btoggle
-	function BrowserWidthSlider.OnValueChanged(pnl, bw)
-		if bw == wire_expression2_editor_browserwidth:GetInt() then return end
-		btoggle.hide = self.C.Browser.Bounds.w > bw
-		btoggle.toggle = true
-		timer.Create("Expression2_ChangeBrowserWidth", 0, 30, function()
-			if btoggle.hide and self.C.Browser.Bounds.w < (bw + 10) then
-				btoggle.hide = false
-				timer.Remove("Expression2_ChangeBrowserWidth")
-			end
-		end)
-	end
 
 	local WorldClicker = vgui.Create("DCheckBoxLabel")
 	dlist:AddItem(WorldClicker)

--- a/lua/wire/client/wire_expression2_editor.lua
+++ b/lua/wire/client/wire_expression2_editor.lua
@@ -889,16 +889,26 @@ function Editor:InitComponents()
 			self:Validate(true)
 		end
 	end
-	self.C.Btoggle:SetText("<")
-	self.C.Btoggle.DoClick = function(button)
+	self.C.Btoggle:SetImage("icon16/application_side_contract.png")
+	function self.C.Btoggle.DoClick(button)
 		if button.hide then
+			self.C.Divider:LoadCookies()
+		else
+			self.C.Divider:SetLeftWidth(0)
+		end
+		button:InvalidateLayout()
+	end
+
+	local oldBtoggleLayout = self.C.Btoggle.PerformLayout
+	function self.C.Btoggle.PerformLayout(button)
+		oldBtoggleLayout(button)
+		if self.C.Divider:GetLeftWidth() > 0 then
 			button.hide = false
-			button:SetText("<")
+			button:SetImage("icon16/application_side_contract.png")
 		else
 			button.hide = true
-			button:SetText(">")
+			button:SetImage("icon16/application_side_expand.png")
 		end
-		button.toggle = true
 	end
 
 	self.C.Credit:SetTextColor(Color(0, 0, 0, 255))

--- a/lua/wire/client/wire_expression2_editor.lua
+++ b/lua/wire/client/wire_expression2_editor.lua
@@ -834,7 +834,7 @@ function Editor:InitComponents()
 		DoClick = function(panel)
 			local name = panel:GetName()
 			local f = name and name ~= "" and self[name] or nil
-			if f then f() end
+			if f then f(self) end
 		end
 	}, "DButton")
 
@@ -871,6 +871,9 @@ function Editor:InitComponents()
 	self.C.SaE:Dock(RIGHT)
 	self.C.SavAs:SetSize(51, 20)
 	self.C.SavAs:Dock(RIGHT)
+
+	self.C.Inf:Dock(NODOCK)
+	self.C.ConBut:Dock(NODOCK)
 
 
 	self.C.Close:SetText("x")

--- a/lua/wire/client/wire_expression2_editor.lua
+++ b/lua/wire/client/wire_expression2_editor.lua
@@ -825,24 +825,29 @@ function Editor:InitComponents()
 	-- if x, y, w, h is minus, it will stay relative to right or buttom border
 	self.C.Close = self:addComponent(vgui.Create("DButton", self), -22, 4, 18, 18) -- Close button
 	self.C.Inf = self:addComponent(vgui.Create("DButton", self), -42, 4, 18, 18) -- Info button
+	self.C.ConBut = self:addComponent(vgui.Create("Button", self), -62, 4, 18, 18) -- Control panel open/close
+
+	self.C.Btoggle = self:addComponent(vgui.Create("Button", self), bw + 20, 30, 20, 20) -- Toggle Browser being shown
 	self.C.Sav = self:addComponent(vgui.Create("Button", self), bw + 41, 30, 20, 20) -- Save button
 	self.C.NewTab = self:addComponent(vgui.Create("Button", self), bw + 62, 30, 20, 20) -- New tab button
 	self.C.CloseTab = self:addComponent(vgui.Create("Button", self), bw + 83, 30, 20, 20) -- Close tab button
 	self.C.Reload = self:addComponent(vgui.Create("Button", self), bw + 104, 30, 20, 20) -- Reload tab button
+
 	self.C.SaE = self:addComponent(vgui.Create("Button", self), -70, 30, -10, 20) -- Save & Exit button
 	self.C.SavAs = self:addComponent(vgui.Create("Button", self), -123, 30, -72, 20) -- Save As button
+
 	self.C.Browser = self:addComponent(vgui.Create("wire_expression2_browser", self), 10, 30, bw + 7, -10) -- Expression browser
 	self.C.TabHolder = self:addComponent(vgui.Create("DPropertySheet", self), bw + 15, 52, -5, -27) -- TabHolder
 	self:CreateTab("generic")
-	self.C.Btoggle = self:addComponent(vgui.Create("Button", self), bw + 20, 30, 20, 20) -- Toggle Browser being shown
-	self.C.ConBut = self:addComponent(vgui.Create("Button", self), -62, 4, 18, 18) -- Control panel open/close
+	self.C.Val = self:addComponent(vgui.Create("Button", self), bw + 20, -30, -10, 20) -- Validation line
+
 	self.C.Control = self:addComponent(vgui.Create("Panel", self), -350, 52, 342, -32) -- Control Panel
 	self.C.Credit = self:addComponent(vgui.Create("DTextEntry", self), -160, 52, 150, 150) -- Credit box
-	self.C.Val = self:addComponent(vgui.Create("Button", self), bw + 20, -30, -10, 20) -- Validation line
+
+	-- extra component options
 
 	self.C.TabHolder.Paint = function() end
 
-	-- extra component options
 	self.C.Close:SetText("x")
 	self.C.Close.DoClick = function(btn) self:Close() end
 	self.C.Credit:SetTextColor(Color(0, 0, 0, 255))

--- a/lua/wire/client/wire_expression2_editor.lua
+++ b/lua/wire/client/wire_expression2_editor.lua
@@ -840,9 +840,9 @@ function Editor:InitComponents()
 
 	-- addComponent( panel, x, y, w, h )
 	-- if x, y, w, h is minus, it will stay relative to right or buttom border
-	self.C.Close = self:addComponent(vgui.Create("DButton", self), -22, 4, 18, 18) -- Close button
-	self.C.Inf = self:addComponent(vgui.CreateFromTable(DMenuButton, self), -42, 4, 18, 18) -- Info button
-	self.C.ConBut = self:addComponent(vgui.CreateFromTable(DMenuButton, self), -62, 4, 18, 18) -- Control panel open/close
+	self.C.Close = self:addComponent(vgui.Create("DButton", self), -45-8, 0, 45, 20) -- Close button
+	self.C.Inf = self:addComponent(vgui.CreateFromTable(DMenuButton, self), -45-8-24, 2, 22, 20) -- Info button
+	self.C.ConBut = self:addComponent(vgui.CreateFromTable(DMenuButton, self), -45-8-24-24, 2, 22, 20) -- Control panel open/close
 
 	self.C.Menu = self:addComponent(vgui.Create("DPanel", self), bw + 20, 30, -8, 20)
 	self.C.Btoggle = vgui.CreateFromTable(DMenuButton, self.C.Menu) -- Toggle Browser being shown
@@ -875,17 +875,21 @@ function Editor:InitComponents()
 	self.C.Inf:Dock(NODOCK)
 	self.C.ConBut:Dock(NODOCK)
 
-
-	self.C.Close:SetText("x")
+	self.C.Close:SetText("r")
+	self.C.Close:SetFont("Marlett")
 	self.C.Close.DoClick = function(btn) self:Close() end
-	self.C.Credit:SetTextColor(Color(0, 0, 0, 255))
-	self.C.Credit:SetText("\t\tCREDITS\n\n\tEditor by: \tSyranide and Shandolum\n\n\tTabs (and more) added by Divran.\n\n\tFixed for GMod13 By Ninja101") -- Sure why not ;)
-	self.C.Credit:SetMultiline(true)
-	self.C.Credit:SetVisible(false)
-	self.C.Inf:SetText("i")
+
+	self.C.ConBut:SetImage("icon16/wrench.png")
+	self.C.ConBut:SetText("")
+	self.C.ConBut.Paint = DoNothing
+	self.C.ConBut.DoClick = function() self.C.Control:SetVisible(not self.C.Control:IsVisible()) end
+
+	self.C.Inf:SetImage("icon16/information.png")
+	self.C.Inf.Paint = DoNothing
 	self.C.Inf.DoClick = function(btn)
 		self.C.Credit:SetVisible(not self.C.Credit:IsVisible())
 	end
+
 
 	self.C.Sav:SetImage("icon16/disk.png")
 	self.C.Sav.DoClick = function(button) self:SaveFile(self:GetChosenFile()) end
@@ -951,10 +955,12 @@ function Editor:InitComponents()
 		end
 		button.toggle = true
 	end
-	self.C.ConBut:SetImage("icon16/wrench.png")
-	self.C.ConBut:SetText("")
-	self.C.ConBut.Paint = function(button) end
-	self.C.ConBut.DoClick = function() self.C.Control:SetVisible(not self.C.Control:IsVisible()) end
+
+	self.C.Credit:SetTextColor(Color(0, 0, 0, 255))
+	self.C.Credit:SetText("\t\tCREDITS\n\n\tEditor by: \tSyranide and Shandolum\n\n\tTabs (and more) added by Divran.\n\n\tFixed for GMod13 By Ninja101") -- Sure why not ;)
+	self.C.Credit:SetMultiline(true)
+	self.C.Credit:SetVisible(false)
+
 	self:InitControlPanel(self.C.Control) -- making it seperate for better overview
 	self.C.Control:SetVisible(false)
 	if self.E2 then self:Validate() end

--- a/lua/wire/client/wire_expression2_editor.lua
+++ b/lua/wire/client/wire_expression2_editor.lua
@@ -821,20 +821,37 @@ function Editor:InitComponents()
 
 	local bw = wire_expression2_editor_browserwidth:GetInt()
 
+	local DMenuButton = vgui.RegisterTable({
+		Init = function(panel)
+			panel:SetText("")
+			panel:SetSize(22, 20)
+			panel:Dock(LEFT)
+		end,
+		Paint = function(panel, w, h)
+			draw.RoundedBox(1, 0, 0, w, h, self.colors.col_FL)
+			if panel:IsHovered() then draw.RoundedBox(0, 1, 1, w - 2, h - 2, Color(0, 0, 0, 192)) end
+		end,
+		DoClick = function(panel)
+			local name = panel:GetName()
+			local f = name and name ~= "" and self[name] or nil
+			if f then f() end
+		end
+	}, "DButton")
+
 	-- addComponent( panel, x, y, w, h )
 	-- if x, y, w, h is minus, it will stay relative to right or buttom border
 	self.C.Close = self:addComponent(vgui.Create("DButton", self), -22, 4, 18, 18) -- Close button
-	self.C.Inf = self:addComponent(vgui.Create("DButton", self), -42, 4, 18, 18) -- Info button
-	self.C.ConBut = self:addComponent(vgui.Create("Button", self), -62, 4, 18, 18) -- Control panel open/close
+	self.C.Inf = self:addComponent(vgui.CreateFromTable(DMenuButton, self), -42, 4, 18, 18) -- Info button
+	self.C.ConBut = self:addComponent(vgui.CreateFromTable(DMenuButton, self), -62, 4, 18, 18) -- Control panel open/close
 
-	self.C.Btoggle = self:addComponent(vgui.Create("Button", self), bw + 20, 30, 20, 20) -- Toggle Browser being shown
-	self.C.Sav = self:addComponent(vgui.Create("Button", self), bw + 41, 30, 20, 20) -- Save button
-	self.C.NewTab = self:addComponent(vgui.Create("Button", self), bw + 62, 30, 20, 20) -- New tab button
-	self.C.CloseTab = self:addComponent(vgui.Create("Button", self), bw + 83, 30, 20, 20) -- Close tab button
-	self.C.Reload = self:addComponent(vgui.Create("Button", self), bw + 104, 30, 20, 20) -- Reload tab button
-
-	self.C.SaE = self:addComponent(vgui.Create("Button", self), -70, 30, -10, 20) -- Save & Exit button
-	self.C.SavAs = self:addComponent(vgui.Create("Button", self), -123, 30, -72, 20) -- Save As button
+	self.C.Menu = self:addComponent(vgui.Create("DPanel", self), bw + 20, 30, -8, 20)
+	self.C.Btoggle = vgui.CreateFromTable(DMenuButton, self.C.Menu) -- Toggle Browser being shown
+	self.C.Sav = vgui.CreateFromTable(DMenuButton, self.C.Menu) -- Save button
+	self.C.NewTab = vgui.CreateFromTable(DMenuButton, self.C.Menu, "NewTab") -- New tab button
+	self.C.CloseTab = vgui.CreateFromTable(DMenuButton, self.C.Menu, "CloseTab") -- Close tab button
+	self.C.Reload = vgui.CreateFromTable(DMenuButton, self.C.Menu) -- Reload tab button
+	self.C.SaE = vgui.CreateFromTable(DMenuButton, self.C.Menu) -- Save & Exit button
+	self.C.SavAs = vgui.CreateFromTable(DMenuButton, self.C.Menu) -- Save As button
 
 	self.C.Browser = self:addComponent(vgui.Create("wire_expression2_browser", self), 10, 30, bw + 7, -10) -- Expression browser
 	self.C.TabHolder = self:addComponent(vgui.Create("DPropertySheet", self), bw + 15, 52, -5, -27) -- TabHolder
@@ -846,7 +863,15 @@ function Editor:InitComponents()
 
 	-- extra component options
 
-	self.C.TabHolder.Paint = function() end
+	local DoNothing = function() end
+	self.C.TabHolder.Paint = DoNothing
+	self.C.Menu.Paint = DoNothing
+
+	self.C.SaE:SetSize(80, 20)
+	self.C.SaE:Dock(RIGHT)
+	self.C.SavAs:SetSize(51, 20)
+	self.C.SavAs:Dock(RIGHT)
+
 
 	self.C.Close:SetText("x")
 	self.C.Close.DoClick = function(btn) self:Close() end
@@ -858,74 +883,23 @@ function Editor:InitComponents()
 	self.C.Inf.DoClick = function(btn)
 		self.C.Credit:SetVisible(not self.C.Credit:IsVisible())
 	end
-	self.C.Sav:SetText("")
+
 	self.C.Sav:SetImage("icon16/disk.png")
-	self.C.Sav.Paint = function(button)
-		local w, h = button:GetSize()
-		draw.RoundedBox(1, 0, 0, w, h, self.colors.col_FL)
-		if button.Hovered then draw.RoundedBox(0, 1, 1, w - 2, h - 2, Color(0, 0, 0, 192)) end
-	end
 	self.C.Sav.DoClick = function(button) self:SaveFile(self:GetChosenFile()) end
 
-	self.C.NewTab:SetText("")
 	self.C.NewTab:SetImage("icon16/page_white_add.png")
-	self.C.NewTab.Paint = function(button)
-		local w, h = button:GetSize()
-		draw.RoundedBox(1, 0, 0, w, h, self.colors.col_FL)
-		if button.Hovered then draw.RoundedBox(0, 1, 1, w - 2, h - 2, Color(0, 0, 0, 192)) end
-	end
-	self.C.NewTab.DoClick = function(button)
-		self:NewTab()
-	end
 
-	self.C.CloseTab:SetText("")
 	self.C.CloseTab:SetImage("icon16/page_white_delete.png")
-	self.C.CloseTab.Paint = function(button)
-		local w, h = button:GetSize()
-		draw.RoundedBox(1, 0, 0, w, h, self.colors.col_FL)
-		if button.Hovered then draw.RoundedBox(0, 1, 1, w - 2, h - 2, Color(0, 0, 0, 192)) end
-	end
-	self.C.CloseTab.DoClick = function(button)
-		self:CloseTab()
-	end
 
-	self.C.Reload:SetText("")
 	self.C.Reload:SetImage("icon16/page_refresh.png")
-	self.C.Reload.Paint = function(button)
-		local w, h = button:GetSize()
-		draw.RoundedBox(1, 0, 0, w, h, self.colors.col_FL)
-		if button.Hovered then draw.RoundedBox(0, 1, 1, w - 2, h - 2, Color(0, 0, 0, 192)) end
-	end
 	self.C.Reload.DoClick = function(button)
 		self:LoadFile(self:GetChosenFile(), false)
 	end
 
-	self.C.SaE:SetText("")
-	self.C.SaE.Font = "E2SmallFont"
-	self.C.SaE.Paint = function(button)
-		local w, h = button:GetSize()
-		draw.RoundedBox(1, 0, 0, w, h, self.colors.col_FL)
-		if button.Hovered then draw.RoundedBox(0, 1, 1, w - 2, h - 2, Color(0, 0, 0, 192)) end
-		surface.SetFont(button.Font)
-		surface.SetTextPos(3, 4)
-		surface.SetTextColor(255, 255, 255, 255)
-		if self.chip then surface.DrawText("Upload & Exit")
-		else surface.DrawText(" Save & Exit")
-		end
-	end
+	self.C.SaE:SetText("Save and Exit")
 	self.C.SaE.DoClick = function(button) self:SaveFile(self:GetChosenFile(), true) end
 
-	self.C.SavAs:SetText("")
-	self.C.SavAs.Font = "E2SmallFont"
-	self.C.SavAs.Paint = function(button)
-		local w, h = button:GetSize()
-		draw.RoundedBox(1, 0, 0, w, h, self.colors.col_FL)
-		if button.Hovered then draw.RoundedBox(0, 1, 1, w - 2, h - 2, Color(0, 0, 0, 192)) end
-		surface.SetFont(button.Font)
-		surface.SetTextPos(3, 4)
-		surface.SetTextColor(255, 255, 255, 255)
-		surface.DrawText("  Save As")
-	end
+	self.C.SavAs:SetText("Save As")
 	self.C.SavAs.DoClick = function(button) self:SaveFile(self:GetChosenFile(), false, true) end
 
 	self.C.Browser:AddRightClick(self.C.Browser.filemenu, 4, "Save to", function()
@@ -964,11 +938,6 @@ function Editor:InitComponents()
 		end
 	end
 	self.C.Btoggle:SetText("<")
-	self.C.Btoggle.Paint = function(button)
-		local w, h = button:GetSize()
-		draw.RoundedBox(1, 0, 0, w, h, self.colors.col_FL)
-		if button.Hovered then draw.RoundedBox(0, 1, 1, w - 2, h - 2, Color(0, 0, 0, 192)) end
-	end
 	self.C.Btoggle.DoClick = function(button)
 		if button.hide then
 			button.hide = false
@@ -978,42 +947,6 @@ function Editor:InitComponents()
 			button:SetText(">")
 		end
 		button.toggle = true
-	end
-	self.C.Btoggle.anispeed = 10
-	self.C.Btoggle.Think = function(button)
-		if not button.toggle then return end
-		local bw = wire_expression2_editor_browserwidth:GetInt()
-		if button.hide and self.C.Btoggle.Bounds.x > 10 then
-			self.C.Btoggle.Bounds.x = self.C.Btoggle.Bounds.x - button.anispeed
-			self.C.Sav.Bounds.x = self.C.Sav.Bounds.x - button.anispeed
-			self.C.NewTab.Bounds.x = self.C.NewTab.Bounds.x - button.anispeed
-			self.C.CloseTab.Bounds.x = self.C.CloseTab.Bounds.x - button.anispeed
-			self.C.Reload.Bounds.x = self.C.Reload.Bounds.x - button.anispeed
-			self.C.TabHolder.Bounds.x = self.C.TabHolder.Bounds.x - button.anispeed
-			self.C.Val.Bounds.x = self.C.Val.Bounds.x - button.anispeed
-			self.C.Browser.Bounds.w = self.C.Browser.Bounds.w - button.anispeed
-		elseif not button.hide and self.C.Btoggle.Bounds.x < bw + 20 then
-			self.C.Btoggle.Bounds.x = self.C.Btoggle.Bounds.x + button.anispeed
-			self.C.Sav.Bounds.x = self.C.Sav.Bounds.x + button.anispeed
-			self.C.NewTab.Bounds.x = self.C.NewTab.Bounds.x + button.anispeed
-			self.C.CloseTab.Bounds.x = self.C.CloseTab.Bounds.x + button.anispeed
-			self.C.Reload.Bounds.x = self.C.Reload.Bounds.x + button.anispeed
-			self.C.TabHolder.Bounds.x = self.C.TabHolder.Bounds.x + button.anispeed
-			self.C.Val.Bounds.x = self.C.Val.Bounds.x + button.anispeed
-			self.C.Browser.Bounds.w = self.C.Browser.Bounds.w + button.anispeed
-		end
-
-		if self.C.Browser:IsVisible() and self.C.Browser.Bounds.w <= 0 then self.C.Browser:SetVisible(false)
-		elseif not self.C.Browser:IsVisible() and self.C.Browser.Bounds.w > 0 then self.C.Browser:SetVisible(true)
-		end
-		self:InvalidateLayout()
-		if button.hide then
-			if self.C.Btoggle.Bounds.x > 10 or self.C.Sav.Bounds.x > 30 or self.C.Val.Bounds.x < bw + 20 or self.C.Browser.Bounds.w > 0 then return end
-			button.toggle = false
-		else
-			if self.C.Btoggle.Bounds.x < bw + 20 or self.C.Sav.Bounds.x < bw + 40 or self.C.Val.Bounds.x < bw + 20 or self.C.Browser.Bounds.w < bw then return end
-			button.toggle = false
-		end
 	end
 	self.C.ConBut:SetImage("icon16/wrench.png")
 	self.C.ConBut:SetText("")


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/908758/5908246/c01223cc-a59d-11e4-97d5-8aee28e9e529.png)

* Changed the text editor to use the default UI.
* Made the browser-editor divide draggable (instead of adjustable with a slider in the settings)
* Made the window buttons a lot prettier

This is a big pile of changes so that it's easier to tell what's going on in this otherwise huge change - when it's time to merge this I'll most likely `git merge --squash` by hand though.