### PR TITLE
Added E2 inputClkName()

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/core.lua
+++ b/lua/entities/gmod_wire_expression2/core/core.lua
@@ -291,6 +291,10 @@ e2function number inputClk()
 	return self.triggerinput and 1 or 0
 end
 
+e2function string inputClkName()
+	return self.triggerinput or ""
+end
+
 -- This MUST be the first destruct hook!
 registerCallback("destruct", function(self)
 	local entity = self.entity


### PR DESCRIPTION
For the moment being I don't see a way to get the name of the input that caused the e2 to update, so by adding this it'll make it so you don't have to have elseif chains to get what input caused the update.

If you have a better name go ahead and say it as this is just following what the other similar functions are called such as clkName and dsClkName.