### PR TITLE
Fix ApplyForce/physics-crash with Forcer

### DIFF
--- a/lua/entities/gmod_wire_forcer.lua
+++ b/lua/entities/gmod_wire_forcer.lua
@@ -53,6 +53,8 @@ function ENT:TriggerInput( name, value )
 	end
 end
 
+local check = WireLib.checkForce
+
 function ENT:Think()
 	if self.Force == 0 and self.OffsetForce == 0 and self.Velocity == 0 then return end
 
@@ -72,14 +74,14 @@ function ENT:Think()
 		local phys = trace.Entity:GetPhysicsObject()
 		if not IsValid(phys) then return end
 
-		if self.Force ~= 0 then phys:ApplyForceCenter( Forward * self.Force * self.ForceMul ) end
-		if self.OffsetForce ~= 0 then phys:ApplyForceOffset( Forward * self.OffsetForce * self.ForceMul, trace.HitPos ) end
+		if self.Force ~= 0 and check(Forward * self.Force * self.ForceMul) then phys:ApplyForceCenter( Forward * self.Force * self.ForceMul ) end
+		if self.OffsetForce ~= 0 and check(Forward * self.OffsetForce * self.ForceMul) then phys:ApplyForceOffset( Forward * self.OffsetForce * self.ForceMul, trace.HitPos ) end
 		if self.Velocity ~= 0 then phys:SetVelocityInstantaneous( Forward * self.Velocity ) end
 	else
 		if self.Velocity ~= 0 then trace.Entity:SetVelocity( Forward * self.Velocity ) end
 	end
 
-	if self.Reaction and IsValid(self:GetPhysicsObject()) and (self.Force + self.OffsetForce ~= 0) then
+	if self.Reaction and IsValid(self:GetPhysicsObject()) and (self.Force + self.OffsetForce ~= 0) and check(Forward * -(self.Force + self.OffsetForce) * self.ForceMul) then
 		self:GetPhysicsObject():ApplyForceCenter( Forward * -(self.Force + self.OffsetForce) * self.ForceMul )
 	end
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/9789070/17271688/9781f3fa-5682-11e6-9381-982657c16464.png) Fixed crash caused by ApplyForce/crazy physics in [Forcer](https://github.com/wiremod/wire/blob/master/lua/entities/gmod_wire_forcer.lua).