### PR TITLE
Fixes broken E2 function createWire

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/wiring.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/wiring.lua
@@ -51,7 +51,7 @@ e2function number entity:createWire(entity ent2, string inputname, string output
 	
 	local trigger = self.entity.trigger
 	self.entity.trigger = { false, {} } -- So the wire creation doesn't execute the E2 immediately because an input changed
-	WireLib.Link_Start(self.player:UniqueID(), this, this:WorldToLocal(this:GetPos()), input, mat, Vector(color[1],color[2],color[3]), width or 1)
+	WireLib.Link_Start(self.player:UniqueID(), this, this:WorldToLocal(this:GetPos()), inputname, mat, Vector(color[1],color[2],color[3]), width or 1)
 	WireLib.Link_End(self.player:UniqueID(), ent2, ent2:WorldToLocal(ent2:GetPos()), outputname, self.player)
 	self.entity.trigger = trigger
 	


### PR DESCRIPTION
This function was broken when materials being used because of a two year old typo.