### PR TITLE
Improved DHDD and added @realinputs

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/preprocessor.lua
+++ b/lua/entities/gmod_wire_expression2/base/preprocessor.lua
@@ -196,6 +196,16 @@ function PreProcessor:ParseDirectives(line)
 				self.directives.outputs[3][key] = retval[2][i]
 			end
 		end
+	elseif directive == "realinputs" then
+		local retval, columns = self:ParsePorts(value, #directive + 2)
+
+		for i, key in ipairs(retval[1]) do
+			if self.directives.realinputs[key] then
+				self:Error("Directive (@realinputs) contains multiple definitions of the same variable", columns[i])
+			else
+				self.directives.realinputs[key] = true
+			end
+		end
 	elseif directive == "persist" then
 		local retval, columns = self:ParsePorts(value, #directive + 2)
 

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -83,7 +83,7 @@ function ENT:UpdateOverlay(clear)
 								prfcount = self.context.prfcount,
 								timebench = self.context.timebench
 							})
-	end	
+	end
 end
 
 function ENT:Initialize()
@@ -142,8 +142,19 @@ function ENT:Execute()
 
 	for k, v in pairs(self.inports[3]) do
 		if self.GlobalScope[k] then
-			if wire_expression_types[self.Inputs[k].Type][3] then
-				self.GlobalScope[k] = wire_expression_types[self.Inputs[k].Type][3](self.context, self.Inputs[k].Value)
+			local CopyFunction = wire_expression_types[self.Inputs[k].Type][3]
+			if CopyFunction then
+				local Copy = CopyFunction(self.context, self.Inputs[k].Value)
+				if Copy then
+					-- If the copy function doesn't return nil, it means that it's legal to input this class
+					if self.realinputs[k] then
+						self.GlobalScope[k] = self.Inputs[k].Value
+					else
+						self.GlobalScope[k] = Copy
+					end
+				else
+					self.GlobalScope[k] = nil
+				end
 			else
 				self.GlobalScope[k] = self.Inputs[k].Value
 			end
@@ -237,6 +248,7 @@ function ENT:CompileCode(buffer, files, filepath)
 	self.outports = directives.outputs
 	self.persists = directives.persist
 	self.trigger = directives.trigger
+	self.realinputs = directives.realinputs
 
 	local status, tokens = Tokenizer.Execute(self.buffer)
 	if not status then self:Error(tokens) return end
@@ -320,11 +332,11 @@ function ENT:ResetContext()
 
 	self.Inputs = WireLib.AdjustSpecialInputs(self, self.inports[1], self.inports[2])
 	self.Outputs = WireLib.AdjustSpecialOutputs(self, self.outports[1], self.outports[2])
-	
+
 	if self.extended then -- It was extended before the adjustment, recreate the wirelink
 		WireLib.CreateWirelinkOutput( self.player, self, {true} )
 	end
-	
+
 	self._original = string.Replace(string.Replace(self.original, "\"", string.char(163)), "\n", string.char(128))
 
 	self._name = self.name
@@ -356,8 +368,19 @@ function ENT:ResetContext()
 	end
 
 	for k, v in pairs(self.Inputs) do
-		if wire_expression_types[v.Type][3] then
-			self.GlobalScope[k] = wire_expression_types[v.Type][3](self.context, v.Value)
+		local CopyFunction = wire_expression_types[v.Type][3]
+		if CopyFunction then
+			local Copy = CopyFunction(self.context, v.Value)
+			if Copy then
+				-- If the copy function doesn't return nil, it means that it's legal to input this class
+				if self.realinputs[k] then
+					self.GlobalScope[k] = v.Value
+				else
+					self.GlobalScope[k] = Copy
+				end
+			else
+				self.GlobalScope[k] = nil
+			end
 		else
 			self.GlobalScope[k] = v.Value
 		end
@@ -544,7 +567,7 @@ function MakeWireExpression2(player, Pos, Ang, model, buffer, name, inputs, outp
 
 	local self = ents.Create("gmod_wire_expression2")
 	if not self:IsValid() then return false end
-	
+
 	self.duped = true
 
 	self:SetModel(model)
@@ -559,21 +582,21 @@ function MakeWireExpression2(player, Pos, Ang, model, buffer, name, inputs, outp
 		buffer = string.Replace(string.Replace(buffer, string.char(163), "\""), string.char(128), "\n")
 		self.buffer = buffer
 		self:SetOverlayText(name)
-		
+
 		self.inc_files = inc_files or {}
 
 		self.Inputs = WireLib.AdjustSpecialInputs(self, inputs[1], inputs[2])
 		self.Outputs = WireLib.AdjustSpecialOutputs(self, outputs[1], outputs[2])
 
 		self.dupevars = vars
-		
+
 		self.filepath = filepath
 	else
 		self.buffer = "error(\"You tried to dupe an E2 with compile errors!\")\n#Unfortunately, no code can be saved when duping an E2 with compile errors.\n#Fix your errors and try again."
-		
+
 		self.inc_files = {}
 		self.dupevars = {}
-		
+
 		self.name = "generic"
 	end
 

--- a/lua/wire/client/texteditor.lua
+++ b/lua/wire/client/texteditor.lua
@@ -3131,6 +3131,7 @@ do -- E2 Syntax highlighting
 		["@outputs"] = 1,
 		["@persist"] = 1,
 		["@trigger"] = 2, -- like 1, except that all/none are yellow
+		["@realinputs"] = 2,
 		["@autoupdate"] = 0,
 	}
 


### PR DESCRIPTION
* DHDD now outputs a proxy object to it's memory (which doesn't bypass the metamethods) and thus updates the "size" overlay text when a field is modified.

* The real inputs feature is functional and tested, it just makes your E2 not copy values that you don't want to be copied from the inputs.
```
@inputs A:array B:array
@realinputs A
```
The input "A" will always be the same object even if you reset the E2, but B will be changing it's address.