### PR TITLE
Removed ragequit/ctrl-w binding

### DIFF
--- a/lua/wire/client/texteditor.lua
+++ b/lua/wire/client/texteditor.lua
@@ -1840,8 +1840,6 @@ function EDITOR:_OnKeyCodeTyped(code)
 			self:GetParent():Close()
 		elseif code == KEY_T then
 			self:GetParent():NewTab()
-		elseif code == KEY_W then
-			self:GetParent():CloseTab()
 		elseif code == KEY_PAGEUP then
 			local parent = self:GetParent()
 


### PR DESCRIPTION
When you press ctrl-w instead of ctrl-s....
Why is there even a binding which closes an unsaved file without asking. why