### PR TITLE
Remove e2sim-specific stuff

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/extloader.lua
+++ b/lua/entities/gmod_wire_expression2/core/extloader.lua
@@ -64,7 +64,12 @@ local function luaExists(luaname)
 	return #file.Find(luaname, "LUA") ~= 0
 end
 
-local included_files = {}
+local included_files
+
+local function e2_include_init()
+	e2_extpp_init()
+	included_files = {}
+end
 
 -- parses typename/typeid associations from a file and stores info about the file for later use by e2_include_finalize/e2_include_pass2
 local function e2_include(name)
@@ -122,6 +127,8 @@ local function e2_include_finalize()
 end
 
 -- end preprocessor stuff
+
+e2_include_init()
 
 e2_include("core.lua")
 e2_include("array.lua")

--- a/lua/entities/gmod_wire_expression2/core/extpp.lua
+++ b/lua/entities/gmod_wire_expression2/core/extpp.lua
@@ -409,13 +409,3 @@ function e2_extpp_pass2(contents)
 		return false
 	end
 end
-
-if e2_sim then
-	function e2_extpp(contents)
-		e2_extpp_init()
-		e2_extpp_pass1(contents)
-		local ret = e2_extpp_pass2(contents)
-		preparsed_types = nil
-		return ret
-	end
-end

--- a/lua/entities/gmod_wire_expression2/core/extpp.lua
+++ b/lua/entities/gmod_wire_expression2/core/extpp.lua
@@ -48,8 +48,14 @@ local optable = {
 	["operator_bshr"] = "bshr",
 }
 
--- This is an array for types that were parsed from all E2 extensions. We initialize it with an alias "number" for "normal".
-local preparsed_types = { ["NUMBER"] = "n" }
+-- This is an array for types that were parsed from all E2 extensions.
+local preparsed_types
+
+-- This function initialized extpp's dynamic fields
+function e2_extpp_init()
+	-- We initialize the array of preparsed types  with an alias "number" for "normal".
+	preparsed_types = { ["NUMBER"] = "n" }
+end
 
 -- This function checks whether its argument is a valid type id.
 local function is_valid_typeid(typeid)
@@ -406,7 +412,7 @@ end
 
 if e2_sim then
 	function e2_extpp(contents)
-		preparsed_types = { ["NUMBER"] = "n" }
+		e2_extpp_init()
 		e2_extpp_pass1(contents)
 		local ret = e2_extpp_pass2(contents)
 		preparsed_types = nil


### PR DESCRIPTION
I have no idea what e2sim is, but it doesn't belong in here.

I think I made sure that this function can be implemented outside extpp.lua, so e2sim can be adjusted to work now... whoever maintains it.

Note that this is entirely untested, so please don't just merge it without reviewing it.