### PR TITLE
Added: Prop velocity control

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/cl_prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cl_prop.lua
@@ -31,3 +31,5 @@ E2Helper.Descriptions["propGetElasticity"] = "Gets prop's elasticity coefficient
 E2Helper.Descriptions["propSpawnUndo"] = "Set to 0 to force prop removal on E2 shutdown, and suppress Undo entries for props."
 E2Helper.Descriptions["propDeleteAll"] = "Removes all entities spawned by this E2"
 E2Helper.Descriptions["propStatic"] = "Sets to 1 to make the entity static (disables movement, physgun, unfreeze, drive...) or 0 to cancel."
+E2Helper.Descriptions["propSetVelocity"] = "Sets the velocity of the prop for the next iteration"
+E2Helper.Descriptions["propSetVelocityInstant"] = "Sets the initial velocity of the prop"

--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -355,6 +355,22 @@ e2function string entity:propPhysicalMaterial()
 	return ""
 end
 
+e2function void entity:propSetVelocity(vector velocity)
+	if not PropCore.ValidAction(self, this, "velocitynxt") then return end
+	local phys = this:GetPhysicsObject()
+	if IsValid( phys ) then
+		phys:SetVelocity(Vector(velocity[1], velocity[2], velocity[3]))
+	end
+end
+
+e2function void entity:propSetVelocityInstant(vector velocity)
+	if not PropCore.ValidAction(self, this, "velocityins") then return end
+	local phys = this:GetPhysicsObject()
+	if IsValid( phys ) then
+		phys:SetVelocityInstantaneous(Vector(velocity[1], velocity[2], velocity[3]))
+	end
+end
+
 hook.Add( "CanDrive", "checkPropStaticE2", function( ply, ent ) if ent.propStaticE2 ~= nil then return false end end )
 e2function void entity:propStatic( number static )
 	if not PropCore.ValidAction( self, this, "static" ) then return end


### PR DESCRIPTION
It will be nice to have a velocity control in the prop core. The potential is limitless ..
Tested with 
```PHP
@name Test
@inputs 
@outputs Out
@persist [Chip Base]:entity
@trigger 

interval(20)

Time = systime()

if(first() || dupefinished())
{
    Chip = entity()
    Base = Chip:isWeldedTo(1)
    
   # Base:setPropVelocityInstant(vec(0,0,500))
}

Base:setPropVelocity(vec(0,0,5000))

Out = (systime() - Time) * 1000
```
The maximum input vector module is clamped inside SetVelocity()
When you give it vector with module > 40000 it doesn't do anything.