### PR TITLE
Remove dependency on beam vars for screen and graphics tablet

### DIFF
--- a/lua/entities/gmod_wire_screen.lua
+++ b/lua/entities/gmod_wire_screen.lua
@@ -2,88 +2,37 @@ AddCSLuaFile()
 DEFINE_BASECLASS( "base_wire_entity" )
 ENT.PrintName       = "Wire Screen"
 ENT.WireDebugName	= "Screen"
+ENT.Editable = true
 
-function ENT:SetDisplayA( float )
-	self:SetNetworkedBeamFloat( 1, float, true )
-end
+function ENT:SetupDataTables()
+	self:NetworkVar("Bool", 0, "SingleValue", { KeyName = "SingleValue",
+		Edit = { type = "Boolean", title = "#Tool_wire_screen_singlevalue", order = 1 } })
+	self:NetworkVar("Bool", 1, "SingleBigFont", { KeyName = "SingleBigFont",
+		Edit = { type = "Boolean", title = "#Tool_wire_screen_singlebigfont", order = 2 } })
+	self:NetworkVar("Bool", 2, "LeftAlign", { KeyName = "LeftAlign",
+		Edit = { type = "Boolean", title = "#Tool_wire_screen_leftalign", order = 3 } })
+	self:NetworkVar("Bool", 3, "Floor", { KeyName = "Floor",
+		Edit = { type = "Boolean", title = "#Tool_wire_screen_floor", order = 4 } })
+	self:NetworkVar("Bool", 4, "FormatNumber", { KeyName = "FormatNumber",
+		Edit = { type = "Boolean", title = "#Tool_wire_screen_formatnumber", order = 5 } })
+	self:NetworkVar("Bool", 5, "FormatTime", { KeyName = "FormatTime",
+		Edit = { type = "Boolean", title = "#Tool_wire_screen_formattime", order = 6 } })
+	self:NetworkVar("String", 0, "TextA", { KeyName = "TextA",
+		Edit = { type = "Generic", title = "#Tool_wire_screen_texta", order = 7 } })
+	self:NetworkVar("String", 1, "TextB", { KeyName = "TextB",
+		Edit = { type = "Generic", title = "#Tool_wire_screen_textb", order = 8 } })
 
-function ENT:SetDisplayB( float )
-	self:SetNetworkedBeamFloat( 2, float, true )
-end
-
-function ENT:GetDisplayA( )
-	return self:GetNetworkedBeamFloat( 1 )
-end
-
-function ENT:GetDisplayB( )
-	return self:GetNetworkedBeamFloat( 2 )
-end
-
--- Extra stuff for Wire Screen (TheApathetic)
-function ENT:SetSingleValue(singlevalue)
-	self:SetNWBool("SingleValue",singlevalue)
-
-	-- Change inputs if necessary
-	if (singlevalue) then
-		WireLib.AdjustInputs(self, {"A"})
-	else
-		WireLib.AdjustInputs(self, {"A","B"})
-	end
-end
-function ENT:GetSingleValue()
-	return self:GetNetworkedBool("SingleValue")
+	if SERVER then self:NetworkVarNotify("SingleValue", function(ent, key, old, value)
+		WireLib.AdjustInputs(self, value and { "A", "B" } or { "A" })
+	end) end
 end
 
-function ENT:SetSingleBigFont(singlebigfont)
-	self:SetNWBool("SingleBigFont",singlebigfont)
-end
-function ENT:GetSingleBigFont()
-	return self:GetNetworkedBool("SingleBigFont")
-end
+function ENT:SetDisplayA(float)	self:SetNWFloat("DisplayA", float) end
+function ENT:SetDisplayB(float)	self:SetNWFloat("DisplayB", float) end
+function ENT:GetDisplayA() return self:GetNWFloat("DisplayA") end
+function ENT:GetDisplayB() return self:GetNWFloat("DisplayB") end
 
-function ENT:SetTextA(text)
-	self:SetNWString("TextA",text)
-end
-function ENT:GetTextA()
-	return self:GetNetworkedString("TextA")
-end
-
-function ENT:SetTextB(text)
-	self:SetNWString("TextB",text)
-end
-function ENT:GetTextB()
-	return self:GetNWString("TextB")
-end
-
-function ENT:SetLeftAlign(leftalign)
-	self:SetNWBool("LeftAlign",leftalign)
-end
-function ENT:GetLeftAlign()
-	return self:GetNWBool("LeftAlign")
-end
-
-function ENT:SetFloor(Floor)
-	self:SetNWBool("Floor",Floor)
-end
-function ENT:GetFloor()
-	return self:GetNWBool("Floor")
-end
-
-function ENT:SetFormatNumber( FormatNumber )
-	self:SetNWBool( "FormatNumber", FormatNumber )
-end
-function ENT:GetFormatNumber()
-	return self:GetNWBool("FormatNumber")
-end
-
-function ENT:SetFormatTime( FormatTime )
-	self:SetNWBool( "FormatTime", FormatTime )
-end
-function ENT:GetFormatTime()
-	return self:GetNWBool("FormatTime")
-end
-
-if CLIENT then 
+if CLIENT then
 	function ENT:Initialize()
 		self.GPU = WireGPU(self, true)
 	end
@@ -136,7 +85,7 @@ if CLIENT then
 			value = "" .. math.floor( value )
 		else
 			-- note: loses precision after ~7 decimals, so don't bother displaying more
-			value = "" .. math.floor( value * 10000000 ) / 10000000 
+			value = "" .. math.floor( value * 10000000 ) / 10000000
 		end
 
 		local align = self:GetLeftAlign() and 0 or 1
@@ -180,7 +129,7 @@ if CLIENT then
 	surface.CreateFont("screen_font_single", fontData )
 	fontData.size = 36
 	surface.CreateFont("Trebuchet36", fontData )
-	
+
 	return  -- No more client
 end
 
@@ -220,33 +169,16 @@ function ENT:TriggerInput(iname, value)
 	end
 end
 
+-- only needed for legacy dupes
 function ENT:Setup(SingleValue, SingleBigFont, TextA, TextB, LeftAlign, Floor, FormatNumber, FormatTime)
-	--for duplication
-	self.SingleValue	= SingleValue
-	self.SingleBigFont	= SingleBigFont
-	self.TextA			= TextA
-	self.TextB 			= TextB
-	self.LeftAlign 		= LeftAlign
-	self.Floor	 		= Floor
-	self.FormatNumber	= FormatNumber
-	self.FormatTime		= FormatTime
-
-	-- Extra stuff for Wire Screen (TheApathetic)
-	self:SetTextA(TextA)
-	self:SetTextB(TextB)
-	self:SetSingleBigFont(SingleBigFont)
-
-	--LeftAlign (TAD2020)
-	self:SetLeftAlign(LeftAlign)
-	--Floor (TAD2020)
-	self:SetFloor(Floor)
-
-	--Put it here to update inputs if necessary (TheApathetic)
-	self:SetSingleValue(SingleValue)
-
-	-- Auto formatting (Divran)
-	self:SetFormatNumber( FormatNumber )
-	self:SetFormatTime( FormatTime )
+	if type(TextA) == "string" then self:SetTextA(TextA) end
+	if type(TextB) == "string" then self:SetTextB(TextB) end
+	if SingleBigFont ~= nil then self:SetSingleBigFont(SingleBigFont) end
+	if LeftAlign ~= nil then self:SetLeftAlign(LeftAlign) end
+	if Floor ~= nil then self:SetFloor(Floor) end
+	if SingleValue ~= nil then self:SetSingleValue(SingleValue) end
+	if FormatNumber ~= nil then self:SetFormatNumber(FormatNumber) end
+	if FormatTime ~= nil then self:SetFormatTime(FormatTime) end
 end
 
 duplicator.RegisterEntityClass("gmod_wire_screen", WireLib.MakeWireEnt, "Data", "SingleValue", "SingleBigFont", "TextA", "TextB", "LeftAlign", "Floor", "FormatNumber", "FormatTime")

--- a/lua/wire/stools/graphics_tablet.lua
+++ b/lua/wire/stools/graphics_tablet.lua
@@ -8,9 +8,9 @@ WireToolSetup.setCategory( "Input, Output/Mouse Interaction" )
 WireToolSetup.open( "graphics_tablet", "Graphics Tablet", "gmod_wire_graphics_tablet", nil, "Graphics Tablet" )
 
 if ( CLIENT ) then
-    language.Add( "Tool.wire_graphics_tablet.name", "Graphics Tablet Tool (Wire)" )
-    language.Add( "Tool.wire_graphics_tablet.desc", "Spawns a graphics tablet, which outputs cursor coordinates" )
-    language.Add( "Tool.wire_graphics_tablet.0", "Primary: Create/Update graphics tablet" )
+  language.Add( "Tool.wire_graphics_tablet.name", "Graphics Tablet Tool (Wire)" )
+  language.Add( "Tool.wire_graphics_tablet.desc", "Spawns a graphics tablet, which outputs cursor coordinates" )
+  language.Add( "Tool.wire_graphics_tablet.0", "Primary: Create/Update graphics tablet" )
 	language.Add( "Tool_wire_graphics_tablet_mode", "Output mode: -1 to 1 (ticked), 0 to 1 (unticked)" )
 	language.Add( "Tool_wire_graphics_tablet_draw_background", "Draw background" )
 	language.Add( "Tool_wire_graphics_tablet_createflat", "Create flat to surface" )
@@ -19,9 +19,12 @@ WireToolSetup.BaseLang()
 WireToolSetup.SetupMax( 20 )
 
 if SERVER then
-	function TOOL:GetConVars() 
-		return self:GetClientNumber("outmode") ~= 0, self:GetClientNumber("draw_background") ~= 0
-	end
+	function TOOL:GetDataTables()
+    return {
+      DrawBackground = self:GetClientNumber("draw_background") ~= 0,
+      CursorMode = self:GetClientNumber("outmode") ~= 0
+    }
+  end
 
 	-- Uses default WireToolObj:MakeEnt's WireLib.MakeWireEnt function
 end

--- a/lua/wire/stools/screen.lua
+++ b/lua/wire/stools/screen.lua
@@ -21,15 +21,17 @@ WireToolSetup.SetupMax( 20 )
 if SERVER then
 	ModelPlug_Register("pixel")
 
-	function TOOL:GetConVars()
-		return self:GetClientNumber("singlevalue") == 1,
-		self:GetClientNumber("singlebigfont") == 1,
-		self:GetClientInfo("texta"),
-		self:GetClientInfo("textb"),
-		self:GetClientNumber("leftalign") == 1,
-		self:GetClientNumber("floor") == 1,
-		self:GetClientNumber("formatnumber") == 1,
-		self:GetClientNumber("formattime") == 1
+	function TOOL:GetDataTables()
+		return {
+			SingleValue = self:GetClientNumber("singlevalue") == 1,
+			SingleBigFont = self:GetClientNumber("singlebigfont") == 1,
+			TextA = self:GetClientInfo("texta"),
+			TextB = self:GetClientInfo("textb"),
+			LeftAlign = self:GetClientNumber("leftalign") == 1,
+			Floor = self:GetClientNumber("floor") == 1,
+			FormatNumber = self:GetClientNumber("formatnumber") == 1,
+			FormatTime = self:GetClientNumber("formattime") == 1
+		}
 	end
 end
 

--- a/lua/wire/tool_loader.lua
+++ b/lua/wire/tool_loader.lua
@@ -59,18 +59,23 @@ if SERVER then
 
 		return ent
 	end
-	
+
 	-- Default MakeEnt function, override to use a different MakeWire* function
 	function WireToolObj:MakeEnt( ply, model, Ang, trace )
-		return WireLib.MakeWireEnt( ply, {Class = self.WireClass, Pos=trace.HitPos, Angle=Ang, Model=model}, self:GetConVars() )
+		local ent = WireLib.MakeWireEnt( ply, {Class = self.WireClass, Pos=trace.HitPos, Angle=Ang, Model=model}, self:GetConVars() )
+		if ent.RestoreNetworkVars then ent:RestoreNetworkVars(self:GetDataTables()) end
+		return ent
 	end
 
 	function WireToolObj:GetConVars() return end
-	
+
+	function WireToolObj:GetDataTables() return {} end
+
 	--
 	-- to prevent update, set TOOL.NoLeftOnClass = true
 	function WireToolObj:LeftClick_Update( trace )
 		if trace.Entity.Setup then trace.Entity:Setup(self:GetConVars()) end
+		if trace.Entity.RestoreNetworkVars then trace.Entity:RestoreNetworkVars(self:GetDataTables()) end
 	end
 
 	--
@@ -93,7 +98,7 @@ if SERVER then
 		elseif not self:GetOwner():KeyDown(IN_WALK) then
 			-- Welding
 			const = WireLib.Weld( ent, trace.Entity, trace.PhysicsBone, true, false, self:GetOwner():GetInfo( "wire_tool_weldworld" )~="0" )
-			
+
 			-- Nocollide All
 			if self:GetOwner():GetInfo( "wire_tool_nocollide" )~="0" then
 				ent:SetCollisionGroup( COLLISION_GROUP_WORLD )
@@ -225,7 +230,7 @@ end
 
 function WireToolObj:GetAngle( trace )
 	local Ang
-	if math.abs(trace.HitNormal.x) < 0.001 and math.abs(trace.HitNormal.y) < 0.001 then 
+	if math.abs(trace.HitNormal.x) < 0.001 and math.abs(trace.HitNormal.y) < 0.001 then
 		Ang = Vector(0,0,trace.HitNormal.z):Angle()
 	else
 		Ang = trace.HitNormal:Angle()
@@ -248,7 +253,7 @@ function WireToolObj:GetAngle( trace )
 	else
 		Ang.pitch = Ang.pitch + 90
 	end
-	
+
 	return Ang
 end
 
@@ -284,7 +289,7 @@ if CLIENT then
 	function WireToolObj:DrawToolScreen(width, height)
 		surface.SetTexture(txBackground)
 		surface.DrawTexturedRect(0, 0, width, height)
-		
+
 		local text = self.Name
 		if self.ScreenFont then
 			surface.SetFont(self.ScreenFont)
@@ -301,21 +306,21 @@ if CLIENT then
 		local w, h = surface.GetTextSize(text)
 		local x = width/2 - w/2
 		local y = 105 - h/2
-		
+
 		-- Draw shadow first
 		surface.SetTextColor(0, 0, 0, 255)
 		surface.SetTextPos(x + 3, y + 3)
 		surface.DrawText(text)
-			
+
 		surface.SetTextColor(255, 255, 255, 255)
 		surface.SetTextPos(x, y)
 		surface.DrawText(text)
-		
+
 		iconparams[ "$basetexture" ] = "spawnicons/"..self:GetModel():sub(1,-5)
 		local mat = CreateMaterial(self:GetModel() .. "_DImage", "UnlitGeneric", iconparams )
 		surface.SetMaterial(mat)
 		surface.DrawTexturedRect( 128 - 32, 150, 64, 64)
-		
+
 		local on = self:GetOwner():GetInfo( "wire_tool_weldworld" )~="0" and not self:GetOwner():KeyDown(IN_WALK)
 		draw.DrawText("World Weld:  "..(on and "On" or "Off"),
 			"GmodToolScreen20",
@@ -329,12 +334,12 @@ if CLIENT then
 			Color(on and 150 or 255, on and 255 or 150, 150, 255)
 		)
 	end
-	
+
 	CreateClientConVar( "wire_tool_weldworld", "0", true, true )
 	CreateClientConVar( "wire_tool_nocollide", "1", true, true )
 	local function CreateCPanel_WireOptions( Panel )
 		Panel:ClearControls()
-		
+
 		Panel:Help("Hold Alt while spawning Wire entities\nto disable Weld and Nocollide All")
 		Panel:CheckBox("Allow Weld to World", "wire_tool_weldworld")
 		Panel:CheckBox("Nocollide All", "wire_tool_nocollide")
@@ -378,7 +383,7 @@ if CLIENT then
 		end
 		panel:AddPanel( ctrl )
 	end
-	
+
 	function WireToolHelpers.MakeModelSizer(panel, convar)
 		return panel:AddControl("ListBox", {
 			Label = "Model Size",
@@ -405,7 +410,7 @@ WireToolSetup = {}
 -- sets the ToolCategory for every wire tool made fallowing its call
 function WireToolSetup.setCategory( s_cat, ... )
 	WireToolSetup.cat = s_cat
-	
+
 	local categories = {...}
 	if #categories > 0 then
 		WireToolSetup.Wire_MultiCategories = categories
@@ -488,7 +493,7 @@ function WireToolSetup.SetupLinking(SingleLink)
 		language.Add( "Tool."..TOOL.Mode..".0", "Primary: Create "..TOOL.Name..", Secondary: Link entities, Reload: Unlink entities" )
 		language.Add( "Tool."..TOOL.Mode..".1", "Now select the entity to link to" .. (SingleLink and "" or " (Tip: Hold shift to link to more entities)"))
 		language.Add( "Tool."..TOOL.Mode..".2", "Now select the entity to unlink" .. (SingleLink and "" or " (Tip: Hold shift to unlink from more entities). Reload on the same controller again to clear all linked entities." ))
-		
+
 		function TOOL:DrawHUD()
 			local trace = self:GetOwner():GetEyeTrace()
 			if self:CheckHitOwnClass(trace) and trace.Entity.Marks then
@@ -503,7 +508,7 @@ function WireToolSetup.SetupLinking(SingleLink)
 			end
 		end
 	end
-	
+
 	function TOOL:RightClick(trace)
 		if not trace.HitPos or not IsValid(trace.Entity) or trace.Entity:IsPlayer() then return false end
 		if CLIENT then return true end
@@ -533,9 +538,9 @@ function WireToolSetup.SetupLinking(SingleLink)
 	end
 
 	function TOOL:Reload(trace)
-		if not trace.HitPos or not IsValid(trace.Entity) or trace.Entity:IsPlayer() then 
+		if not trace.HitPos or not IsValid(trace.Entity) or trace.Entity:IsPlayer() then
 			self:SetStage(0)
-			return false 
+			return false
 		end
 		if CLIENT then return true end
 		local ent = trace.Entity
@@ -564,7 +569,7 @@ function WireToolSetup.SetupLinking(SingleLink)
 			return success
 		end
 	end
-	
+
 	if not SingleLink then
 		function TOOL:Think()
 			if self.HasLinked then


### PR DESCRIPTION
This PR changes the graphics tablet and screen entities to use datatables instead of beam vars for configuration settings, and NWVars for the screen's values to be displayed.

This is mainly as a prelude to #946 (removing the beam var library entirely), but also has the happy side-effect that screens and graphics tablets can now be edited with the right-click 'Edit properties...' menu.