### PR TITLE
Fix steamFriends

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -381,7 +381,7 @@ local steamfriends = {}
 concommand.Add("wire_expression2_friend_status", function(ply, command, args)
 	local friends = {}
 
-	for index in args[1]:gmatch("[^,]") do
+	for index in args[1]:gmatch("[^,]+") do
 		local n = tonumber(index)
 		if not n then return end
 		table.insert(friends, Entity(index))
@@ -390,7 +390,7 @@ concommand.Add("wire_expression2_friend_status", function(ply, command, args)
 	steamfriends[ply:EntIndex()] = friends
 end)
 
-hook.Add("EntityRemoved", "wire_expression2_friend_status", function(ply)
+hook.Add("PlayerDisconnected", "wire_expression2_friend_status", function(ply)
 	steamfriends[ply:EntIndex()] = nil
 end)
 

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -384,7 +384,7 @@ concommand.Add("wire_expression2_friend_status", function(ply, command, args)
 	for index in args[1]:gmatch("[^,]+") do
 		local n = tonumber(index)
 		if not n then return end
-		table.insert(friends, Entity(index))
+		table.insert(friends, Entity(n))
 	end
 
 	steamfriends[ply:EntIndex()] = friends

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -390,7 +390,7 @@ concommand.Add("wire_expression2_friend_status", function(ply, command, args)
 	steamfriends[ply:EntIndex()] = friends
 end)
 
-hook.Add("PlayerDisconnected", "wire_expression2_friend_status", function(ply)
+hook.Add("EntityRemoved", "wire_expression2_friend_status", function(ply)
 	steamfriends[ply:EntIndex()] = nil
 end)
 


### PR DESCRIPTION
Should fix #905 as the match was using the wrong pattern. Also changed remove hook so it doesn't attempt to remove friends for every entity deleted.

Can't test this as I don't have a server to test on.