### PR TITLE
Digital screen fix

### DIFF
--- a/lua/entities/gmod_wire_digitalscreen/init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/init.lua
@@ -231,9 +231,13 @@ function ENT:WriteCell(Address, value)
 			end
 			self.Memory = mem
 			-- clear pixel data from usermessage queue
-			while #self.ChangedCellRanges > 0 and
-				  self.ChangedCellRanges[1].start + self.ChangedCellRanges[1].length < 1048500 do
-				table.remove(self.ChangedCellRanges, 1)
+			local i = 1
+			while self.ChangedCellRanges[i] ~= nil do
+				if self.ChangedCellRanges[i].start + self.ChangedCellRanges[i].length < 1048500 then
+					table.remove(self.ChangedCellRanges, i)
+				else
+					i = i + 1
+				end
 			end
 		elseif Address == 1048575 then -- CLK
 			-- not needed atm


### PR DESCRIPTION
Fixed the following error:

    [ERROR] addons/wire/lua/entities/gmod_wire_digitalscreen/init.lua:80: attempt to perform arithmetic on local 'number' (a nil value)
      1. numberToString - addons/wire/lua/entities/gmod_wire_digitalscreen/init.lua:80
       2. buildData - addons/wire/lua/entities/gmod_wire_digitalscreen/init.lua:122
        3. FlushCache - addons/wire/lua/entities/gmod_wire_digitalscreen/init.lua:143
         4. unknown - addons/wire/lua/entities/gmod_wire_digitalscreen/init.lua:255

It was occurring when the screen was cleared (hardware clear screen) more often than its `Think` calling `FlushCache` was called (200ms) due to the control address stacking up first in the `ChangedCellRanges` array and causing the original loop to break.