### PR TITLE
Wire CD Ray Fix for write with read ray

### DIFF
--- a/lua/entities/gmod_wire_cd_ray.lua
+++ b/lua/entities/gmod_wire_cd_ray.lua
@@ -132,7 +132,7 @@ function ENT:DoJob()
 			if (self.Command[0] ~= 0) then //write ray
 				disk.DiskMemory[sector_addr] = table.Copy(self.WriteBuffer)
 			else //read ray
-				self.WriteBuffer = disk.DiskMemory[sector_addr] or { [0] = 0 }
+				self.WriteBuffer = table.Copy(disk.DiskMemory[sector_addr]) or { [0] = 0 }
 			end
 		end
 	end


### PR DESCRIPTION
Actually without this change impossible to write on another sector if you read some sector before - data will be overwritten in previous sector.