### PR TITLE
Fixed nil function call

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/extloader.lua
+++ b/lua/entities/gmod_wire_expression2/core/extloader.lua
@@ -98,14 +98,14 @@ local function e2_include_pass2(name, luaname, contents)
 	-- file needed preprocessing => Run the processed file
 	local ok, func = pcall(CompileString,ret,luaname)
 	if not ok then -- an error occurred while compiling
-		error(func)
+		ErrorNoHalt(func.."\n") --Lets not error and halt the rest of the loading.
 		return
 	end
 	
 	local ok, err = pcall(func)
 	if not ok then -- an error occured while executing
 		if not err:find( "EXTENSION_DISABLED" ) then
-			error(err)
+			ErrorNoHalt(err.."\n")
 		end
 		return
 	end


### PR DESCRIPTION
"error" does not exist in GLua. ("Error" and "ErrorNoHalt" does though).

I have swapped "error" with "ErrorNoHalt" (as we don't want to halt any of wires other executions).

Fixes the following:
```
[ERROR] addons/wire/lua/entities/gmod_wire_expression2/core/extloader.lua:108: attempt to call a nil value
  1. error - [C]:-1
   2. e2_include_pass2 - addons/wire/lua/entities/gmod_wire_expression2/core/extloader.lua:108
    3. e2_include_finalize - addons/wire/lua/entities/gmod_wire_expression2/core/extloader.lua:118
     4. unknown - addons/wire/lua/entities/gmod_wire_expression2/core/extloader.lua:183
      5. include - [C]:-1
       6. unknown - addons/wire/lua/entities/gmod_wire_expression2/core/extloader.lua:37
        7. unknown - lua/includes/modules/concommand.lua:54
```