### PR TITLE
Remove E:isTyping()

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/cl_player.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_player.lua
@@ -17,7 +17,3 @@ hook.Add("OnEntityCreated", "wire_expression2_extension_player", function(ent)
 
 	SendFriendStatus()
 end)
-
--- isTyping
-hook.Add("StartChat","E2_IsTyping_Start",function() RunConsoleCommand("E2_StartChat") end)
-hook.Add("FinishChat","E2_IsTyping_Finish",function() RunConsoleCommand("E2_FinishChat") end)

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -314,17 +314,6 @@ e2function string keyClkPressed()
 	return pressedKey
 end
 
-
--- isTyping
-local plys = {}
-concommand.Add("E2_StartChat",function(ply,cmd,args) plys[ply] = true end)
-concommand.Add("E2_FinishChat",function(ply,cmd,args) plys[ply] = nil end)
-hook.Add("PlayerDisconnected","E2_istyping",function(ply) plys[ply] = nil end)
-
-e2function number entity:isTyping()
-	return plys[this] and 1 or 0
-end
-
 /******************************************************************************/
 
 local Trusts


### PR DESCRIPTION
E:isTyping() is beyond the scope of an in-world scripting environment like E2.

To prevent further [feature creep] (https://github.com/wiremod/wire/pull/885), it should be removed.