### PR TITLE
Compensate bullet position lag.

### DIFF
--- a/lua/entities/gmod_wire_turret.lua
+++ b/lua/entities/gmod_wire_turret.lua
@@ -39,7 +39,7 @@ function ENT:FireShot()
 	local Attachment = self:GetAttachment( 1 )
 
 	-- Get the shot angles and stuff.
-	local shootOrigin = Attachment.Pos
+	local shootOrigin = Attachment.Pos + self:GetVelocity() * engine.TickInterval() 
 	local shootAngles = self:GetAngles()
 
 	-- Shoot a bullet


### PR DESCRIPTION
Seems like the bullet trace doesn't happen until after a physics iteration so the bullet tends to lag behind and hit whatever the turret is attached to if the object has velocity. I tested this by pointing the turret in a slit between two props, gave them motion, and then monitored them with a damage detector and the bullet was able to pass through without hitting them. I'll test it some more tomorrow.