### PR TITLE
Make foreach operator pass typechecking

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -696,7 +696,21 @@ function Compiler:InstrFEA(args)
 
 	local op = self:GetOperator(args, "fea", { tabletp })
 	self:PushScope()
-	self:SetLocalVariableType(keyvar, op[2], args)
+
+	-- The type of the keys iterated over depends on what's being iterated over (ie. tabletp).
+	-- The 'table' returned by tableexpr can be a table, an array, a gtable, or others in future.
+	-- If the type has an indexing operator that takes strings, then we iterate over strings,
+	-- otherwise we iterator over numbers.
+	local keytype
+	if self:HasOperator(args, "idx", { valtype, "=", tabletp, "s" }) then
+		keytype = "s"
+	elseif self:HasOperator(args, "idx", { valtype, "=", tabletp, "n" }) then
+		keytype = "n"
+	else
+		self:Error("Table expression (of type '" .. tabletp .. "') has no indexing operator", args)
+	end
+
+	self:SetLocalVariableType(keyvar, keytype, args)
 	self:SetLocalVariableType(valvar, valtype, args)
 
 	local stmt, _ = self:EvaluateStatement(args, 5)

--- a/lua/entities/gmod_wire_expression2/core/core.lua
+++ b/lua/entities/gmod_wire_expression2/core/core.lua
@@ -108,7 +108,7 @@ registerOperator("for", "", "", function(self, args)
 
 end)
 
-registerOperator("fea","r","n",function(self,args)
+registerOperator("fea","r","",function(self,args)
 	local keyname,valname,valtypeid = args[2],args[3],args[4]
 	local tbl = args[5]
 	tbl = tbl[1](self,tbl)

--- a/lua/entities/gmod_wire_expression2/core/globalvars.lua
+++ b/lua/entities/gmod_wire_expression2/core/globalvars.lua
@@ -51,7 +51,7 @@ registerOperator("ass", "xgt", "xgt", function(self, args)
 	return rhs
 end)
 
-registerOperator("fea","xgt","s",function(self,args)
+registerOperator("fea","xgt","",function(self,args)
 	local keyname,valname,valtypeid = args[2],args[3],args[4]
 	local tbl = args[5]
 	tbl = tbl[1](self,tbl)

--- a/lua/entities/gmod_wire_expression2/core/table.lua
+++ b/lua/entities/gmod_wire_expression2/core/table.lua
@@ -284,7 +284,7 @@ end
 
 __e2setcost(nil)
 
-registerOperator("fea","t","s",function(self,args)
+registerOperator("fea","t","",function(self,args)
 	local keyname,valname,valtypeid = args[2],args[3],args[4]
 	local tbl = args[5]
 	tbl = tbl[1](self,tbl)


### PR DESCRIPTION
Previously, any code that used a `foreach` would fail when `wire_expression2_debug 1` was set.

Now, the following works:

```PHP
Array = array("hello", "world", "it's me")
foreach (Key, Value:string = Array) { print(Key, Value) }

Table = table()
Table["hello", string] = "world"
Table["it's", string] = "me"
Table[1, string] = "numerical indices aren't enumerated"
foreach (Key, Value:string = Table) {
    print(Key, Value)
}
```

Fixes #1081.