### PR TITLE
Added camera position to the user's PVS

### DIFF
--- a/lua/entities/gmod_wire_cameracontroller.lua
+++ b/lua/entities/gmod_wire_cameracontroller.lua
@@ -575,6 +575,16 @@ function ENT:Think()
 end
 
 --------------------------------------------------
+-- PVS Hook
+--------------------------------------------------
+
+hook.Add("SetupPlayerVisibility", "gmod_wire_cameracontroller", function(player)
+	if IsValid(player.CamController) then
+		AddOriginToPVS(player.CamController.Position)
+	end
+end)
+
+--------------------------------------------------
 -- OnRemove
 --------------------------------------------------
 


### PR DESCRIPTION
I noticed in multiple servers and even my local server that the cam
controller never rendered entities outside of the user's PVS.

In this commit I've added the SetupPlayerVisibility hook to add the
position of the active camera to the player's PVS, so they can see
entities.

**Before fix:**
![Before](https://cloud.githubusercontent.com/assets/3161594/6879855/0f99cee6-d4cd-11e4-8abb-ebdcc659e4f2.jpg)

**After:**
![After](https://cloud.githubusercontent.com/assets/3161594/6879854/0f981b8c-d4cd-11e4-9922-721c3a9d7982.jpg)