### PR TITLE
Add mode-neutral syntax colors to the text editor

### DIFF
--- a/lua/wire/client/text_editor/modes/e2.lua
+++ b/lua/wire/client/text_editor/modes/e2.lua
@@ -57,7 +57,6 @@ local colors = {
   ["typename"]  = { Color(240, 160,  96), false}, -- orange
   ["constant"]  = { Color(240, 160, 240), false}, -- pink
   ["userfunction"] = { Color(102, 122, 102), false}, -- dark grayish-green
-  ["dblclickhighlight"] = { Color(0, 100, 0), false}, -- dark green
 }
 
 function EDITOR:GetSyntaxColor(name)

--- a/lua/wire/client/text_editor/texteditor.lua
+++ b/lua/wire/client/text_editor/texteditor.lua
@@ -76,6 +76,10 @@ function EDITOR:Init()
 	self.LastClick = 0
 
 	self.e2fs_functions = {}
+
+	self.Colors = {
+		dblclickhighlight = Color(0, 100, 0),
+	}
 end
 
 function EDITOR:SetMode(mode_name)
@@ -2824,6 +2828,10 @@ function EDITOR:NextPattern(pattern)
 	return true
 end
 
+function EDITOR:GetSyntaxColor(name)
+	return self.Colors[name] or self:DoAction("GetSyntaxColor", name)
+end
+
 function EDITOR:SetSyntaxColors(colors)
 	for name, color in pairs(colors) do
 		self:SetSyntaxColor(name, color)
@@ -2831,7 +2839,11 @@ function EDITOR:SetSyntaxColors(colors)
 end
 
 function EDITOR:SetSyntaxColor(name, color)
-	return self:DoAction("SetSyntaxColor", name, color)
+	if self.Colors[name] then
+		self.Colors[name] = color
+	else
+		return self:DoAction("SetSyntaxColor", name, color)
+	end
 end
 
 function EDITOR:SyntaxColorLine(row)


### PR DESCRIPTION
Fixes #1072