### PR TITLE
Remove entity's dependencies on beam vars

### DIFF
--- a/lua/wire/stools/graphics_tablet.lua
+++ b/lua/wire/stools/graphics_tablet.lua
@@ -19,9 +19,12 @@ WireToolSetup.BaseLang()
 WireToolSetup.SetupMax( 20 )
 
 if SERVER then
-	function TOOL:GetConVars() 
-		return self:GetClientNumber("outmode") ~= 0, self:GetClientNumber("draw_background") ~= 0
-	end
+  function TOOL:GetDataTables()
+    return {
+      CursorMode = self:GetClientNumber("outmode") ~= 0,
+      DrawBackground = self:GetClientNumber("draw_background") ~= 0
+    }
+  end
 
 	-- Uses default WireToolObj:MakeEnt's WireLib.MakeWireEnt function
 end

--- a/lua/wire/stools/screen.lua
+++ b/lua/wire/stools/screen.lua
@@ -21,15 +21,17 @@ WireToolSetup.SetupMax( 20 )
 if SERVER then
 	ModelPlug_Register("pixel")
 
-	function TOOL:GetConVars()
-		return self:GetClientNumber("singlevalue") == 1,
-		self:GetClientNumber("singlebigfont") == 1,
-		self:GetClientInfo("texta"),
-		self:GetClientInfo("textb"),
-		self:GetClientNumber("leftalign") == 1,
-		self:GetClientNumber("floor") == 1,
-		self:GetClientNumber("formatnumber") == 1,
-		self:GetClientNumber("formattime") == 1
+	function TOOL:GetDataTables()
+		return {
+			SingleValue = self:GetClientNumber("singlevalue") == 1,
+			SingleBigFont = self:GetClientNumber("singlebigfont") == 1,
+			TextA = self:GetClientInfo("texta"),
+			TextB = self:GetClientInfo("textb"),
+			LeftAlign = self:GetClientNumber("leftalign") == 1,
+			Floor = self:GetClientNumber("floor") == 1,
+			FormatNumber = self:GetClientNumber("formatnumber") == 1,
+			FormatTime = self:GetClientNumber("formattime") == 1
+		}
 	end
 end
 

--- a/lua/wire/tool_loader.lua
+++ b/lua/wire/tool_loader.lua
@@ -59,18 +59,29 @@ if SERVER then
 
 		return ent
 	end
-	
+
 	-- Default MakeEnt function, override to use a different MakeWire* function
 	function WireToolObj:MakeEnt( ply, model, Ang, trace )
-		return WireLib.MakeWireEnt( ply, {Class = self.WireClass, Pos=trace.HitPos, Angle=Ang, Model=model}, self:GetConVars() )
+		local ent = WireLib.MakeWireEnt( ply, {Class = self.WireClass, Pos=trace.HitPos, Angle=Ang, Model=model}, self:GetConVars() )
+
+		for k, v in pairs(self:GetDataTables()) do
+			ent["Set" .. k](ent, v)
+		end
+
+		return ent
 	end
 
 	function WireToolObj:GetConVars() return end
-	
+
+	function WireToolObj:GetDataTables() return {} end
 	--
 	-- to prevent update, set TOOL.NoLeftOnClass = true
 	function WireToolObj:LeftClick_Update( trace )
 		if trace.Entity.Setup then trace.Entity:Setup(self:GetConVars()) end
+
+		for k, v in pairs(self:GetDataTables()) do
+			trace.Entity["Set" .. k](trace.Entity, v)
+		end
 	end
 
 	--
@@ -93,7 +104,7 @@ if SERVER then
 		elseif not self:GetOwner():KeyDown(IN_WALK) then
 			-- Welding
 			const = WireLib.Weld( ent, trace.Entity, trace.PhysicsBone, true, false, self:GetOwner():GetInfo( "wire_tool_weldworld" )~="0" )
-			
+
 			-- Nocollide All
 			if self:GetOwner():GetInfo( "wire_tool_nocollide" )~="0" then
 				ent:SetCollisionGroup( COLLISION_GROUP_WORLD )
@@ -225,7 +236,7 @@ end
 
 function WireToolObj:GetAngle( trace )
 	local Ang
-	if math.abs(trace.HitNormal.x) < 0.001 and math.abs(trace.HitNormal.y) < 0.001 then 
+	if math.abs(trace.HitNormal.x) < 0.001 and math.abs(trace.HitNormal.y) < 0.001 then
 		Ang = Vector(0,0,trace.HitNormal.z):Angle()
 	else
 		Ang = trace.HitNormal:Angle()
@@ -248,7 +259,7 @@ function WireToolObj:GetAngle( trace )
 	else
 		Ang.pitch = Ang.pitch + 90
 	end
-	
+
 	return Ang
 end
 
@@ -284,7 +295,7 @@ if CLIENT then
 	function WireToolObj:DrawToolScreen(width, height)
 		surface.SetTexture(txBackground)
 		surface.DrawTexturedRect(0, 0, width, height)
-		
+
 		local text = self.Name
 		if self.ScreenFont then
 			surface.SetFont(self.ScreenFont)
@@ -301,21 +312,21 @@ if CLIENT then
 		local w, h = surface.GetTextSize(text)
 		local x = width/2 - w/2
 		local y = 105 - h/2
-		
+
 		-- Draw shadow first
 		surface.SetTextColor(0, 0, 0, 255)
 		surface.SetTextPos(x + 3, y + 3)
 		surface.DrawText(text)
-			
+
 		surface.SetTextColor(255, 255, 255, 255)
 		surface.SetTextPos(x, y)
 		surface.DrawText(text)
-		
+
 		iconparams[ "$basetexture" ] = "spawnicons/"..self:GetModel():sub(1,-5)
 		local mat = CreateMaterial(self:GetModel() .. "_DImage", "UnlitGeneric", iconparams )
 		surface.SetMaterial(mat)
 		surface.DrawTexturedRect( 128 - 32, 150, 64, 64)
-		
+
 		local on = self:GetOwner():GetInfo( "wire_tool_weldworld" )~="0" and not self:GetOwner():KeyDown(IN_WALK)
 		draw.DrawText("World Weld:  "..(on and "On" or "Off"),
 			"GmodToolScreen20",
@@ -329,12 +340,12 @@ if CLIENT then
 			Color(on and 150 or 255, on and 255 or 150, 150, 255)
 		)
 	end
-	
+
 	CreateClientConVar( "wire_tool_weldworld", "0", true, true )
 	CreateClientConVar( "wire_tool_nocollide", "1", true, true )
 	local function CreateCPanel_WireOptions( Panel )
 		Panel:ClearControls()
-		
+
 		Panel:Help("Hold Alt while spawning Wire entities\nto disable Weld and Nocollide All")
 		Panel:CheckBox("Allow Weld to World", "wire_tool_weldworld")
 		Panel:CheckBox("Nocollide All", "wire_tool_nocollide")
@@ -378,7 +389,7 @@ if CLIENT then
 		end
 		panel:AddPanel( ctrl )
 	end
-	
+
 	function WireToolHelpers.MakeModelSizer(panel, convar)
 		return panel:AddControl("ListBox", {
 			Label = "Model Size",
@@ -405,7 +416,7 @@ WireToolSetup = {}
 -- sets the ToolCategory for every wire tool made fallowing its call
 function WireToolSetup.setCategory( s_cat, ... )
 	WireToolSetup.cat = s_cat
-	
+
 	local categories = {...}
 	if #categories > 0 then
 		WireToolSetup.Wire_MultiCategories = categories
@@ -488,7 +499,7 @@ function WireToolSetup.SetupLinking(SingleLink)
 		language.Add( "Tool."..TOOL.Mode..".0", "Primary: Create "..TOOL.Name..", Secondary: Link entities, Reload: Unlink entities" )
 		language.Add( "Tool."..TOOL.Mode..".1", "Now select the entity to link to" .. (SingleLink and "" or " (Tip: Hold shift to link to more entities)"))
 		language.Add( "Tool."..TOOL.Mode..".2", "Now select the entity to unlink" .. (SingleLink and "" or " (Tip: Hold shift to unlink from more entities). Reload on the same controller again to clear all linked entities." ))
-		
+
 		function TOOL:DrawHUD()
 			local trace = self:GetOwner():GetEyeTrace()
 			if self:CheckHitOwnClass(trace) and trace.Entity.Marks then
@@ -503,7 +514,7 @@ function WireToolSetup.SetupLinking(SingleLink)
 			end
 		end
 	end
-	
+
 	function TOOL:RightClick(trace)
 		if not trace.HitPos or not IsValid(trace.Entity) or trace.Entity:IsPlayer() then return false end
 		if CLIENT then return true end
@@ -533,9 +544,9 @@ function WireToolSetup.SetupLinking(SingleLink)
 	end
 
 	function TOOL:Reload(trace)
-		if not trace.HitPos or not IsValid(trace.Entity) or trace.Entity:IsPlayer() then 
+		if not trace.HitPos or not IsValid(trace.Entity) or trace.Entity:IsPlayer() then
 			self:SetStage(0)
-			return false 
+			return false
 		end
 		if CLIENT then return true end
 		local ent = trace.Entity
@@ -564,7 +575,7 @@ function WireToolSetup.SetupLinking(SingleLink)
 			return success
 		end
 	end
-	
+
 	if not SingleLink then
 		function TOOL:Think()
 			if self.HasLinked then


### PR DESCRIPTION
See #946.

The only entities which currently use beam vars are the graphics tablet (for networked configuration vars) and the screen (for the values to be displayed on the screen). In both cases I've replaced their networked configuration vars with DataTables, and for the screen's values I've replaced them with a net message.

In the future I'd like to see DataTables replace `ENT:Setup(...)` where possible. To make this easier, I've added a new optional method, `TOOL:GetDataTables()`, to the wire tool object. If a tool defines this then it should return a table with the keys and values of everything to be set in the DataTables.