### PR TITLE
Speedup randvec2 and randvec4

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/vector2.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector2.lua
@@ -509,8 +509,10 @@ __e2setcost(5)
 
 -- Returns a random vector2 between -1 and 1
 e2function vector2 randvec2()
-	local randomang = random() * pi * 2
-	return { math.cos( randomang ), math.sin( randomang ) }
+	local x = random()*2-1
+	local y = random()*2-1
+	local invsqrt = ( x^2 + y^2 ) ^ -0.5
+	return { invsqrt * x, invsqrt * y }
 end
 
 -- Returns a random vector2 between min and max
@@ -1095,9 +1097,12 @@ __e2setcost(7)
 
 -- Returns a random vector4 between -1 and 1
 e2function vector4 randvec4()
-	local vec = { random()*2-1, random()*2-1, random()*2-1, random()*2-1 }
-	local length = ( vec[1]^2+vec[2]^2+vec[3]^2+vec[4]^2 ) ^ 0.5 -- x ^ 0.5 <=> math.sqrt( x )
-	return { vec[1] / length, vec[2] / length, vec[3] / length, vec[4] / length }
+	local x = random()*2-1
+	local y = random()*2-1
+	local z = random()*2-1
+	local w = random()*2-1
+	local invsqrt = ( x^2 + y^2 + z^2 + w^2 ) ^ -0.5
+	return { invsqrt * x, invsqrt * y, invsqrt * z, invsqrt * w }
 end
 
 -- Returns a random vector4 between min and max


### PR DESCRIPTION
randvec2() now faster using Muller's method for random point on hypersphere.
randvec4() now returns a uniformly distributed, random, normalized direction vector and now it faster using Muller's method.
http://mathworld.wolfram.com/HyperspherePointPicking.html .