### PR TITLE
Improve serverside performance

### DIFF
--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -51,11 +51,11 @@ local CurLink = {}
 
 local frametime = FrameTime()
 local cur_time = CurTime()
-local max_overtime = 1/0
+local max_overtime = math.huge
 hook.Add("Think", "WireLib_Think", function()
 	frametime = FrameTime()
 	cur_time = CurTime()
-	max_overtime = cur_time + frametime * 8
+	max_overtime = cur_time + frametime * 5
 end)
 
 -- helper function that pcalls an input

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -47,10 +47,13 @@ local Inputs = {}
 local Outputs = {}
 local CurLink = {}
 
+local frametime = FrameTime()
+local cur_time = CurTime()
+local max_overtime = cur_time + frametime*4
 hook.Add("Think", "WireLib_Think", function()
-	for idx,port in pairs(Outputs) do
-		port.TriggerLimit = 4
-	end
+	frametime = FrameTime()
+	cur_time = CurTime()
+	max_overtime = cur_time + frametime * 4
 end)
 
 -- helper function that pcalls an input
@@ -158,7 +161,7 @@ function WireLib.CreateSpecialOutputs(ent, names, types, descs)
 			Type = tp,
 			Value = WireLib.DT[ tp ].Zero,
 			Connected = {},
-			TriggerLimit = 8,
+			TriggerLimit = 0,
 			Num = n,
 		}
 
@@ -258,7 +261,7 @@ function WireLib.AdjustSpecialOutputs(ent, names, types, descs)
 				Type = types[n] or "NORMAL",
 				Value = WireLib.DT[ (types[n] or "NORMAL") ].Zero,
 				Connected = {},
-				TriggerLimit = 8,
+				TriggerLimit = 0,
 				Num = n,
 			}
 
@@ -506,9 +509,13 @@ function WireLib.TriggerOutput(ent, oname, value, iter)
 
 	local output = ent.Outputs[oname]
 	if (output) and (value ~= output.Value or output.Type == "ARRAY" or output.Type == "TABLE") then
-		if (output.TriggerLimit <= 0) then return end
-		output.TriggerLimit = output.TriggerLimit - 1
 
+		local lastfire = output.TriggerLimit
+		
+		if (lastfire >= max_overtime) then return end
+		
+		output.TriggerLimit = (lastfire < cur_time and cur_time or lastfire) + frametime
+		
 		output.Value = value
 
 		if (iter) then

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -19,6 +19,8 @@ local tostring = tostring
 local Vector = Vector
 local Color = Color
 local Material = Material
+local FrameTime = FrameTime
+local CurTime= CurTime
 
 local HasPorts = WireLib.HasPorts -- Very important for checks!
 
@@ -49,11 +51,11 @@ local CurLink = {}
 
 local frametime = FrameTime()
 local cur_time = CurTime()
-local max_overtime = cur_time + frametime*4
+local max_overtime = 1/0
 hook.Add("Think", "WireLib_Think", function()
 	frametime = FrameTime()
 	cur_time = CurTime()
-	max_overtime = cur_time + frametime * 4
+	max_overtime = cur_time + frametime * 8
 end)
 
 -- helper function that pcalls an input

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -20,7 +20,7 @@ local Vector = Vector
 local Color = Color
 local Material = Material
 local FrameTime = FrameTime
-local CurTime= CurTime
+local CurTime = CurTime
 
 local HasPorts = WireLib.HasPorts -- Very important for checks!
 

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -55,7 +55,7 @@ local max_overtime = math.huge
 hook.Add("Think", "WireLib_Think", function()
 	frametime = FrameTime()
 	cur_time = CurTime()
-	max_overtime = cur_time + frametime * 5
+	max_overtime = cur_time + frametime -- timestamp of one frame into future
 end)
 
 -- helper function that pcalls an input
@@ -514,9 +514,11 @@ function WireLib.TriggerOutput(ent, oname, value, iter)
 
 		local lastfire = output.TriggerLimit
 		
+		-- Do not trigger if we have eaten our slices of the frame (rate limiter)
 		if (lastfire >= max_overtime) then return end
 		
-		output.TriggerLimit = (lastfire < cur_time and cur_time or lastfire) + frametime
+		-- Each trigger eats 1/4 of a frame time, after 4 triggers we are one frametime into future and get rate limited
+		output.TriggerLimit = (lastfire < cur_time and cur_time or lastfire) + frametime * 0.22221 -- around 4.5 per triggers frame (1/4.5 rounded down, 4.5 to allow headroom for float weirdnesses)
 		
 		output.Value = value
 


### PR DESCRIPTION
Do not iterate over a huge array, but make the runtime checking work through time keeping.
Pending proper testing and validation. All I'm worried of is that this makes output firing stricter.

EDIT by TomyLobo:
old PR: https://github.com/wiremod/wire/pull/1021
