### PR TITLE
Fix fileWrite and fileAppend

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/files.lua
+++ b/lua/entities/gmod_wire_expression2/core/files.lua
@@ -83,7 +83,7 @@ end
 
 local function file_Download( ply, filename, data, append )
 	if !file_canDownload( ply ) or !IsValid( ply ) or !ply:IsPlayer() or string.Right( filename, 4 ) != ".txt" then return false end
-	if string.len( data ) > (cv_max_transfer_size:GetInt() * 1024) then return false end
+	if data == "" or string.len( data ) > (cv_max_transfer_size:GetInt() * 1024) then return false end
 
 	downloads[ply] = {
 		name = filename,


### PR DESCRIPTION
Fixes #1068 

When using a zero length string the finish net message isn't sent, to fix this lets just not write or append the file at all.