### PR TITLE
Check model validity wherever we set models

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -69,7 +69,7 @@ function PropCore.CreateProp(self,model,pos,angles,freeze,isVehicle)
 		if model == "" then model = "models/nova/airboat_seat.mdl" end
 	end
 
-	if not util.IsValidModel( model ) or not util.IsValidProp( model ) then return nil end
+	if not util.IsValidProp( model ) or not WireLib.CanModel(self.player, model) then return nil end
 
 	pos = E2Lib.clampPos( pos )
 

--- a/lua/entities/gmod_wire_expression2/core/hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/hologram.lua
@@ -492,6 +492,7 @@ local function CreateHolo(self, index, pos, scale, ang, color, model)
 	if not ang   then ang   = self.entity:GetAngles() end
 
 	model = GetModel(model or "cube") or "models/holograms/cube.mdl"
+	if not WireLib.CanModel(self.player, model) then return end
 
 	local Holo = CheckIndex(self, index)
 	if not Holo then
@@ -690,7 +691,7 @@ end
 
 e2function void holoReset(index, string model, vector scale, vector color, string material)
 	model = GetModel(model)
-	if not model then return end
+	if not model or not WireLib.CanModel(self.player, model) then return end
 	local Holo = CheckIndex(self, index)
 	if not Holo then return end
 
@@ -937,7 +938,7 @@ e2function void holoModel(index, string model)
 	if not Holo then return end
 
 	model = GetModel(model)
-	if not model then return end
+	if not model or not WireLib.CanModel(self.player, model) then return end
 
 	Holo.ent:SetModel(model)
 end
@@ -950,7 +951,7 @@ e2function void holoModel(index, string model, skin)
 	Holo.ent:SetSkin(skin)
 
 	model = GetModel(model)
-	if not model then return end
+	if not model or not WireLib.CanModel(self.player, model, skin) then return end
 
 	Holo.ent:SetModel(model)
 end

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -541,6 +541,7 @@ end)
 function MakeWireExpression2(player, Pos, Ang, model, buffer, name, inputs, outputs, vars, inc_files, filepath)
 	if not player then player = game.GetWorld() end -- For Garry's Map Saver
 	if IsValid(player) and not player:CheckLimit("wire_expressions") then return false end
+	if not WireLib.CanModel(player, model) then return false end
 
 	local self = ents.Create("gmod_wire_expression2")
 	if not self:IsValid() then return false end

--- a/lua/entities/gmod_wire_gpulib_controller.lua
+++ b/lua/entities/gmod_wire_gpulib_controller.lua
@@ -55,6 +55,8 @@ function ENT:TriggerInput(iname, value)
 end
 
 function MakeGPULibController( pl, Pos, Ang, model, screen )
+	model = model or "models/jaanus/wiretool/wiretool_siren.mdl"
+	if not WireLib.CanModel(pl, model) then return false end
 	--if ( !pl:CheckLimit( "wire_cams" ) ) then return false end
 
 	local controller = ents.Create( "gmod_wire_gpulib_controller" )
@@ -62,7 +64,7 @@ function MakeGPULibController( pl, Pos, Ang, model, screen )
 
 	controller:SetAngles( Ang )
 	controller:SetPos( Pos )
-	controller:SetModel( Model(model or "models/jaanus/wiretool/wiretool_siren.mdl") )
+	controller:SetModel(model)
 	controller:Spawn()
 	controller:Setup(screen)
 

--- a/lua/entities/sent_deployableballoons.lua
+++ b/lua/entities/sent_deployableballoons.lua
@@ -44,6 +44,7 @@ hook.Add("Initialize", "CreateDamageFilter", CreateDamageFilter)
 
 local function MakeBalloonSpawner(pl, Data)
 	if IsValid(pl) and not pl:CheckLimit("wire_deployers") then return nil end
+	if Data.Model and not WireLib.CanModel(pl, Data.Model, Data.Skin) then return false end
 
 	local ent = ents.Create("sent_deployableballoons")
 	if not ent:IsValid() then return end

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1058,9 +1058,18 @@ function WireLib.dummytrace(ent)
 	}
 end
 
+--- @return whether the given player can spawn an object with the given model and skin
+function WireLib.CanModel(player, model, skin)
+	if not util.IsValidModel(model) then return false end
+	if skin ~= nil and NumModelSkins(model) <= skin then return false end
+	if IsValid(player) and player:IsPlayer() and not hook.Run("PlayerSpawnObject", player, model, skin) then return false end
+	return true
+end
+
 function WireLib.MakeWireEnt( pl, Data, ... )
 	Data.Class = scripted_ents.Get(Data.Class).ClassName
 	if IsValid(pl) and not pl:CheckLimit(Data.Class:sub(6).."s") then return false end
+	if Data.Model and not WireLib.CanModel(pl, Data.Model, Data.Skin) then return false end
 
 	local ent = ents.Create( Data.Class )
 	if not IsValid(ent) then return false end

--- a/lua/wire/stools/egp.lua
+++ b/lua/wire/stools/egp.lua
@@ -17,6 +17,7 @@ if (SERVER) then
 	local function SpawnEnt( ply, Pos, Ang, model, class)
 		if IsValid(ply) and (!ply:CheckLimit("wire_egps")) then return false end
 		if not ply then ply = game.GetWorld() end -- For Garry's Map Saver
+		if model and not WireLib.CanModel(ply, model) then return false end
 		local ent = ents.Create(class)
 		if (model) then ent:SetModel(model) end
 		ent:SetAngles(Ang)


### PR DESCRIPTION
This adds `WireLib.CanModel(player, model, skin)` and uses it wherever we set models. It wraps `util.IsValidModel` and the `PlayerSpawnObject` hook, so security / admin addons can decide whether a given model should be usable by players.

Fixes #1080.