### PR TITLE
Added E2 propStatic (removed propScale)

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/cl_prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cl_prop.lua
@@ -30,3 +30,5 @@ E2Helper.Descriptions["propSetElasticity"] = "Sets prop's elasticity coefficient
 E2Helper.Descriptions["propGetElasticity"] = "Gets prop's elasticity coefficient"
 E2Helper.Descriptions["propSpawnUndo"] = "Set to 0 to force prop removal on E2 shutdown, and suppress Undo entries for props."
 E2Helper.Descriptions["propDeleteAll"] = "Removes all entities spawned by this E2"
+E2Helper.Descriptions["propStatic"] = "Sets to 1 to make the entity static (disables movement, physgun, unfreeze, drive...) or 0 to cancel."
+E2Helper.Descriptions["propScale"] = "Resizes the entity to the given scale vector (between 0.1 and 10)"

--- a/lua/entities/gmod_wire_expression2/core/custom/cl_prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cl_prop.lua
@@ -31,4 +31,3 @@ E2Helper.Descriptions["propGetElasticity"] = "Gets prop's elasticity coefficient
 E2Helper.Descriptions["propSpawnUndo"] = "Set to 0 to force prop removal on E2 shutdown, and suppress Undo entries for props."
 E2Helper.Descriptions["propDeleteAll"] = "Removes all entities spawned by this E2"
 E2Helper.Descriptions["propStatic"] = "Sets to 1 to make the entity static (disables movement, physgun, unfreeze, drive...) or 0 to cancel."
-E2Helper.Descriptions["propScale"] = "Resizes the entity to the given scale vector (between 0.1 and 10)"

--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -355,7 +355,7 @@ e2function string entity:propPhysicalMaterial()
 	return ""
 end
 
-hook.Add( "CanDrive", "checkPropStaticE2", function( ply, ent ) return ent.propStaticE2 == nil end )
+hook.Add( "CanDrive", "checkPropStaticE2", function( ply, ent ) if ent.propStaticE2 ~= nil then return false end end )
 e2function void entity:propStatic( number static )
 	if not PropCore.ValidAction( self, this, "static" ) then return end
 	if static ~= 0 and this.propStaticE2 == nil then
@@ -376,19 +376,6 @@ e2function void entity:propStatic( number static )
 		this.propStaticE2 = nil
 	end
 end
-
-if AdvancedResize then
-	__e2setcost( 30 )
-	e2function void entity:propScale( vector scale )
-		if not PropCore.ValidAction(self, this, "scale") then return end
-		local sx = math.Clamp( scale[1], 0.1, 10 )
-		local sy = math.Clamp( scale[2], 0.1, 10 )
-		local sz = math.Clamp( scale[3], 0.1, 10 )
-		AdvancedResize( this, sx, sy, sz, sx, sy, sz, 0 )
-	end
-end
-
-__e2setcost(5)
 
 --------------------------------------------------------------------------------
 

--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -355,6 +355,41 @@ e2function string entity:propPhysicalMaterial()
 	return ""
 end
 
+hook.Add( "CanDrive", "checkPropStaticE2", function( ply, ent ) return ent.propStaticE2 == nil end )
+e2function void entity:propStatic( number static )
+	if not PropCore.ValidAction( self, this, "static" ) then return end
+	if static ~= 0 and this.propStaticE2 == nil then
+		local phys = this:GetPhysicsObject()
+		this.propStaticE2 = phys:IsMotionEnabled()
+		this.PhysgunDisabled = true
+		this:SetUnFreezable( true )
+		phys:EnableMotion( false )
+		--phys:Sleep()
+	elseif this.propStaticE2 ~= nil then
+		this.PhysgunDisabled = false
+		this:SetUnFreezable( false )
+		if this.propStaticE2 == true then
+			local phys = this:GetPhysicsObject()
+			phys:Wake()
+			phys:EnableMotion( true )
+		end
+		this.propStaticE2 = nil
+	end
+end
+
+if AdvancedResize then
+	__e2setcost( 30 )
+	e2function void entity:propScale( vector scale )
+		if not PropCore.ValidAction(self, this, "scale") then return end
+		local sx = math.Clamp( scale[1], 0.1, 10 )
+		local sy = math.Clamp( scale[2], 0.1, 10 )
+		local sz = math.Clamp( scale[3], 0.1, 10 )
+		AdvancedResize( this, sx, sy, sz, sx, sy, sz, 0 )
+	end
+end
+
+__e2setcost(5)
+
 --------------------------------------------------------------------------------
 
 e2function void entity:setPos(vector pos)

--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -364,7 +364,6 @@ e2function void entity:propStatic( number static )
 		this.PhysgunDisabled = true
 		this:SetUnFreezable( true )
 		phys:EnableMotion( false )
-		--phys:Sleep()
 	elseif this.propStaticE2 ~= nil then
 		this.PhysgunDisabled = false
 		this:SetUnFreezable( false )


### PR DESCRIPTION
propScale will only be available if this [Prop Resizer tool](https://steamcommunity.com/sharedfiles/filedetails/?id=217376234) is installed on the server.

propStatic is really useful, the prop can't be moved in any way (that I know of), but tools and traces still work on it. Perfect for building houses, for example.