### PR TITLE
HTTP Functions: Remove line which modifies data irreversibly

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/http.lua
+++ b/lua/entities/gmod_wire_expression2/core/http.lua
@@ -43,7 +43,6 @@ e2function void httpRequest( string url )
 		preq.t_end = CurTime()
 		preq.in_progress = false
 		preq.data = contents or ""
-		preq.data = string.gsub( preq.data, string.char( 13 ) .. string.char( 10 ), "\n" )
 
 		run_on.clk = 1
 


### PR DESCRIPTION
The line is fairly self-explanatory. The original purpose of the line was to fix issues with fileWrite, which can be implemented by the user. Additionally, I did not encounter any problems with fileWrite when using this combination of characters. The inclusion of this line means that any non-textual data with those two bytes of data in sequence is modified in transit in a damaging way.