### PR TITLE
Add UUID functions

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/serverinfo.lua
+++ b/lua/entities/gmod_wire_expression2/core/serverinfo.lua
@@ -20,6 +20,10 @@ e2function string gamemode()
 	return gmod.GetGamemode().Name
 end
 
+e2function string serverUUID()
+	return WireLib.GetServerUUID()
+end
+
 e2function number isSinglePlayer()
 	return game.SinglePlayer() and 1 or 0
 end


### PR DESCRIPTION
Fixes #1013.

* `WireLib.GenerateUUID()` generates a new UUID
* `WireLib.GetServerUUID()` returns a persistent UUID associated with the server
* `e2function string serverUUID()` does the same as above