### PR TITLE
Multiple (HL-)ZASM compiler patches

### DIFF
--- a/lua/wire/client/hlzasm/hc_compiler.lua
+++ b/lua/wire/client/hlzasm/hc_compiler.lua
@@ -222,7 +222,7 @@ function HCOMP:StartCompile(sourceCode,fileName,writeByteCallback,writeByteCalle
   -- Prepare parser
   self.Stage = 1
   self.Tokens = {}
-  self.Code = {{ Text = sourceCode, Line = 1, Col = 1, File = self.FileName }}
+  self.Code = {{ Text = sourceCode, Line = 1, Col = 1, File = self.FileName, NextCharPos = 1 }}
 
   -- Structs
   self.Structs = {}

--- a/lua/wire/client/hlzasm/hc_compiler.lua
+++ b/lua/wire/client/hlzasm/hc_compiler.lua
@@ -179,9 +179,9 @@ function HCOMP:StartCompile(sourceCode,fileName,writeByteCallback,writeByteCalle
   self.FileName = string.sub(fileName,string.find(fileName,"\\$") or 1)
   if string.GetPathFromFilename then
     local filePath = string.GetPathFromFilename(fileName)
-    self.WorkingDir = ".\\"..string.sub(filePath,(string.find(filePath,"Chip") or -4)+5)
+    self.WorkingDir = string.sub(filePath,(string.find(string.lower(filePath),"chip") or -4)+5)
   else
-    self.WorkingDir = ".\\"
+    self.WorkingDir = ""
   end
 
   -- Initialize compiler settings

--- a/lua/wire/client/hlzasm/hc_preprocess.lua
+++ b/lua/wire/client/hlzasm/hc_preprocess.lua
@@ -58,7 +58,7 @@ function HCOMP:ParsePreprocessMacro(lineText,macroPosition)
       local crtFilename = "lib\\"..string.lower(pragmaCommand).."\\init.txt"
       local fileText = self:LoadFile(crtFilename)
       if fileText then
-        table.insert(self.Code, 1, { Text = fileText, Line = 1, Col = 1, File = crtFilename })
+        table.insert(self.Code, 1, { Text = fileText, Line = 1, Col = 1, File = crtFilename, NextCharPos = 1 })
       else
         self:Error("Unable to include CRT library "..pragmaCommand,
           macroPosition.Line,macroPosition.Col,macroPosition.File)
@@ -152,7 +152,7 @@ function HCOMP:ParsePreprocessMacro(lineText,macroPosition)
 
     -- Push this file on top of the stack
     if fileText then
-      table.insert(self.Code, 1, { Text = fileText, Line = 1, Col = 1, File = fileName })
+      table.insert(self.Code, 1, { Text = fileText, Line = 1, Col = 1, File = fileName, NextCharPos = 1 })
     else
       self:Error("Cannot open file: "..fileName,
         macroPosition.Line,macroPosition.Col,macroPosition.File)

--- a/lua/wire/client/hlzasm/hc_tokenizer.lua
+++ b/lua/wire/client/hlzasm/hc_tokenizer.lua
@@ -147,12 +147,16 @@ end
 -- Create lookup table for double-character tokens
 HCOMP.PARSER_DBCHAR = {}
 for symID,symList in pairs(HCOMP.TOKEN_TEXT) do
+  local languages = symList[1]
   local symText = symList[2][1] or ""
   if #symText == 2 then
     local char1 = string.sub(symText,1,1)
     local char2 = string.sub(symText,2,2)
-    HCOMP.PARSER_DBCHAR[char1] = HCOMP.PARSER_DBCHAR[char1] or {}
-    HCOMP.PARSER_DBCHAR[char1][char2] = true
+    for _,lang in pairs(languages) do
+      HCOMP.PARSER_DBCHAR[lang] = HCOMP.PARSER_DBCHAR[lang] or {}
+      HCOMP.PARSER_DBCHAR[lang][char1] = HCOMP.PARSER_DBCHAR[lang][char1] or {}
+      HCOMP.PARSER_DBCHAR[lang][char1][char2] = true
+    end
   end
 end
 
@@ -338,9 +342,9 @@ function HCOMP:Tokenize() local TOKEN = self.TOKEN
     token = self:getChar()
     self:nextChar()
 
-    if HCOMP.PARSER_DBCHAR[token] then
+    if HCOMP.PARSER_DBCHAR[self.Settings.CurrentLanguage][token] then
       local curChar = self:getChar()
-      if HCOMP.PARSER_DBCHAR[token][curChar] then
+      if HCOMP.PARSER_DBCHAR[self.Settings.CurrentLanguage][token][curChar] then
         token = token .. curChar
         self:nextChar()
         if token == "//" then -- Line comment

--- a/lua/wire/client/hlzasm/hc_tokenizer.lua
+++ b/lua/wire/client/hlzasm/hc_tokenizer.lua
@@ -213,7 +213,8 @@ function HCOMP:Tokenize() local TOKEN = self.TOKEN
   -- Skip whitespaces
   while (self:getChar() ==  " ") or
         (self:getChar() == "\t") or
-        (self:getChar() == "\n") do self:nextChar() end
+        (self:getChar() == "\n") or
+		(self:getChar() == "\r") do self:nextChar() end
 
   -- Store this line as previous (FIXME: need this?)
   self.PreviousCodeLine = self.Code[1].Text


### PR DESCRIPTION
* Fixed #include with local paths not working
* Fixed \r not being considered whitespace (don't ask me why GMod doesn't strip \r's when reading files)
* The HL-ZASM tokenizer should limit which symbols it will accept. Previously, any symbol that was the first character of a two-character symbol could be accepted as a one-character symbol - e.g. "+" was accepted because "+=" is a two-character symbol. That behaviour made no sense.
* Fixed the HL-ZASM tokenizer sometimes mistaking symbols for identifiers.
* Fixed the HL-ZASM tokenizer being extremely slow on large source files.