### PR TITLE
Prop spawner related changes

### DIFF
--- a/lua/entities/gmod_wire_grabber.lua
+++ b/lua/entities/gmod_wire_grabber.lua
@@ -91,10 +91,13 @@ function ENT:TriggerInput(iname, value)
 			local vStart = self:GetPos()
 			local vForward = self:GetUp()
 
+			local filter = ents.FindByClass( "gmod_wire_spawner" ) -- for prop spawning contraptions that grab spawned props
+			table.insert( filter, self )
+
 			local trace = util.TraceLine {
 				start = vStart,
 				endpos = vStart + (vForward * self:GetBeamLength()),
-				filter = { self }
+				filter = filter
 			}
 			if not self:CanGrab(trace) then return end
 

--- a/lua/wire/stools/spawner.lua
+++ b/lua/wire/stools/spawner.lua
@@ -21,7 +21,6 @@ if SERVER then
 end
 
 cleanup.Register("gmod_wire_spawner")
-
 function TOOL:LeftClick(trace)
 	local ent = trace.Entity
 	if !ent or !ent:IsValid() then return false end
@@ -54,8 +53,15 @@ function TOOL:LeftClick(trace)
 	local c		        = ent:GetColor()
 	local skin			= ent:GetSkin() or 0
 
-	local wire_spawner = WireLib.MakeWireEnt(pl, {Class = self.WireClass, Pos=trace.HitPos, Angle=Ang, Model=model}, delay, undo_delay, spawn_effect, mat, c.r, c.g, c.b, c.a, skin)
+	local preserveMotion = phys:IsMotionEnabled()
+
+	local wire_spawner = WireLib.MakeWireEnt(pl, {Class = self.WireClass, Pos=Pos, Angle=Ang, Model=model}, delay, undo_delay, spawn_effect, mat, c.r, c.g, c.b, c.a, skin)
 	if !wire_spawner:IsValid() then return end
+
+	local physObj = wire_spawner:GetPhysicsObject()
+	if IsValid( physObj ) then
+		physObj:EnableMotion( preserveMotion )
+	end
 
 	ent:Remove()
 


### PR DESCRIPTION
Spawner preserves position + frozen state of old prop upon creation
Grabbers no longer grab spawners (to allow grabbing spawned props instead of the spawner)