### PR TITLE
E2: Add "steamIDFrom64" and "steamIDTo64" functions

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/steamidconv.lua
+++ b/lua/entities/gmod_wire_expression2/core/steamidconv.lua
@@ -1,0 +1,15 @@
+﻿local util = util
+local util_SteamIDFrom64 = util.SteamIDFrom64
+local util_SteamIDTo64 = util.SteamIDTo64
+
+__e2setcost(5) -- approximated
+
+--- Given a 64bit SteamID will return a STEAM_0 style Steam ID.
+e2function string steamIDFrom64(string community_id)
+    return util_SteamIDFrom64(community_id)
+end
+
+--- Given a STEAM_0 style Steam ID will return a 64bit Steam ID.
+e2function string steamIDTo64(string id)
+    return util_SteamIDTo64(id)
+end

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -849,6 +849,10 @@ E2Helper.Descriptions["toUnit(sn)"] = "Converts default garrysmod units to speci
 E2Helper.Descriptions["fromUnit(sn)"] = "Converts specified units to default garrysmod units"
 E2Helper.Descriptions["convertUnit(ssn)"] = "Converts between two units"
 
+-- Steam ID conversion
+E2Helper.Descriptions["steamIDFrom64(s)"] = "Converts Steam Community ID to Steam ID"
+E2Helper.Descriptions["steamIDTo64(s)"] = "Converts Steam ID to Steam Community ID"
+
 -- Server information
 E2Helper.Descriptions["map()"] = "Returns the current map name"
 E2Helper.Descriptions["hostname()"] = "Returns the Name of the server"


### PR DESCRIPTION
This pull request (after merged) would add the following to Expression 2 gate:

![new](https://cloud.githubusercontent.com/assets/9789070/16093393/024dce8a-333c-11e6-9ac4-71a0c0a3de2d.png) Functions:

Signature | Description
------------ | -------------
string=steamIDFrom64(string) | Converts Steam Community ID to Steam ID
string=steamIDTo64(string) | Converts Steam ID to Steam Community ID