### PR TITLE
Bugfix: Fixed 7 font limit

### DIFF
--- a/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
+++ b/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
@@ -1561,7 +1561,7 @@ VM.OpcodeTable[216] = function(self)  --DTEXTURE
   self:Dyn_Emit("VM.Texture = $1")
 end
 VM.OpcodeTable[217] = function(self)  --DSETFONT
-  self:Dyn_Emit("VM.Font = math.Clamp(math.floor($1),0,7)")
+  self:Dyn_Emit("VM.Font = math.Clamp(math.floor($1),0,#VM.FontName)")
   end
 VM.OpcodeTable[218] = function(self)  --DSETSIZE
   self:Dyn_Emit("VM.FontSize = math.floor(math.max(4,math.min($1,200)))")


### PR DESCRIPTION
For some reason the font index was being clamped to a constant value of 7, preventing the use of the 8th and 9th font.
Fixed this by clamping to font index to the number of fonts in the table, thus enabling all 9 current fonts and facilitating the easy addition of new fonts.