### PR TITLE
xwl:writeArray() - No longer null-terminate

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/wirelink.lua
+++ b/lua/entities/gmod_wire_expression2/core/wirelink.lua
@@ -79,9 +79,7 @@ local function WriteArray(entity, address, data)
 	-- check if enough space is available
 	if not entity:WriteCell(address+#data-1, 0) then return 0 end
 
-	-- write the trailing 0 byte.
-	entity:WriteCell(address+#data, 0)
-	local free_address = address+#data+1
+	local free_address = address+#data
 
 	for index, value in ipairs(data) do
 		local tp = type(value)
@@ -97,11 +95,11 @@ local function WriteArray(entity, address, data)
 			else
 				wa_lookup[value] = free_address
 				if not entity:WriteCell(address+index-1, free_address) then return 0 end
-				free_address = WriteArray(entity, free_address, value)
+				free_address = WriteArray(entity, free_address, table.Add(table.Copy(value),{0}))
 			end
 		elseif tp == "Vector" then
 			if not entity:WriteCell(address+index-1, free_address) then return 0 end
-			free_address = WriteArray(entity, free_address, { value[1], value[2], value[3] })
+			free_address = WriteArray(entity, free_address, { value[1], value[2], value[3], 0 })
 		end
 	end
 	return free_address


### PR DESCRIPTION
Fixes #879

There is no need to automatically null terminate all arrays, readArray specifies the size of the area to read and manually adding a 0 to array in case it is needed for whatever reason is trivial. And there are seperate functions for writing/reading strings.

I added back the null-terminator for sub-tables (there probably is a better way to do that) since those would otherwise be hard to parse back into a array without mapping out all pointers beforehand.

An alternate solution would be a wirelink:writeArraySimple(address,array) function, that just writes the numerical contents of the array, without any sub-tables, null-terminations or other confusing stuff, which is certainly useful for many things including digital screens, where you just want to input a row of simple numbers.
