### PR TITLE
CPU/GPU/SPU Clk inputs should act consistently.

### DIFF
--- a/lua/entities/gmod_wire_cpu.lua
+++ b/lua/entities/gmod_wire_cpu.lua
@@ -244,7 +244,7 @@ WireLib.AddInputAlias( "NMI", "Interrupt" )
 
 function ENT:TriggerInput(iname, value)
 	if iname == "Clk" then
-		self.Clk = value
+		self.Clk = (value >= 1 and 1 or 0)
 		if self.Clk >= 1.0 then self:NextThink(CurTime()) end
 	elseif iname == "Frequency" then
 		if (not game.SinglePlayer()) and (value > 1400000) then self.Frequency = 1400000 return end

--- a/lua/entities/gmod_wire_gpu/init.lua
+++ b/lua/entities/gmod_wire_gpu/init.lua
@@ -205,7 +205,7 @@ end
 --------------------------------------------------------------------------------
 function ENT:TriggerInput(iname, value)
   if iname == "Clk" then
-    self.Clk = value
+    self.Clk = (value >= 1 and 1 or 0)
     self:WriteCell(65535,self.Clk)
   elseif iname == "Reset" then
     if value >= 1.0 then self:WriteCell(65534,1) end

--- a/lua/entities/gmod_wire_spu/init.lua
+++ b/lua/entities/gmod_wire_spu/init.lua
@@ -205,7 +205,7 @@ end
 --------------------------------------------------------------------------------
 function ENT:TriggerInput(iname, value)
   if iname == "Clk" then
-    self.Clk = value
+    self.Clk = (value >= 1 and 1 or 0)
     self:WriteCell(65535,self.Clk)
   elseif iname == "Reset" then
     if value >= 1.0 then self:WriteCell(65534,1) end


### PR DESCRIPTION
The various ZASM processors seem to act inconsistently with how their Clk inputs are converted to booleans.

GPUs and SPUs will not run unless the value is equal to 1. On the other hand, CPUs will try to run if it's greater than 0, will update their NextThink time if it's >=1, and the debugger requires it to be equal to 1. CPUs also won't accept external interrupts unless it's >=1.

Since I can't find all the places where the Clk value is used, this patch coerces it to 0 or 1 right at the source, when the wire input is updated.

I chose >=1 for consistency with the Reset inputs. Is there standard convention for boolean inputs to Wiremod devices?
