### PR TITLE
GPU dwrite and dwritefmt fix

### DIFF
--- a/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
+++ b/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
@@ -828,11 +828,12 @@ function VM:ReadString(address)
 
   while currentChar ~= 0 do
     currentChar = self:ReadCell(address + charCount)
-
-    if currentChar and currentChar < 255 then
+    -- Reading failed
+    if not currentChar then
+    	return
+    elseif currentChar > 0 and currentChar < 255 then
       charString = charString .. string.char(currentChar)
-    else
-      if currentChar ~= 0 then
+    elseif currentChar ~= 0 then
         self:Interrupt(23,currentChar)
         return ""
       end

--- a/lua/entities/gmod_wire_gpu/init.lua
+++ b/lua/entities/gmod_wire_gpu/init.lua
@@ -102,7 +102,7 @@ concommand.Add("wire_gpu_resendcache", GPU_PlayerRespawn)
 --------------------------------------------------------------------------------
 -- Checks if address is valid
 --------------------------------------------------------------------------------
-local function IsValidAddress(n)
+local function isValidAddress(n)
   return n and (math.floor(n) == n) and (n >= -140737488355327) and (n <= 140737488355328)
 end
 

--- a/lua/entities/gmod_wire_gpu/init.lua
+++ b/lua/entities/gmod_wire_gpu/init.lua
@@ -98,10 +98,26 @@ hook.Add("PlayerInitialSpawn", "GPUPlayerRespawn", GPU_PlayerRespawn)
 concommand.Add("wire_gpu_resendcache", GPU_PlayerRespawn)
 
 
+
+--------------------------------------------------------------------------------
+-- Checks if address is valid
+--------------------------------------------------------------------------------
+local function IsValidAddress(n)
+  return n and (math.floor(n) == n) and (n >= -140737488355327) and (n <= 140737488355328)
+end
+
+
+
 --------------------------------------------------------------------------------
 -- Read cell from GPU memory
 --------------------------------------------------------------------------------
 function ENT:ReadCell(Address)
+  -- Check if address is valid
+  if not isValidAddress(Address) then
+    self:Interrupt(15,Address)
+    return
+  end
+  
   if (Address < 0) or (Address >= self.RAMSize) then
     return nil
   else


### PR DESCRIPTION
AbigailBuccaneer's commit (https://github.com/wiremod/wire/commit/397b9e349f8dfb080bdd5389bfbe025f2502d505) removed the check of currentChar for larger than 0.
Also fixes dwrite and dwritefmt when the pointer is float (#818) by checking for valid address.