### PR TITLE
Integrating entity:applyOffsetAngForce and array:massCenter

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -586,6 +586,12 @@ e2function vector entity:inertia()
 	return this:GetPhysicsObject():GetInertia()
 end
 
+e2function angle entity:inertia()
+	if not validPhysics(this) then return {0,0,0} end
+	local Inertia = this:GetPhysicsObject():GetInertia()
+	return Angle(Inertia[2], Inertia[3], Inertia[1]) * 90/math.pi
+end
+	
 e2function vector array:massCenter()
 	if not next(this) then return {0, 0, 0} end
 	local Center = Vector()

--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -514,6 +514,7 @@ end
 e2function void entity:applyOffsetAngForce(angle angForce, vector position)
 	if not validPhysics(this) then return nil end
 	if not isOwner(self, this) then return nil end
+	if not check(position) then return nil end
 
 	if angForce[1] == 0 and angForce[2] == 0 and angForce[3] == 0 then return end
 	if not check(angForce) then return end
@@ -586,7 +587,7 @@ e2function vector entity:inertia()
 end
 
 e2function vector array:massCenter()
-	if !next(this) then return {0, 0, 0} end
+	if not next(this) then return {0, 0, 0} end
 	local Center = Vector()
 	local Mass = 0
 	for _, Entity in pairs(this) do

--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -586,7 +586,7 @@ e2function vector entity:inertia()
 	return this:GetPhysicsObject():GetInertia()
 end
 
-e2function angle entity:inertia()
+e2function angle entity:angInertia()
 	if not validPhysics(this) then return {0,0,0} end
 	local Inertia = this:GetPhysicsObject():GetInertia()
 	return Angle(Inertia[2], Inertia[3], Inertia[1]) * 90/math.pi


### PR DESCRIPTION
So I'm bringing those two E2 functions for people to be able to move contraptions from within their real gravity centers. I didn't know where the E2 description for this file was so I didn't add it.

entity:applyOffsetAngForce(angle angForce, vector position)
vector = array:massCenter()