### PR TITLE
Added entity:setSubMaterial and entity:getMaterials

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -361,12 +361,7 @@ __e2setcost(20)
 
 e2function array entity:getMaterials()
 	if not IsValid(this) then return {} end
-	local tmp = {}
-	local mats = this:GetMaterials()
-	for i=1, #mats do
-		tmp[i] = mats[i]
-	end
-	return tmp
+	return this:GetMaterials()
 end
 
 __e2setcost(10)

--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -357,11 +357,32 @@ e2function string entity:getMaterial()
 	return this:GetMaterial() or ""
 end
 
+__e2setcost(20)
+
+e2function array entity:getMaterials()
+	if not IsValid(this) then return {} end
+	local tmp = {}
+	local mats = this:GetMaterials()
+	for i=1, #mats do
+		tmp[i] = mats[i]
+	end
+	return tmp
+end
+
+__e2setcost(10)
+
 e2function void entity:setMaterial(string material)
 	if not IsValid(this) then return end
 	if not isOwner(self, this) then return end
 	if string.lower(material) == "pp/copy" then return end
 	this:SetMaterial(material)
+end
+
+e2function void entity:setSubMaterial(index, string material)
+	if not IsValid(this) then return end
+	if not isOwner(self, this) then return end
+	if string.lower(material) == "pp/copy" then return end
+	this:SetSubMaterial(index+1,material)
 end
 
 --- Gets <this>'s current skin number.

--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -357,6 +357,11 @@ e2function string entity:getMaterial()
 	return this:GetMaterial() or ""
 end
 
+e2function string entity:getSubMaterial(index)
+	if not IsValid(this) then return "" end
+	return this:GetSubMaterial(index-1) or ""
+end
+
 __e2setcost(20)
 
 e2function array entity:getMaterials()

--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -382,7 +382,7 @@ e2function void entity:setSubMaterial(index, string material)
 	if not IsValid(this) then return end
 	if not isOwner(self, this) then return end
 	if string.lower(material) == "pp/copy" then return end
-	this:SetSubMaterial(index+1,material)
+	this:SetSubMaterial(index-1,material)
 end
 
 --- Gets <this>'s current skin number.


### PR DESCRIPTION
entity():setSubMaterial( number, string ) will allow you to change the sub materials on props that allow it.
entity():getMaterials() returns an array of all of the materials on a prop.

Cost for setSubMaterial is set to the normal setMaterial of 10, but the getMaterials cost is set to 20.