### PR TITLE
Fix exploitable E2 rendering issues

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -650,8 +650,8 @@ end
 local function composedata(startSize, endSize, length, material, color, alpha)
 	if string.find(material, '"', 1, true) then return nil end
 
-	endSize = math.Clamp( endsize, 0, 128 )
-	startSize = math.Clamp( startsize, 0, 128 )
+	endSize = math.Clamp( endSize, 0, 128 )
+	startSize = math.Clamp( startSize, 0, 128 )
 
 	return {
 		Color = Color( color[1], color[2], color[3], alpha ),

--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -650,6 +650,9 @@ end
 local function composedata(startSize, endSize, length, material, color, alpha)
 	if string.find(material, '"', 1, true) then return nil end
 
+	endSize = math.Clamp( endsize, 0, 128 )
+	startSize = math.Clamp( startsize, 0, 128 )
+
 	return {
 		Color = Color( color[1], color[2], color[3], alpha ),
 		Length = length,

--- a/lua/entities/gmod_wire_expression2/core/hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/hologram.lua
@@ -672,7 +672,9 @@ e2function void holoReset(index, string model, vector scale, vector color, strin
 
 	Holo.ent:SetModel(model)
 	Holo.ent:SetColor(Color(color[1],color[2],color[3],255))
-	Holo.ent:SetMaterial(material)
+	if string.lower(material) ~= "pp/copy" then
+		Holo.ent:SetMaterial(material)
+	end
 
 	reset_clholo(Holo, scale) -- Reset scale, clips, and visible status
 end
@@ -933,6 +935,7 @@ end
 e2function void holoMaterial(index, string material)
 	local Holo = CheckIndex(self, index)
 	if not Holo then return end
+	if string.lower(material) == "pp/copy" then return end
 
 	Holo.ent:SetMaterial(material)
 end


### PR DESCRIPTION
Prevent the material from being set to pp/copy inside setHoloMaterial() and holoReset()

The [entity:setMaterial()](https://github.com/wiremod/wire/blob/master/lua/entities/gmod_wire_expression2/core/entity.lua#L363) function already checks for this but the setHoloMaterial() does not.