### PR TITLE
Reworked E2 extensions loading + changed a few other things

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -483,30 +483,30 @@ do
 	local function buildPrettyList()
 		local function padLeft( str, len ) return (" "):rep( len - #str ) .. str end
 		local function padRight( str, len ) return str .. (" "):rep( len - #str ) end
-		local function padCenter( str, len ) return padRight( padLeft( str, math.floor( (len/2) + #str - (#str/2) ) ), len ) end
+		local function padCenter( str, len ) return padRight( padLeft( str, math.floor( (len + #str) / 2 ) ), len ) end
 		
-		local list, column1, column2 = extensions.list, {}, {}
-		local columnsWidth = 0
+		local list, column1, column2, columnsWidth = extensions.list, {}, {}, 0
 		for i = 1, #list do
 			local name = list[ i ]
 			if #name > columnsWidth then columnsWidth = #name end
 			if extensions.status[ name ] == true then column1[ #column1 + 1 ] = name else column2[ #column2 + 1 ] = name end
 		end
-		local title = "E2 EXTENSIONS"
-		local maxWidth = math.max( 16, columnsWidth * 2, #title - 3 )
+		local mainTitle, column1Title, column2Title = "E2 EXTENSIONS", "ENABLED", "DISABLED"
+		local maxWidth, maxRows = math.max( columnsWidth * 2, #column1Title + #column2Title, #mainTitle - 3 ), math.max( #column1, #column2 )
 		if maxWidth % 2 ~= 0 then maxWidth = maxWidth + 1 end
 		columnsWidth = maxWidth / 2
 		maxWidth = maxWidth + 3
-		local rows = math.max( #column1, #column2 )
 		local delimiter =  " +-" .. ("-"):rep( columnsWidth ) .. "-+-" .. ("-"):rep( columnsWidth ) .. "-+"
 		
-		list = {}
-		list[ 1 ] = " +-" .. ("-"):rep( maxWidth ) .. "-+"
-		list[ 2 ] = " | " .. padCenter( title, maxWidth ) .. " |"
-		list[ 3 ] = delimiter
-		list[ 4 ] = " | " .. padCenter( "ENABLED", columnsWidth ) .. " | " .. padCenter( "DISABLED", columnsWidth ) .. " |"
-		list[ 5 ] = delimiter
-		for i = 1, rows do list[ #list + 1 ] = " | " .. padRight( column1[i] or "", columnsWidth ) .. " | " .. padRight( column2[i] or "", columnsWidth ) .. " |" end
+		list =
+		{
+			" +-" .. ("-"):rep( maxWidth ) .. "-+",
+			" | " .. padCenter( mainTitle, maxWidth ) .. " |",
+			delimiter,
+			" | " .. padCenter( column1Title, columnsWidth ) .. " | " .. padCenter( column2Title, columnsWidth ) .. " |",
+			delimiter,
+		}
+		for i = 1, maxRows do list[ #list + 1 ] = " | " .. padRight( column1[ i ] or "", columnsWidth ) .. " | " .. padRight( column2[ i ] or "", columnsWidth ) .. " |" end
 		list[ #list + 1 ] = delimiter
 		
 		extensions.prettyList = list
@@ -524,10 +524,7 @@ do
 
 	local function makeAutoCompleteList( cmd, args )
 		args = args:Trim():lower()
-		local status = tobool( cmd:find( "enable" ) )
-		local list = extensions.list
-		local tbl = {}
-		local j = 1
+		local status, list, tbl, j = tobool( cmd:find( "enable" ) ), extensions.list, {}, 1
 		for i = 1, #list do
 			local name = list[ i ]
 			if extensions.status[ name ] ~= status and name:find( args ) then

--- a/lua/entities/gmod_wire_expression2/core/extloader.lua
+++ b/lua/entities/gmod_wire_expression2/core/extloader.lua
@@ -2,12 +2,15 @@
   Loading extensions
 ]]
 
+wire_expression2_PreLoadExtensions()
+
 -- Save E2's metatable for wire_expression2_reload
 if ENT then
 	local wire_expression2_ENT = ENT
 	function wire_expression2_reload(ply, cmd, args)
 		if IsValid(ply) and ply:IsPlayer() and not ply:IsSuperAdmin() and not game.SinglePlayer() then return end
-
+		
+		timer.Destroy( "E2_AutoReloadTimer" )
 		Msg("Calling destructors for all Expression2 chips.\n")
 		local chips = ents.FindByClass("gmod_wire_expression2")
 		for _, chip in ipairs(chips) do
@@ -88,11 +91,8 @@ local function e2_include_pass2(name, luaname, contents)
 	
 	local ok, err = pcall(func)
 	if not ok then -- an error occured while executing
-		if string.find(err,"Skipping disabled E2 extension") ~= 0 then -- if it's just a disabled E2 extension...
-			local err = string.match(err,"(Skipping disabled E2 extension.+).$") -- filter to the part we want
-			print(err) -- print the error
-		else
-			error(err) -- otherwise, actually cause an error
+		if not err:find( "EXTENSION_DISABLED" ) then
+			error(err)
 		end
 		return
 	end
@@ -170,3 +170,5 @@ end
 e2_include_finalize()
 
 wire_expression2_CallHook("postinit")
+
+wire_expression2_PostLoadExtensions()


### PR DESCRIPTION
- Fixed issue with loading of inexistent or renamed extensions.
- Improved listing of extensions, now shows a pleasant table.
- Made sure the extensions names are always lowercase.
- Added hooks "Expression2_PreLoadExtensions" and
"Expression2_PostLoadExtensions", for use in external scripts.
- Added automatic reload timer (10 seconds) after changing an extension
status by commands.
- Added command 'wire_expression2_extensions' so players can see
available extensions on server.

This should be bullet proof, yet if you find any bug then please tell me