### PR TITLE
Fix of #787

### DIFF
--- a/lua/wire/client/hlzasm/hc_expression.lua
+++ b/lua/wire/client/hlzasm/hc_expression.lua
@@ -561,22 +561,46 @@ function HCOMP:Expression_Level0()
            )
   elseif self:MatchToken(self.TOKEN.EQLADD) then -- +=
     local rightLeaf = self:Expression_LevelLeaf(0)
-    return self:NewOpcode("add",leftLeaf,rightLeaf)
+    
+    local operationLeaf = self:NewOpcode("add",leftLeaf,rightLeaf)
+    operationLeaf.ExplictAssign = true
+    operationLeaf.ReturnAfterAssign = true
+    return operationLeaf
   elseif self:MatchToken(self.TOKEN.EQLSUB) then -- -=
     local rightLeaf = self:Expression_LevelLeaf(0)
-    return self:NewOpcode("sub",leftLeaf,rightLeaf)
+    
+    local operationLeaf = self:NewOpcode("sub",leftLeaf,rightLeaf)
+    operationLeaf.ExplictAssign = true
+    operationLeaf.ReturnAfterAssign = true
+    return operationLeaf
   elseif self:MatchToken(self.TOKEN.EQLMUL) then -- *=
     local rightLeaf = self:Expression_LevelLeaf(0)
-    return self:NewOpcode("mul",leftLeaf,rightLeaf)
+    
+    local operationLeaf = self:NewOpcode("mul",leftLeaf,rightLeaf)
+    operationLeaf.ExplictAssign = true
+    operationLeaf.ReturnAfterAssign = true
+    return operationLeaf
   elseif self:MatchToken(self.TOKEN.EQLDIV) then -- /=
     local rightLeaf = self:Expression_LevelLeaf(0)
-    return self:NewOpcode("div",leftLeaf,rightLeaf)
+    
+    local operationLeaf = self:NewOpcode("div",leftLeaf,rightLeaf)
+    operationLeaf.ExplictAssign = true
+    operationLeaf.ReturnAfterAssign = true
+    return operationLeaf
   elseif self:MatchToken(self.TOKEN.SHR) then -- >>
     local rightLeaf = self:Expression_LevelLeaf(0)
-    return self:NewOpcode("bshr",leftLeaf,rightLeaf)
+    
+    local operationLeaf = self:NewOpcode("bshr",leftLeaf,rightLeaf)
+    operationLeaf.ExplictAssign = true
+    operationLeaf.ReturnAfterAssign = true
+    return operationLeaf
   elseif self:MatchToken(self.TOKEN.SHL) then -- <<
     local rightLeaf = self:Expression_LevelLeaf(0)
-    return self:NewOpcode("bshl",leftLeaf,rightLeaf)
+    
+    local operationLeaf = self:NewOpcode("bshl",leftLeaf,rightLeaf)
+    operationLeaf.ExplictAssign = true
+    operationLeaf.ReturnAfterAssign = true
+    return operationLeaf
   else
     return leftLeaf
   end


### PR DESCRIPTION
HL-ZASM Augmented assignments fix.
```c
/* Code from https://github.com/wiremod/wire/issues/787 */

Data;
    float Var;
Code;


EAX += 2
Var += 3
R0   = R0 + 4

R0  += 5
EBP += 6
ES  += 7
{
    // Anonymous scope
    preserve EAX;
    EAX += 8;
}
```
Gets compiled into:
```c
     0 jmp 4
Var:
     3 alloc 1
_code:
// EAX+=2
     4 add EAX,2
// Var+=3
     7 add #3,3
    11 mov EAX,R0
    13 add EAX,4
// R0=R0+4
    16 mov R0,EAX
// R0+=5
    18 add R0,5
// EBP+=6
    21 add EBP,6
// ES+=7
    24 add ES,7
    27 enter -0
__1:
// EAX+=8
    30 add EAX,8
__0:
    33 leave 

```