### PR TITLE
Fix incorrect activation on cam controller duplication

### DIFF
--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -392,6 +392,10 @@ local function EntityLookup(CreatedEntities)
 	end
 end
 
+function ENT:OnDuplicated()
+	self.DuplicationInProgress = true
+end
+
 function ENT:PostEntityPaste(Player,Ent,CreatedEntities)
 	-- We manually apply the entity mod here rather than using a
 	-- duplicator.RegisterEntityModifier because we need access to the
@@ -399,4 +403,5 @@ function ENT:PostEntityPaste(Player,Ent,CreatedEntities)
 	if Ent.EntityMods and Ent.EntityMods.WireDupeInfo then
 		Ent:ApplyDupeInfo(Player, Ent, Ent.EntityMods.WireDupeInfo, EntityLookup(CreatedEntities))
 	end
+	self.DuplicationInProgress = nil
 end

--- a/lua/entities/gmod_wire_cameracontroller.lua
+++ b/lua/entities/gmod_wire_cameracontroller.lua
@@ -617,6 +617,10 @@ end
 --------------------------------------------------
 
 function ENT:EnableCam( ply )
+	-- if we're in the middle of being pasted, then there may be linked vehicles
+	-- that we don't know about yet so we just ignore the call. See wiremod/wire#1062
+	if self.DuplicationInProgress then return end
+
 	if #self.Vehicles == 0 and not ply then -- if the cam controller isn't linked, it controls the owner's view
 		ply = self:GetPlayer()
 	end


### PR DESCRIPTION
Fixes #1062.

When a cam controller is linked to a vehicle, the 'Activated' input can be set to 1, and the cam controller will affect any players that enter the vehicle. If the contraption is duplicated and pasted, however, the player's view will be immediately controlled - this is because `ENT:ApplyDupeInfo` hasn't yet been called as that only happens when the entire contraption has finished pasting, and so the cam controller doesn't know that it's linked to any vehicles.

As as workaround, the cam controller now ignores calls to `ENT:EnableCam` that happen after `ENT:OnDuplicated` and before `ENT:PostEntityPaste`. This works in the stock duplicator and AdvDupe2. (For advdupe, see wiremod/advduplicator#69).