### PR TITLE
Don't accept unmatched string delimiters in HLZASM

### DIFF
--- a/lua/wire/client/hlzasm/hc_tokenizer.lua
+++ b/lua/wire/client/hlzasm/hc_tokenizer.lua
@@ -258,7 +258,7 @@ function HCOMP:Tokenize() local TOKEN = self.TOKEN
     self:nextChar() -- Skip leading character
 
     local fetchString = ""
-    while (self.Code[1].Text ~= "") and (self:getChar() ~= "'") and (self:getChar() ~= "\"") do
+    while self.Code[1].Text ~= "" and self:getChar() ~= stringType do
 
       if self:getChar() == "\\" then
         self:nextChar()
@@ -407,7 +407,7 @@ end
 -- Print a string of tokens as an expression
 function HCOMP:PrintTokens(tokenList)
   local text = ""
-  if !istable(tokenList) then error("[global 1:1] Internal error 516 ("..tokenList..")") end
+  if not istable(tokenList) then error("[global 1:1] Internal error 516 ("..tokenList..")") end
 
   for _,token in ipairs(tokenList) do
     if (token.Type == self.TOKEN.NUMBER) or

--- a/lua/wire/client/hlzasm/hc_tokenizer.lua
+++ b/lua/wire/client/hlzasm/hc_tokenizer.lua
@@ -276,7 +276,7 @@ function HCOMP:Tokenize() local TOKEN = self.TOKEN
         end
         self:nextChar()
       elseif self:getChar() == "\n" then
-        self:Error("Newline in string constant",
+        self:Error("Missing terminating " .. stringType .. " character",
           tokenPosition.Line,tokenPosition.Col,tokenPosition.File)
       else
         fetchString = fetchString .. self:getChar()

--- a/lua/wire/client/texteditor.lua
+++ b/lua/wire/client/texteditor.lua
@@ -701,7 +701,7 @@ end
 
 
 function EDITOR:HasSelection()
-	return self.Caret[1] != self.Start[1] || self.Caret[2] != self.Start[2]
+	return self.Caret[1] ~= self.Start[1] or self.Caret[2] ~= self.Start[2]
 end
 
 function EDITOR:Selection()
@@ -3547,7 +3547,7 @@ do
 		["keyword"]  = { Color(255, 136,   0), false},
 		["memref"]   = { Color(232, 232,   0), false},
 		["pmacro"]   = { Color(136, 136, 255), false},
-
+		["error"]    = { Color(240,  96,  96), false},
 --		["compare"]  = { Color(255, 186,  40), true},
 	}
 
@@ -3635,13 +3635,15 @@ do
 					tokenname = "normal"
 				end
 			elseif (self.character == "'") or (self.character == "\"")  then
+				tokenname = "string"
+				local delimiter = self.character
 				self:NextCharacter()
-				while self.character and (self.character != "'") and (self.character != "\"") do
+				while self.character ~= delimiter do
+					if not self.character then tokenname = "error" break end
 					if self.character == "\\" then self:NextCharacter() end
 					self:NextCharacter()
 				end
 				self:NextCharacter()
-				tokenname = "string"
 			elseif self:NextPattern("^//.*$") then
 				tokenname = "comment"
 			elseif self:NextPattern("^/%*") then -- start of a multi-line comment


### PR DESCRIPTION
Now `"Foo'` isn't a valid string constant, but `"isn't"` is.

Fixes #1011