### PR TITLE
Add E2 hostip()

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/serverinfo.lua
+++ b/lua/entities/gmod_wire_expression2/core/serverinfo.lua
@@ -2,6 +2,8 @@
   Server Information
 \******************************************************************************/
 
+__e2setcost(1)
+
 e2function string map()
 	return game.GetMap()
 end
@@ -9,6 +11,10 @@ end
 local hostname = GetConVar("hostname")
 e2function string hostname()
 	return hostname:GetString()
+end
+
+e2function string hostip()
+	return game.GetIPAddress()
 end
 
 local sv_lan = GetConVar("sv_lan")

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -851,6 +851,7 @@ E2Helper.Descriptions["convertUnit(ssn)"] = "Converts between two units"
 -- Server information
 E2Helper.Descriptions["map()"] = "Returns the current map name"
 E2Helper.Descriptions["hostname()"] = "Returns the Name of the server"
+E2Helper.Descriptions["hostip()"] = "Returns the IP of the server"
 E2Helper.Descriptions["isLan()"] = "Returns 1 if lan mode is enabled"
 E2Helper.Descriptions["gamemode()"] = "Returns the name of the current gamemode"
 E2Helper.Descriptions["gravity()"] = "Returns gravity"


### PR DESCRIPTION
Last talked about here #1010, though the method to get the IP was possibly unreliable and overly complicated. Now that the game has a function to get the server IP itself we have no reason not to add this.

It returns a string with the IP and port in this format: "x.x.x.x:x"