### PR TITLE
Added E2 hostip()

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/serverinfo.lua
+++ b/lua/entities/gmod_wire_expression2/core/serverinfo.lua
@@ -2,6 +2,8 @@
   Server Information
 \******************************************************************************/
 
+__e2setcost(1)
+
 e2function string map()
 	return game.GetMap()
 end
@@ -9,6 +11,17 @@ end
 local hostname = GetConVar("hostname")
 e2function string hostname()
 	return hostname:GetString()
+end
+
+local hostipnum = tonumber(GetConVar("hostip"):GetString())
+local ipstructure = {}
+ipstructure[1] = bit.rshift(bit.band(hostipnum, 0xFF000000), 24)
+ipstructure[2] = bit.rshift(bit.band(hostipnum, 0x00FF0000), 16)
+ipstructure[3] = bit.rshift(bit.band(hostipnum, 0x0000FF00), 8)
+ipstructure[4] = bit.band(hostipnum, 0x000000FF)
+local hostip = table.concat(ipstructure, ".")
+e2function string hostip()
+	return hostip
 end
 
 local sv_lan = GetConVar("sv_lan")

--- a/lua/entities/gmod_wire_expression2/core/serverinfo.lua
+++ b/lua/entities/gmod_wire_expression2/core/serverinfo.lua
@@ -34,7 +34,7 @@ local function httpRequestServerIP()
 		end
 	)
 end
-timer.Simple( 5, httpRequestServerIP ) -- Http sometimes isn't initialized by the time Initialize is called
+hook.Add( "Initialize", "httpRequestServerIP", httpRequestServerIP )
 
 e2function string hostip()
 	return hostip


### PR DESCRIPTION
With the upcoming change that the http extension could be disabled by default, there will no longer be a way to get the server IP, that and having to do a http request to get the server IP is ridiculous, so with this we can get the IPv4 address through a function.