### PR TITLE
Fix nil value from return of user function

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/angle.lua
+++ b/lua/entities/gmod_wire_expression2/core/angle.lua
@@ -46,7 +46,7 @@ end
 
 registerOperator("ass", "a", "a", function(self, args)
 	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
+	local      rv2 = op2[1](self, op2) or { 0, 0, 0 }
 	self.Scopes[scope][op1] = rv2
 	self.Scopes[scope].vclk[op1] = true
 	return rv2

--- a/lua/entities/gmod_wire_expression2/core/array.lua
+++ b/lua/entities/gmod_wire_expression2/core/array.lua
@@ -88,7 +88,7 @@ end)
 --------------------------------------------------------------------------------
 registerOperator("ass", "r", "r", function(self, args)
 	local lhs, op2, scope = args[2], args[3], args[4]
-	local      rhs = op2[1](self, op2)
+	local      rhs = op2[1](self, op2) or {}
 
 	local Scope = self.Scopes[scope]
 	if !Scope.lookup then Scope.lookup = {} end

--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -56,7 +56,7 @@ __e2setcost(5) -- temporary
 
 registerOperator("ass", "e", "e", function(self, args)
 	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
+	local      rv2 = op2[1](self, op2) or NULL
 	self.Scopes[scope][op1] = rv2
 	self.Scopes[scope].vclk[op1] = true
 	return rv2

--- a/lua/entities/gmod_wire_expression2/core/number.lua
+++ b/lua/entities/gmod_wire_expression2/core/number.lua
@@ -53,7 +53,7 @@ __e2setcost(2)
 
 registerOperator("ass", "n", "n", function(self, args)
 	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
+	local      rv2 = op2[1](self, op2) or 0
 	self.Scopes[scope][op1] = rv2
 	self.Scopes[scope].vclk[op1] = true
 	return rv2

--- a/lua/entities/gmod_wire_expression2/core/quaternion.lua
+++ b/lua/entities/gmod_wire_expression2/core/quaternion.lua
@@ -110,7 +110,7 @@ end
 __e2setcost(1)
 
 --- Creates a zero quaternion
-e2function quaternion quat()
+e2function  quaternionquat()
 	return { 0, 0, 0, 0 }
 end
 
@@ -232,7 +232,7 @@ __e2setcost(2)
 
 registerOperator("ass", "q", "q", function(self, args)
 	local lhs, op2, scope = args[2], args[3], args[4]
-	local      rhs = op2[1](self, op2)
+	local      rhs = op2[1](self, op2) or { 0, 0, 0, 0 }
 
 	self.Scopes[scope][lhs] = rhs
 	self.Scopes[scope].vclk[lhs] = true

--- a/lua/entities/gmod_wire_expression2/core/quaternion.lua
+++ b/lua/entities/gmod_wire_expression2/core/quaternion.lua
@@ -110,7 +110,7 @@ end
 __e2setcost(1)
 
 --- Creates a zero quaternion
-e2function  quaternionquat()
+e2function quaternion quat()
 	return { 0, 0, 0, 0 }
 end
 
@@ -232,7 +232,7 @@ __e2setcost(2)
 
 registerOperator("ass", "q", "q", function(self, args)
 	local lhs, op2, scope = args[2], args[3], args[4]
-	local      rhs = op2[1](self, op2) or { 0, 0, 0, 0 }
+	local      rhs = op2[1](self, op2)
 
 	self.Scopes[scope][lhs] = rhs
 	self.Scopes[scope].vclk[lhs] = true

--- a/lua/entities/gmod_wire_expression2/core/quaternion.lua
+++ b/lua/entities/gmod_wire_expression2/core/quaternion.lua
@@ -232,7 +232,7 @@ __e2setcost(2)
 
 registerOperator("ass", "q", "q", function(self, args)
 	local lhs, op2, scope = args[2], args[3], args[4]
-	local      rhs = op2[1](self, op2)
+	local      rhs = op2[1](self, op2) or { 0, 0, 0, 0 }
 
 	self.Scopes[scope][lhs] = rhs
 	self.Scopes[scope].vclk[lhs] = true

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -28,7 +28,7 @@ __e2setcost(3) -- temporary
 
 registerOperator("ass", "s", "s", function(self, args)
 	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
+	local      rv2 = op2[1](self, op2) or ""
 	self.Scopes[scope][op1] = rv2
 	self.Scopes[scope].vclk[op1] = true
 	return rv2

--- a/lua/entities/gmod_wire_expression2/core/table.lua
+++ b/lua/entities/gmod_wire_expression2/core/table.lua
@@ -257,7 +257,7 @@ __e2setcost(5)
 
 registerOperator("ass", "t", "t", function(self, args)
 	local lhs, op2, scope = args[2], args[3], args[4]
-	local      rhs = op2[1](self, op2)
+	local      rhs = op2[1](self, op2) or table.Copy(DEFAULT)
 
 	local Scope = self.Scopes[scope]
 	if !Scope.lookup then Scope.lookup = {} end

--- a/lua/entities/gmod_wire_expression2/core/vector.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector.lua
@@ -73,7 +73,7 @@ end
 
 registerOperator("ass", "v", "v", function(self, args)
 	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
+	local      rv2 = op2[1](self, op2) or { 0, 0, 0 }
 	self.Scopes[scope][op1] = rv2
 	self.Scopes[scope].vclk[op1] = true
 	return rv2

--- a/lua/entities/gmod_wire_expression2/core/vector2.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector2.lua
@@ -61,7 +61,7 @@ end)
 
 registerOperator("ass", "xv2", "xv2", function(self, args)
 	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
+	local      rv2 = op2[1](self, op2) or { 0, 0 }
 	self.Scopes[scope][op1] = rv2
 	self.Scopes[scope].vclk[op1] = true
 	return rv2
@@ -599,7 +599,7 @@ end)
 
 registerOperator("ass", "xv4", "xv4", function(self, args)
 	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
+	local      rv2 = op2[1](self, op2) or { 0, 0, 0, 0 }
 	self.Scopes[scope][op1] = rv2
 	self.Scopes[scope].vclk[op1] = true
 	return rv2


### PR DESCRIPTION
In the E2, when you create a user function with a return and don't use the return, it return an unusable value.

example:

```
function table test(){
    print("no retrun >:)")
}
V = test()
```

it return in the console:
```
no retrun >:) 
sv: Expression 2 (generic): entities/gmod_wire_expression2/core/table.lua:267: table index is nil
```
And it's like this for the most of value type.

With a default value in the registerOperator, it works perfectly.