### PR TITLE
Unified font system

### DIFF
--- a/lua/entities/gmod_wire_egp/lib/egplib/materials.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/materials.lua
@@ -19,24 +19,9 @@ EGP.ValidFonts[10] = "Roboto"
 EGP.ValidFonts[11] = "csd"
 
 if (CLIENT) then
-	local new = {}
+	
 	for k,v in ipairs( EGP.ValidFonts ) do
-		local font = "WireEGP_18_"..k
-		local fontTable =
-		{
-			font=v,
-			size = 18,
-			weight = 800,
-			antialias = true,
-			additive = false
-		}
-		surface.CreateFont( font, fontTable )
-		
-		EGP.ValidFonts_Lookup[font] = true
-		table.insert( new, font )
-	end
-	for k,v in ipairs( new ) do
-		table.insert( EGP.ValidFonts, v )
+		local font = WireLib.LoadFont( v, 18 )
 	end
 
 	local type = type

--- a/lua/entities/gmod_wire_egp/lib/egplib/materials.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/materials.lua
@@ -4,19 +4,19 @@
 local EGP = EGP
 
 -- Valid fonts table
-EGP.ValidFonts_Lookup = {}
 EGP.ValidFonts = {}
-EGP.ValidFonts[1] = "WireGPU_ConsoleFont"
-EGP.ValidFonts[2] = "Coolvetica"
+EGP.ValidFonts[0] = "Lucida Console"
+EGP.ValidFonts[1] = "Courier New"
+EGP.ValidFonts[2] = "Trebuchet"
 EGP.ValidFonts[3] = "Arial"
-EGP.ValidFonts[4] = "Lucida Console"
-EGP.ValidFonts[5] = "Trebuchet"
-EGP.ValidFonts[6] = "Courier New"
-EGP.ValidFonts[7] = "Times New Roman"
-EGP.ValidFonts[8] = "ChatFont"
+EGP.ValidFonts[4] = "Times New Roman"
+EGP.ValidFonts[5] = "Coolvetica"
+EGP.ValidFonts[6] = "Akbar"
+EGP.ValidFonts[7] = "csd"
+EGP.ValidFonts[8] = "Roboto"
 EGP.ValidFonts[9] = "Marlett"
-EGP.ValidFonts[10] = "Roboto"
-EGP.ValidFonts[11] = "csd"
+EGP.ValidFonts[10] = "ChatFont"
+EGP.ValidFonts[11] = "WireGPU_ConsoleFont"
 
 if (CLIENT) then
 	

--- a/lua/entities/gmod_wire_egp/lib/egplib/materials.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/materials.lua
@@ -16,6 +16,8 @@ EGP.ValidFonts[7] = "Times New Roman"
 EGP.ValidFonts[8] = "ChatFont"
 EGP.ValidFonts[9] = "Marlett"
 EGP.ValidFonts[10] = "Roboto"
+EGP.ValidFonts[11] = "csd"
+
 if (CLIENT) then
 	local new = {}
 	for k,v in ipairs( EGP.ValidFonts ) do

--- a/lua/entities/gmod_wire_egp/lib/egplib/objectcontrol.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/objectcontrol.lua
@@ -170,7 +170,7 @@ if CLIENT then mat = Material else mat = function( str ) return str end end
 -- Create table
 local tbl = {
 	{ ID = EGP.Objects.Names["Box"], Settings = { x = 256, y = 256, h = 356, w = 356, material = mat("expression 2/cog"), r = 150, g = 34, b = 34, a = 255 } },
-	{ ID = EGP.Objects.Names["Text"], Settings = {x = 256, y = 256, text = "EGP 3", fontid = 1, valign = 1, halign = 1, size = 50, r = 135, g = 135, b = 135, a = 255 } }
+	{ ID = EGP.Objects.Names["Text"], Settings = {x = 256, y = 256, text = "EGP 3", fontid = 11, valign = 1, halign = 1, size = 50, r = 135, g = 135, b = 135, a = 255 } }
 }
 
 --[[ Old homescreen (EGP v2 home screen design contest winner)

--- a/lua/entities/gmod_wire_egp/lib/objects/text.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/text.lua
@@ -45,20 +45,7 @@ Obj.Draw = function( self )
 		surface_SetTextColor( self.r, self.g, self.b, self.a )
 
 		if (!EGP.ValidFonts[self.fontid]) then self.fontid = 1 end
-		local font = "WireEGP_" .. self.size .. "_" .. self.fontid
-		if (!EGP.ValidFonts_Lookup[font]) then
-			local fontTable =
-			{
-				font=EGP.ValidFonts[self.fontid],
-				size = self.size,
-				weight = 800,
-				antialias = true,
-				additive = false
-			}
-			surface_CreateFont( font, fontTable )
-			EGP.ValidFonts[#EGP.ValidFonts+1]= font
-			EGP.ValidFonts_Lookup[font] = true
-		end
+		local font = WireLib.LoadFont(EGP.ValidFonts[self.fontid], self.size)
 		surface_SetFont( font )
 
 		if self.angle == 0 then

--- a/lua/entities/gmod_wire_egp/lib/objects/textlayout.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/textlayout.lua
@@ -24,20 +24,7 @@ Obj.Draw = function( self )
 		surface.SetTextColor( self.r, self.g, self.b, self.a )
 
 		if (!EGP.ValidFonts[self.fontid]) then self.fontid = 1 end
-		local font = "WireEGP_" .. self.size .. "_" .. self.fontid
-		if (!EGP.ValidFonts_Lookup[font]) then
-			local fontTable =
-			{
-				font=EGP.ValidFonts[self.fontid],
-				size = self.size,
-				weight = 800,
-				antialias = true,
-				additive = false
-			}
-			surface.CreateFont( font, fontTable )
-			table.insert( EGP.ValidFonts, font )
-			EGP.ValidFonts_Lookup[font] = true
-		end
+		local font = WireLib.LoadFont(EGP.ValidFonts[self.fontid], self.size)
 		surface.SetFont( font )
 
 		--if (!self.layouter) then self.layouter = EGP:MakeTextLayouter() end -- Trying to make my own layouter...

--- a/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
+++ b/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
@@ -1556,7 +1556,7 @@ VM.OpcodeTable[216] = function(self)  --DTEXTURE
   self:Dyn_Emit("VM.Texture = $1")
 end
 VM.OpcodeTable[217] = function(self)  --DSETFONT
-  self:Dyn_Emit("VM.Font = math.Clamp(math.floor($1),0,7)")
+  self:Dyn_Emit("VM.Font = math.Clamp(math.floor($1),0,#VM.FontName)")
   end
 VM.OpcodeTable[218] = function(self)  --DSETSIZE
   self:Dyn_Emit("VM.FontSize = math.floor(math.max(4,math.min($1,200)))")

--- a/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
+++ b/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
@@ -182,10 +182,10 @@ function ENT:OverrideVM()
   self.VM.FontName[5] = "Coolvetica"
   self.VM.FontName[6] = "Akbar"
   self.VM.FontName[7] = "csd"
-  self.VM.FontName[8] = "WireGPU_ConsoleFont"
-  self.VM.FontName[9] = "ChatFont"
-  self.VM.FontName[10] = "Marlett"
-  self.VM.FontName[11] = "Roboto"
+  self.VM.FontName[8] = "Roboto"
+  self.VM.FontName[9] = "Marlett"
+  self.VM.FontName[10] = "ChatFont"
+  self.VM.FontName[11] = "WireGPU_ConsoleFont"
 
   -- Add text layouter
   self.VM.Layouter = MakeTextScreenLayouter()

--- a/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
+++ b/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
@@ -182,6 +182,10 @@ function ENT:OverrideVM()
   self.VM.FontName[5] = "Coolvetica"
   self.VM.FontName[6] = "Akbar"
   self.VM.FontName[7] = "csd"
+  self.VM.FontName[8] = "WireGPU_ConsoleFont"
+  self.VM.FontName[9] = "ChatFont"
+  self.VM.FontName[10] = "Marlett"
+  self.VM.FontName[11] = "Roboto"
 
   -- Add text layouter
   self.VM.Layouter = MakeTextScreenLayouter()
@@ -193,23 +197,14 @@ end
 --------------------------------------------------------------------------------
 -- Switches to a font, creating it if it does not exist
 --------------------------------------------------------------------------------
-local fontcache = {}
 function VM:SetFont()
-	local name, size = self.FontName[self.Font], self.FontSize
-	if not fontcache[name] or not fontcache[name][size] then
-		if not fontcache[name] then fontcache[name] = {} end
-		
-		surface.CreateFont("WireGPU_"..name..size, {
-			font = name,
-			size = size,
-			weight = 800,
-			antialias = true,
-			additive = false,
-		})
-		fontcache[name][size] = true
-	end
+	local name = self.FontName[self.Font]
+	local size = self.FontSize
+	local fontKey = WireLib.LoadFont(name, size)
 	
-	surface.SetFont("WireGPU_"..name..size)
+	if fontKey then
+		surface.SetFont(fontKey)
+	end
 end
 
 

--- a/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
+++ b/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
@@ -883,7 +883,7 @@ function VM:FontWrite(posaddr,text)
       self.Layouter:DrawText(tostring(text), vertex.x, vertex.y, self.TextBox.x,
                        self.TextBox.y, self.Memory[65473], self.Memory[65471])
     else
-      draw.DrawText(text,"WireGPU_"..self.FontName[self.Font]..self.FontSize,
+      draw.DrawText(text, WireLib.LoadFont(self.FontName[self.Font], self.FontSize),
               vertex.x,vertex.y,Color(self.Color.x,self.Color.y,self.Color.z,self.Color.w),
               self.Memory[65473])
     end

--- a/lua/wire/wireshared.lua
+++ b/lua/wire/wireshared.lua
@@ -999,3 +999,71 @@ function nicenumber.nicetime( n )
 		return "0s"
 	end
 end
+
+------------------------------------------------------
+-- Loads a font into the cache if it doesn't exist
+-- Returns true if font exists, else returns false
+------------------------------------------------------
+local _fontcache = {}
+local _defaultFontSize = 18
+
+function WireLib.LoadFont( name, size )
+	if not name then return false end
+	
+	local fontSize = size or _defaultFontSize
+	local fontKey = name .. "_" .. fontSize
+	
+	-- Shortcircuit if font has already loaded
+	if _fontcache[fontKey] ~= nil then
+		return true
+	end
+	
+	-- If font isn't in cache, create it
+	local fontTable =
+	{
+		font = name,
+		size = fontSize,
+		weight = 800,
+		antialias = true,
+		additive = false,
+	}
+	
+	-- Font may or may not load, but assume it did
+	surface.CreateFont(fontKey, fontTable)
+	fontcache[fontKey] = true
+	
+	return true
+end
+
+-- Bypass the cache
+function WireLib.ReloadFont( name, size )
+	if not name then return false end
+	
+	local fontSize = size or _defaultFontSize
+	local fontKey = name .. "_" .. fontSize
+	
+	local fontTable =
+	{
+		font = name,
+		size = fontSize,
+		weight = 800,
+		antialias = true,
+		additive = false,
+	}
+	
+	-- Font may or may not load, but assume it did
+	surface.CreateFont(fontKey, fontTable)
+	fontcache[fontKey] = true
+	
+	return true
+end
+
+function WireLib.FontExists( name, size )
+	if not name then return false end
+	return _fontcache[name .. "_" .. (size or _defaultFontSize)] ~= nil
+end
+
+function WireLib.SetFont( name, size )
+	if not name then return false end
+	surface.SetFont(name .. "_" .. (size or _defaultFontSize))	
+end

--- a/lua/wire/wireshared.lua
+++ b/lua/wire/wireshared.lua
@@ -1008,14 +1008,14 @@ local _fontcache = {}
 local _defaultFontSize = 18
 
 function WireLib.LoadFont( name, size )
-	if not name then return false end
+	if not name then return nil end
 	
 	local fontSize = size or _defaultFontSize
 	local fontKey = name .. "_" .. fontSize
 	
 	-- Shortcircuit if font has already loaded
 	if _fontcache[fontKey] ~= nil then
-		return true
+		return fontKey
 	end
 	
 	-- If font isn't in cache, create it
@@ -1032,7 +1032,7 @@ function WireLib.LoadFont( name, size )
 	surface.CreateFont(fontKey, fontTable)
 	fontcache[fontKey] = true
 	
-	return true
+	return fontKey
 end
 
 -- Bypass the cache
@@ -1055,7 +1055,7 @@ function WireLib.ReloadFont( name, size )
 	surface.CreateFont(fontKey, fontTable)
 	fontcache[fontKey] = true
 	
-	return true
+	return fontKey
 end
 
 function WireLib.FontExists( name, size )

--- a/lua/wire/wireshared.lua
+++ b/lua/wire/wireshared.lua
@@ -1030,7 +1030,7 @@ function WireLib.LoadFont( name, size )
 	
 	-- Font may or may not load, but assume it did
 	surface.CreateFont(fontKey, fontTable)
-	fontcache[fontKey] = true
+	_fontcache[fontKey] = true
 	
 	return fontKey
 end
@@ -1053,7 +1053,7 @@ function WireLib.ReloadFont( name, size )
 	
 	-- Font may or may not load, but assume it did
 	surface.CreateFont(fontKey, fontTable)
-	fontcache[fontKey] = true
+	_fontcache[fontKey] = true
 	
 	return fontKey
 end


### PR DESCRIPTION
I have gone through and edited various files in order to create a more unified font system between the EGP and the GPU.

Both the EGP and the GPU are able to use the same fonts and have had their source altered so that their font ordering matches. They still exist as separate lists however as I was unsure of the best way to fully merge them.

I made the font loading API part of the `WireLib` API since the cache technically belongs to the mod and I was unsure if creating a separate table for the font functions was a good idea or not.

I have tested both the EGP and the GPU and both seem to be in working order. The transition appears seamless. Despite this I would appreciate if others tested the code before confirming the pull just in case I missed anything. My tests were only for light use, I did not attempt any major stress tests.

(This took longer than expected because I thought I was having an issue with the EGP not drawing to the screen. Turned out I forgot to hook up the correct input for the program I was using to test so I wasted about 4-6 hours trying to debug a nonexistant problem. Oops.)