### PR TITLE
Fix #795 (SPU channels not working at different angles)

### DIFF
--- a/lua/entities/gmod_wire_spu/init.lua
+++ b/lua/entities/gmod_wire_spu/init.lua
@@ -40,7 +40,7 @@ function ENT:Initialize()
     self.SoundSources[i]:SetParent(self)
     self.SoundSources[i]:SetModel("models/cheeze/wires/nano_math.mdl")
     self.SoundSources[i]:SetNotSolid(true)
-    self.SoundSources[i]:SetPos(self:GetPos()+Vector(1*math.sin(2*math.pi*i/WireSPU_MaxChannels),1*math.cos(2*math.pi*i/WireSPU_MaxChannels),0))
+    self.SoundSources[i]:SetPos(self:GetPos())
     self.SoundSources[i]:Spawn()
   end
 


### PR DESCRIPTION
Each SPU spawns 32 invisible dummy entities (one for each channel) which it actually plays the sounds from.

Previously, they were placed in a small circle. This seems to trigger some weirdness inside Source, and some channels don't play sometimes.

This patch places them all at the same position, which seems to work better.