### PR TITLE
Fixed 'Set' input on buttons being able to break the button completely.

### DIFF
--- a/lua/entities/gmod_wire_button.lua
+++ b/lua/entities/gmod_wire_button.lua
@@ -74,6 +74,8 @@ function ENT:TriggerInput(iname, value)
 	if iname == "Set" then
 		if (self.toggle) then
 			self:Switch(value ~= 0)
+			self.PrevUser = nil
+			self.podpress = nil
 		end
 	end
 end

--- a/lua/entities/gmod_wire_dynamic_button.lua
+++ b/lua/entities/gmod_wire_dynamic_button.lua
@@ -51,6 +51,8 @@ function ENT:TriggerInput(iname, value)
 	if iname == "Set" then
 		if (self.toggle) then
 			self:Switch(value ~= 0)
+			self.PrevUser = nil
+			self.podpress = nil
 		end
 	end
 end


### PR DESCRIPTION
If you change the "Set" input on a (Dynamic) Button really quickly after it is turned on by a player (and yes this is possible), it will lock out user input until it is updated with the toolgun.