### PR TITLE
ZCPU Editor's validator fixed

### DIFF
--- a/lua/wire/cpulib.lua
+++ b/lua/wire/cpulib.lua
@@ -84,11 +84,10 @@ if CLIENT then
   -- Make sure the file is opened in the tab
   function CPULib.SelectTab(editor,fileName)
     if not editor then return end
-    local fullFileName = editor.EditorType.."Chip\\"..fileName
-    fileName = string.lower(fileName)
-    fullFileName = string.lower(fullFileName)
-    editor.EditorType = string.lower(editor.EditorType)
-    if string.sub(fileName,1,7) == editor.EditorType.."chip" then
+    local editorType = string.lower(editor.EditorType)
+    local fullFileName = editorType.."chip\\"..fileName
+
+    if string.sub(fileName,1,7) == editorType.."chip" then
       fullFileName = fileName
     end
 


### PR DESCRIPTION
Fixes #817.
The line `editor.EditorType = string.lower(editor.EditorType)` (https://github.com/wiremod/wire/blob/master/lua/wire/cpulib.lua#L90) lowers the editor's type. So "CPU" gets to "cpu", but the validate function for CPU checks for "CPU". So after first wrong validating the validator is broken.

This also fixes another bug: when you have an error in an included file (or attaching a debugger), the file got opened with lowercased filename, which caused to open a copy of the file.