### PR TITLE
ZCPU: Removed unnecessary compiling

### DIFF
--- a/lua/wire/client/wire_expression2_editor.lua
+++ b/lua/wire/client/wire_expression2_editor.lua
@@ -1837,7 +1837,7 @@ function Editor:Close()
 	timer.Stop("e2autosave")
 	self:AutoSave()
 
-	self:Validate()
+	if self.E2 then self:Validate() end
 	self:ExtractName()
 	self:SetV(false)
 	self.chip = false

--- a/lua/wire/stools/cpu.lua
+++ b/lua/wire/stools/cpu.lua
@@ -86,28 +86,13 @@ end
 
 if CLIENT then
   ------------------------------------------------------------------------------
-  -- Compiler callbacks on the compiling state
+  -- Request compiled code (called remotely from server)
   ------------------------------------------------------------------------------
-  local function compile_success()
+  
+  net.Receive("ZCPU_RequestCode", function()
     CPULib.Upload()
-  end
-
-  local function compile_error(errorText)
-    print(errorText)
-    GAMEMODE:AddNotify(errorText,NOTIFY_GENERIC,7)
-  end
-
-
-  ------------------------------------------------------------------------------
-  -- Request code to be compiled (called remotely from server)
-  ------------------------------------------------------------------------------
-  function ZCPU_RequestCode()
-    if ZCPU_Editor then
-      CPULib.Compile(ZCPU_Editor:GetCode(),ZCPU_Editor:GetChosenFile(),compile_success,compile_error)
-    end
-  end
-  net.Receive("ZCPU_RequestCode", ZCPU_RequestCode)
-
+  end)
+  
   ------------------------------------------------------------------------------
   -- Open ZCPU editor
   ------------------------------------------------------------------------------


### PR DESCRIPTION
Programs which include 5 different libraries and are >2000 lines of code need ~5 seconds to compile. The code gets then 3 times compiled:
1. When validating
2. When closing editor
3. When placing ZCPU
That's really annoying if you make a small change. It's also pretty useless to compile a program 2-3 times.
I fixed it by only letting it compile when validating.