### PR TITLE
Fixed Trigger not removing correct entity index

### DIFF
--- a/lua/entities/gmod_wire_trigger_entity.lua
+++ b/lua/entities/gmod_wire_trigger_entity.lua
@@ -38,7 +38,7 @@ function ENT:StartTouch( ent )
 	if owner:GetOwnerOnly() and ( WireLib.GetOwner( ent ) or ply ) ~= WireLib.GetOwner( owner ) then return end
 
 	self.EntsInside[ #self.EntsInside+1 ] = ent
-	self.EntsLookup[ ent ] = #self.EntsInside
+	self.EntsLookup[ ent ] = true
 
 	WireLib.TriggerOutput( owner, "EntCount", #self.EntsInside )
 	WireLib.TriggerOutput( owner, "Entities", self.EntsInside )
@@ -50,8 +50,13 @@ function ENT:EndTouch( ent )
 	if not IsValid( owner ) then return end
 	if not self.EntsLookup[ ent ] then return end
 
-	table.remove( self.EntsInside, self.EntsLookup[ ent ] )
-	self.EntsLookup[ ent ] = nil
+	for i = 1, #self.EntsInside do 
+		if self.EntsInside[ i ] == ent then
+			table.remove( self.EntsInside, i ) 
+			self.EntsLookup[ ent ] = nil
+		end 
+	end
+	
 	WireLib.TriggerOutput( owner, "EntCount", #self.EntsInside )
 	WireLib.TriggerOutput( owner, "Entities", self.EntsInside )
 

--- a/lua/entities/gmod_wire_trigger_entity.lua
+++ b/lua/entities/gmod_wire_trigger_entity.lua
@@ -7,7 +7,6 @@ ENT.Author = "mitterdoo"
 function ENT:Initialize()
 
 	if SERVER then
-		self.EntsLookup = {}
 		self.EntsInside = {}
 	end
 
@@ -20,7 +19,6 @@ end
 
 function ENT:Reset()
 	self.EntsInside = {}
-	self.EntsLookup = {}
 
 	local owner = self:GetTriggerEntity()
 	if not IsValid( owner ) then return end
@@ -38,7 +36,6 @@ function ENT:StartTouch( ent )
 	if owner:GetOwnerOnly() and ( WireLib.GetOwner( ent ) or ply ) ~= WireLib.GetOwner( owner ) then return end
 
 	self.EntsInside[ #self.EntsInside+1 ] = ent
-	self.EntsLookup[ ent ] = true
 
 	WireLib.TriggerOutput( owner, "EntCount", #self.EntsInside )
 	WireLib.TriggerOutput( owner, "Entities", self.EntsInside )
@@ -48,12 +45,10 @@ function ENT:EndTouch( ent )
 
 	local owner = self:GetTriggerEntity()
 	if not IsValid( owner ) then return end
-	if not self.EntsLookup[ ent ] then return end
 
 	for i = 1, #self.EntsInside do 
 		if self.EntsInside[ i ] == ent then
 			table.remove( self.EntsInside, i ) 
-			self.EntsLookup[ ent ] = nil
 		end 
 	end
 	


### PR DESCRIPTION
If you put a prop in the trigger, add another prop, then remove the first, the lookup table won't have the correct index anymore because table.remove shifts all values. This fixes the issue by not using a lookup table to check for the index.