### PR TITLE
Add rotate-only option for ballsockets

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/cl_constraintcore.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cl_constraintcore.lua
@@ -10,6 +10,7 @@ E2Helper.Descriptions["enableConstraintUndo"] = "If 0, suppresses creation of un
 E2Helper.Descriptions["axis"] = "Creates an axis constraint between two entities at vectors local to each entity"
 E2Helper.Descriptions["ballsocket"] = "Creates a ballsocket constraint between two entities at a vector local to ent1"
 E2Helper.Descriptions["ballsocket(evevvv)"] = "Creates an AdvBallsocket constraint between two entities at a vector local to ent1, using the specified mins, maxs, and frictions)"
+E2Helper.Descriptions["ballsocket(evevvvn)"] = "Creates an AdvBallsocket constraint between two entities at a vector local to ent1, using the specified mins, maxs, frictions, rotateonly)"
 E2Helper.Descriptions["weldAng"] = "Creates an angular weld constraint (angles are fixed, position is free) between two entities at a vector local to ent1"
 E2Helper.Descriptions["winch"] = "Creates a winch constraint with a referenceid, between two entities, at vectors local to each"
 E2Helper.Descriptions["hydraulic"] = "Creates a hydraulic constraint with a referenceid, between two entities, at vectors local to each"

--- a/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
@@ -68,6 +68,13 @@ e2function void ballsocket(entity ent1, vector v, entity ent2, vector mins, vect
 	addundo(self, constraint.AdvBallsocket(ent1, ent2, 0, 0, Vector(), vec, 0, 0, mins[1], mins[2], mins[3], maxs[1], maxs[2], maxs[3], frictions[1], frictions[2], frictions[3], 0, 0), "ballsocket")
 end
 
+--- Creates an adv ballsocket between <ent1> and <ent2> at <v>, which is local to <ent1>, with many settings
+e2function void ballsocket(entity ent1, vector v, entity ent2, vector mins, vector maxs, vector frictions, rotateonly)
+	if !checkEnts(self, ent1, ent2) then return end
+	local vec = Vector(v[1], v[2], v[3])
+	addundo(self, constraint.AdvBallsocket(ent1, ent2, 0, 0, Vector(), vec, 0, 0, mins[1], mins[2], mins[3], maxs[1], maxs[2], maxs[3], frictions[1], frictions[2], frictions[3], rotateonly, 0), "ballsocket")
+end
+
 --- Creates an angular weld (angles are fixed, position isn't) between <ent1> and <ent2> at <v>, which is local to <ent1>
 e2function void weldAng(entity ent1, vector v, entity ent2)
 	if !checkEnts(self, ent1, ent2) then return end


### PR DESCRIPTION
I need this. Maybe somebody will find it useful too.