### PR TITLE
GPU async thread reset fix

### DIFF
--- a/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
+++ b/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
@@ -584,6 +584,9 @@ function VM:HardReset()
 
   -- Has initialized already
   self.INIT = 0
+  
+  -- Reset async thread
+  self.AsyncState = nil
 end
 
 


### PR DESCRIPTION
Currently, resetting a GPU whose async thread is running doesn't actually reset the async thread. That makes it a bit hard to upload a new program if you're using the async thread, because it will keep doing what it was doing before (but in your new program, causing chaos), instead of starting from scratch in your new program. This fixes that.

Paging @PhoenixBlack