### PR TITLE
HL-ZASM: Fixes

### DIFF
--- a/lua/wire/client/hlzasm/hc_expression.lua
+++ b/lua/wire/client/hlzasm/hc_expression.lua
@@ -786,14 +786,14 @@ function HCOMP:ConstantExpression_Level1()
     if not rightConst then return false end
 
     if token == self.TOKEN.LAND then
-      if (leftValue > 0) and (rightValeu > 0) then
+      if (leftValue > 0) and (rightValue > 0) then
         return true,(leftPrecise and rightPrecise),1
       else
         return true,(leftPrecise and rightPrecise),0
       end
     end
     if token == self.TOKEN.LOR  then
-      if (leftValue > 0) or (rightValeu > 0) then
+      if (leftValue > 0) or (rightValue > 0) then
         return true,(leftPrecise and rightPrecise),1
       else
         return true,(leftPrecise and rightPrecise),0

--- a/lua/wire/client/hlzasm/hc_output.lua
+++ b/lua/wire/client/hlzasm/hc_output.lua
@@ -143,7 +143,6 @@ function HCOMP:OutputLibrary(block)
     for index,value in ipairs(block.Data) do
       if istable(value)then -- Data is a constant expression
         block.Data[index] = self:PrintTokens(value)
-        block.Data[index] = v or self.Settings.MagicValue
       end
     end
   end

--- a/lua/wire/client/hlzasm/hc_syntax.lua
+++ b/lua/wire/client/hlzasm/hc_syntax.lua
@@ -446,7 +446,6 @@ end
 function HCOMP:DefineVariable(isFunctionParam,isForwardDecl,isRegisterDecl,isStructMember) local TOKEN = self.TOKEN
   local varType,varSize,isStruct
   if self:MatchToken(TOKEN.IDENT) then -- Define structure
-    local structData = self.Structs[structName]
     varType = self.TokenData
     varSize = 0 -- Depends on pointer level
     isStruct = true
@@ -1125,7 +1124,7 @@ function HCOMP:Statement() local TOKEN = self.TOKEN
       self:AddLeafToTail(returnLeaf)
     end
     self:MatchToken(TOKEN.COLON)
-    
+
     -- Check if this is the last return in the function
 --    if self:MatchToken(TOKEN.RBRACKET) then
 --      if self.BlockDepth > 0 then


### PR DESCRIPTION
Fixes the lua error when having 2 constants in an expression with a && operator.
```C
define A, 9 && 2;
```
Also removed some useless code