### PR TITLE
ZGPU Interrupt fix

### DIFF
--- a/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
+++ b/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
@@ -43,7 +43,7 @@ function ENT:OverrideVM()
     if self.ASYNC == 1 then
       if self.EntryPoint5 > 0 then
         self.IP = self.EntryPoint5
-        self.LADD = interruptParameter
+        self.LADD = interruptParameter or self.XEIP
         self.LINT = interruptNo
       else
         -- Shutdown asynchronous thread
@@ -52,7 +52,7 @@ function ENT:OverrideVM()
     else
       if self.EntryPoint3 > 0 then
         self.IP = self.EntryPoint3
-        self.LADD = interruptParameter
+        self.LADD = interruptParameter or self.XEIP
         self.LINT = interruptNo
       else
         if (interruptNo == 2) and (self.XEIP == 0) then self.INTR = 1 return end
@@ -64,7 +64,7 @@ function ENT:OverrideVM()
 		  
           draw.DrawText("Error in the instruction stream","WireGPU_ErrorFont",48,16,Color(255,255,255,255))
           draw.DrawText((self.ErrorText[interruptNo] or "Unknown error").." (#"..interruptNo..")","WireGPU_ErrorFont",16,16+32*2,Color(255,255,255,255))
-          draw.DrawText("Parameter: "..interruptParameter,"WireGPU_ErrorFont",16,16+32*3,Color(255,255,255,255))
+          draw.DrawText("Parameter: "..(interruptParameter or 0),"WireGPU_ErrorFont",16,16+32*3,Color(255,255,255,255))
           draw.DrawText("Address: "..self.XEIP,"WireGPU_ErrorFont",16,16+32*4,Color(255,255,255,255))
 
           local errorPosition = CPULib.Debugger.PositionByPointer[self.XEIP]


### PR DESCRIPTION
Fixes  #975.
The ZVM's interrupt Parameter is nil if the number is too large. It gets checked for nil in ZCPU but not in GPU. In the ZCPU Documentation it says
```lua
// Set registers
LINT = interruptNo
LADD = interruptParameter or XEIP
```
so LADD gets set to XEIP and not to nil (which would create other issues).