### PR TITLE
Disconnect wires when changing a port's type

### DIFF
--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -244,11 +244,7 @@ function WireLib.AdjustSpecialOutputs(ent, names, types, descs)
 
 		if (ent_ports[name]) then
 			if tp ~= ent_ports[name].Type then
-				for i,inp in ipairs(ent_ports[name].Connected) do
-					if (IsValid(inp.Entity)) then
-						WireLib.Link_Clear(inp.Entity, inp.Name)
-					end
-				end
+				WireLib.DisconnectOutput(ent, name)
 				ent_ports[name].Type = tp
 			end
 			ent_ports[name].Keep = true
@@ -281,12 +277,7 @@ function WireLib.AdjustSpecialOutputs(ent, names, types, descs)
 		if (port.Keep) then
 			port.Keep = nil
 		else
-			-- fix by Syranide: unlinks wires of removed outputs
-			for i,inp in ipairs(port.Connected) do
-				if (IsValid(inp.Entity)) then
-					WireLib.Link_Clear(inp.Entity, inp.Name)
-				end
-			end
+			WireLib.DisconnectOutput(ent, portname)
 			ent_ports[portname] = nil
 		end
 	end
@@ -296,14 +287,27 @@ function WireLib.AdjustSpecialOutputs(ent, names, types, descs)
 	return ent_ports
 end
 
+--- Disconnects all wires from the given output.
+function WireLib.DisconnectOutput(entity, output_name)
+	local output = entity.Outputs[output_name]
+	if output == nil then return end
+	for _, input in pairs_consume(output.Connected) do
+		if IsValid(input.Entity) then
+			WireLib.Link_Clear(input.Entity, input.Name)
+		end
+	end
+end
 
 function WireLib.RetypeInputs(ent, iname, itype, descs)
 	if not HasPorts(ent) then return end
 
 	local ent_ports = ent.Inputs
 	if (not ent_ports[iname]) or (not itype) then return end
+	if itype ~= ent_ports[iname].Type then
+		WireLib.Link_Clear(ent, iname)
+		ent_ports[iname].Type = itype
+	end
 	ent_ports[iname].Desc = descs
-	ent_ports[iname].Type = itype
 	ent_ports[iname].Value = WireLib.DT[itype].Zero
 
 	WireLib._SetInputs(ent)
@@ -315,8 +319,11 @@ function WireLib.RetypeOutputs(ent, oname, otype, descs)
 
 	local ent_ports = ent.Outputs
 	if (not ent_ports[oname]) or (not otype) then return end
+	if otype ~= ent_ports[oname].Type then
+		WireLib.DisconnectOutput(ent, oname)
+		ent_ports[oname].Type = otype
+	end
 	ent_ports[oname].Desc = descs
-	ent_ports[oname].Type = otype
 	ent_ports[oname].Value = WireLib.DT[otype].Zero
 
 	WireLib._SetOutputs(ent)
@@ -717,7 +724,7 @@ end
 
 function WireLib.WireAll(ply, ient, oent, ipos, opos, material, color, width)
 	if not IsValid(ient) or not IsValid(oent) or not ient.Inputs or not oent.Outputs then return false end
-	
+
 	for iname, _ in pairs(ient.Inputs) do
 		if oent.Outputs[iname] then
 			WireLib.Link_Start(ply:UniqueID(), ient, ipos, iname, material or "arrowire/arrowire2", color or Color(255,255,255), width or 0)
@@ -825,7 +832,7 @@ function WireLib.ApplyDupeInfo( ply, ent, info, GetEntByID )
 	if (info.Wires) then
 		for k,input in pairs(info.Wires) do
 			local ent2 = GetEntByID(input.Src)
-			
+
 			-- Input alias
 			if ent.Inputs and not ent.Inputs[k] then -- if the entity has any inputs and the input 'k' is not one of them...
 				if ent.InputAliases and ent.InputAliases[k] then
@@ -835,13 +842,13 @@ function WireLib.ApplyDupeInfo( ply, ent, info, GetEntByID )
 					continue
 				end
 			end
-			
+
 			if IsValid( ent2 ) then
 				-- Wirelink and entity outputs
-				
+
 				-- These are required if whichever duplicator you're using does not do entity modifiers before it runs PostEntityPaste
 				-- because if so, the wirelink and entity outputs may not have been created yet
-				
+
 				if input.SrcId == "link" or input.SrcId == "wirelink" then -- If the target entity has no wirelink output, create one (& more old dupe compatibility)
 					input.SrcId = "wirelink"
 					if not ent2.extended then
@@ -850,7 +857,7 @@ function WireLib.ApplyDupeInfo( ply, ent, info, GetEntByID )
 				elseif input.SrcId == "entity" and ((ent2.Outputs and not ent2.Outputs.entity) or not ent2.Outputs) then -- if the input name is 'entity', and the target entity doesn't have that output...
 					WireLib.CreateEntityOutput( ply, ent2, {true} )
 				end
-				
+
 				-- Output alias
 				if ent2.Outputs and not ent2.Outputs[input.SrcId] then -- if the target entity has any outputs and the output 'input.SrcId' is not one of them...
 					if ent2.OutputAliases and ent2.OutputAliases[input.SrcId] then
@@ -861,7 +868,7 @@ function WireLib.ApplyDupeInfo( ply, ent, info, GetEntByID )
 					end
 				end
 			end
-			
+
 			WireLib.Link_Start(idx, ent, input.StartPos, k, input.Material, input.Color, input.Width)
 
 			if input.Path then
@@ -1130,10 +1137,10 @@ end
 function WireLib.MakeWireEnt( pl, Data, ... )
 	Data.Class = scripted_ents.Get(Data.Class).ClassName
 	if IsValid(pl) and not pl:CheckLimit(Data.Class:sub(6).."s") then return false end
-	
+
 	local ent = ents.Create( Data.Class )
 	if not IsValid(ent) then return false end
-	
+
 	duplicator.DoGeneric( ent, Data )
 	ent:Spawn()
 	ent:Activate()
@@ -1163,9 +1170,9 @@ function WireLib.AddInputAlias( class, old, new )
 		old = class
 		class = nil
 	end
-	
+
 	local ENT_table
-	
+
 	if not class and ENT then
 		ENT_table = ENT
 	elseif isstring( class ) then
@@ -1176,7 +1183,7 @@ function WireLib.AddInputAlias( class, old, new )
 		error( "Invalid class or entity specified" )
 		return
 	end
-	
+
 	if not ENT_table.InputAliases then ENT_table.InputAliases = {} end
 	ENT_table.InputAliases[old] = new
 end
@@ -1191,9 +1198,9 @@ function WireLib.AddOutputAlias( class, old, new )
 		old = class
 		class = nil
 	end
-	
+
 	local ENT_table
-	
+
 	if not class and ENT then
 		ENT_table = ENT
 	elseif isstring( class ) then
@@ -1204,7 +1211,7 @@ function WireLib.AddOutputAlias( class, old, new )
 		error( "Invalid class or entity specified" )
 		return
 	end
-	
+
 	if not ENT_table.OutputAliases then ENT_table.OutputAliases = {} end
 	ENT_table.OutputAliases[old] = new
 end
@@ -1233,7 +1240,7 @@ function WireLib.GetVersion()
 			return cachedversion
 		end
 	end
-	
+
 	-- Find what our legacy folder is called
 	local wirefolder = "addons/wire"
 	if not file.Exists(wirefolder, "GAME") then
@@ -1244,7 +1251,7 @@ function WireLib.GetVersion()
 			end
 		end
 	end
-	
+
 	if file.Exists(wirefolder, "GAME") then
 		if file.Exists(wirefolder.."/.git", "GAME") then
 			cachedversion = "Git "..(file.Read(wirefolder.."/.git/refs/heads/master", "GAME") or "Unknown"):sub(1,7)
@@ -1261,14 +1268,14 @@ function WireLib.GetVersion()
 			cachedversion = "Extracted"
 		end
 	end
-	
+
 	if not cachedversion then cachedversion = "Unknown" end
-	
+
 	return cachedversion
 end
 concommand.Add("wireversion", function(ply,cmd,args)
 	local text = "Wiremod's version: '"..WireLib.GetVersion().."'"
-	if IsValid(ply) then 
+	if IsValid(ply) then
 		ply:ChatPrint(text)
 	else
 		print(text)

--- a/lua/wire/wireshared.lua
+++ b/lua/wire/wireshared.lua
@@ -92,6 +92,16 @@ function pairs_sortvalues(tbl, criterion)
 	end
 end
 
+--- Iterates over a table like `pairs`, but also removes each field from the
+--- table as it does so. Adding to the table while iterating is allowed, and
+--- each added entry will be consumed in some future iteration.
+function pairs_consume(table)
+	return function()
+		local k, v = next(table)
+		if k then table[k] = nil return k, v end
+	end
+end
+
 -- like ipairs, except it maps the value with mapfunction before returning.
 function ipairs_map(tbl, mapfunction)
 	local iter, state, k = ipairs(tbl)
@@ -311,7 +321,7 @@ do
 		NOTIFY_UNDO = 2
 		NOTIFY_HINT = 3
 		NOTIFY_CLEANUP = 4
-		
+
 		util.AddNetworkString("wire_addnotify")
 		function WireLib.AddNotify(ply, Message, Type, Duration, Sound)
 			if isstring(ply) then ply, Message, Type, Duration, Sound = nil, ply, Message, Type, Duration end
@@ -363,7 +373,7 @@ end
 	A basic framework for entities that should send newly connecting players data
 
 	Server requirements: ENT:Retransmit(ply) -- Should send all data to one player
-	Client requirements: 
+	Client requirements:
 		WireLib.netRegister(self) in ENT:Initialize()
 		ENT:Receive()
 
@@ -373,7 +383,7 @@ end
 			net.Write*...
 		WireLib.netEnd(ply) -- you can pass a Player or a table of players to only send to some clients, otherwise it broadcasts
 	end
-	
+
 	To receive:
 	function ENT:Receive()
 		net.Read*...
@@ -385,7 +395,7 @@ end
 if SERVER then
 	util.AddNetworkString("wire_netmsg_register")
 	util.AddNetworkString("wire_netmsg_registered")
-	
+
 	function WireLib.netStart(self)
 		net.Start("wire_netmsg_registered")
 		net.WriteEntity(self)
@@ -393,8 +403,8 @@ if SERVER then
 	function WireLib.netEnd(ply)
 		if ply then net.Send(ply) else net.Broadcast() end
 	end
-	
-	net.Receive("wire_netmsg_register", function(netlen, ply) 
+
+	net.Receive("wire_netmsg_register", function(netlen, ply)
 		local self = net.ReadEntity()
 		if IsValid(self) and self.Retransmit then self:Retransmit(ply) end
 	end)
@@ -445,7 +455,7 @@ if SERVER then
 	local ents_with_inputs = {}
 	local ents_with_outputs = {}
 	--local IOlookup = { [INPUT] = ents_with_inputs, [OUTPUT] = ents_with_outputs }
-	
+
 	util.AddNetworkString("wire_ports")
 	timer.Create("Debugger.PoolTypeStrings",1,1,function()
 		if WireLib.Debugger and WireLib.Debugger.formatPort then
@@ -485,7 +495,7 @@ if SERVER then
 	function WireLib._SetInputs(ent, lqueue)
 		local queue = lqueue or queue
 		local eid = ent:EntIndex()
-		
+
 		if not ents_with_inputs[eid] then ents_with_inputs[eid] = {} end
 
 		queue[#queue+1] = { eid, DELETE, INPUT }
@@ -503,7 +513,7 @@ if SERVER then
 	function WireLib._SetOutputs(ent, lqueue)
 		local queue = lqueue or queue
 		local eid = ent:EntIndex()
-		
+
 		if not ents_with_outputs[eid] then ents_with_outputs[eid] = {} end
 
 		queue[#queue+1] = { eid, DELETE, OUTPUT }
@@ -525,7 +535,7 @@ if SERVER then
 
 		queue[#queue+1] = {eid, LINK, num, state}
 	end
-	
+
 	local eid = 0
 	local numports, firstportnum, portstrings = {}, {}, {}
 	local function writeCurrentStrings()
@@ -543,7 +553,7 @@ if SERVER then
 	local function writemsg(msg)
 		-- First write a signed int for the command code
 		-- Then sometimes write extra data specific to the command (type varies)
-		
+
 		if msg[1] ~= eid then
 			eid = msg[1]
 			writeCurrentStrings() -- We're switching to talking about a different entity, lets send port information
@@ -737,7 +747,7 @@ end
 	ie the amount of character swaps you have to do to get the first string to equal the second
 	Example:
 		levenshtein( "test", "toast" ) returns 2, because two steps: 'e' swapped to 'o', and 'a' is added
-	
+
 	Very useful for searching algorithms
 	Used by custom spawn menu search & gate tool search, for example
 	Credits go to: http://lua-users.org/lists/lua-l/2009-07/msg00461.html
@@ -768,7 +778,7 @@ end
 
 WireLib.nicenumber = {}
 local nicenumber = WireLib.nicenumber
- 
+
 local numbers = {
 	{
 		name = "septillion",
@@ -827,7 +837,7 @@ local numbers = {
 		zeroes = 10^3
 	}
 }
- 
+
 local one = {
 	name = "ones",
 	short = "",
@@ -835,7 +845,7 @@ local one = {
 	prefix = "",
 	zeroes = 1
 }
- 
+
 -- returns a table of tables that inherit from the above info
 local floor = math.floor
 local min = math.min
@@ -872,9 +882,9 @@ function nicenumber.info( n, steps )
 
 	return t
 end
- 
+
 local sub = string.sub
- 
+
 -- returns string
 -- example 12B 34M
 function nicenumber.format( n, steps )
@@ -890,7 +900,7 @@ function nicenumber.format( n, steps )
 
 	return sub( str, 1, -2 ) -- remove trailing space
 end
- 
+
 -- returns string with decimals
 -- example 12.34B
 local round = math.Round
@@ -920,7 +930,7 @@ local times = {
 	{ "h", 3600 }, -- hours
 	{ "m", 60 }, -- minutes
 	{ "s", 1 }, -- seconds
-}       
+}
 function nicenumber.nicetime( n )
 	n = math.abs( n )
 


### PR DESCRIPTION
`WireLib.AdjustSpecialOutputs` had a subtle bug which meant if an output was connected to multiple inputs on the same entity then not all of them would be disconnected, due to removing while iterating. `WireLib.RetypeIn/Outputs` simply didn't check and left them connected.

Fixes #981