### PR TITLE
Add check to wire remote to prevent pod hijacking

### DIFF
--- a/lua/weapons/remotecontroller.lua
+++ b/lua/weapons/remotecontroller.lua
@@ -62,6 +62,11 @@ function SWEP:On()
 
 	if not hook.Run("CanTool", self:GetOwner(), WireLib.dummytrace(self.Linked), "remotecontroller") then return end
 
+	if self.Linked:HasPly() then
+		ply:ChatPrint("Pod is in use.")
+		return
+	end
+
 	self.Active = true
 	self.OldMoveType = not ply:InVehicle() and ply:GetMoveType() or MOVETYPE_WALK
 	ply:SetMoveType(MOVETYPE_NONE)

--- a/lua/weapons/remotecontroller.lua
+++ b/lua/weapons/remotecontroller.lua
@@ -59,10 +59,20 @@ end
 
 function SWEP:On()
 	local ply = self:GetOwner()
+	local pod = self.Linked
 
-	if IsValid(self.Linked) and self.Linked:HasPly() then
-		ply:ChatPrint("Pod is in use.")
-		return
+	if IsValid(pod) and pod:HasPly() then
+		local podOwner = pod:CPPIGetOwner()
+		if IsValid(podOwner) and podOwner:SteamID() ~= pod:GetPly():SteamID() then
+			if pod.RC then
+				pod:RCEject(pod:GetPly())
+			else
+				pod:GetPly():ExitVehicle()
+			end
+		else
+			ply:ChatPrint("Pod is in use.")
+			return
+		end
 	end
 
 	self.Active = true

--- a/lua/weapons/remotecontroller.lua
+++ b/lua/weapons/remotecontroller.lua
@@ -59,20 +59,10 @@ end
 
 function SWEP:On()
 	local ply = self:GetOwner()
-	local pod = self.Linked
 
-	if IsValid(pod) and pod:HasPly() then
-		local podOwner = pod:CPPIGetOwner()
-		if IsValid(podOwner) and podOwner:SteamID() == ply:SteamID() then
-			if pod.RC then
-				pod:RCEject(pod:GetPly())
-			else
-				pod:GetPly():ExitVehicle()
-			end
-		else
-			ply:ChatPrint("Pod is in use.")
-			return
-		end
+	if self.Linked:HasPly() then
+		ply:ChatPrint("Pod is in use.")
+		return
 	end
 
 	self.Active = true
@@ -105,7 +95,7 @@ function SWEP:Think()
 	if not self.Linked then return end
 
 	if self:GetOwner():KeyPressed(IN_USE) then
-		if not self.Active then
+		if not self.Active and hook.Run("CanTool", self:GetOwner(), WireLib.dummytrace(self.Linked), "remotecontroller") then
 			self:On()
 		else
 			self:Off()

--- a/lua/weapons/remotecontroller.lua
+++ b/lua/weapons/remotecontroller.lua
@@ -60,6 +60,11 @@ end
 function SWEP:On()
 	local ply = self:GetOwner()
 
+	if IsValid(self.Linked) and self.Linked:HasPly() then
+		ply:ChatPrint("Pod is in use.")
+		return
+	end
+
 	self.Active = true
 	self.OldMoveType = not ply:InVehicle() and ply:GetMoveType() or MOVETYPE_WALK
 	ply:SetMoveType(MOVETYPE_NONE)

--- a/lua/weapons/remotecontroller.lua
+++ b/lua/weapons/remotecontroller.lua
@@ -63,7 +63,7 @@ function SWEP:On()
 
 	if IsValid(pod) and pod:HasPly() then
 		local podOwner = pod:CPPIGetOwner()
-		if IsValid(podOwner) and podOwner:SteamID() ~= pod:GetPly():SteamID() then
+		if IsValid(podOwner) and podOwner:SteamID() == ply:SteamID() then
 			if pod.RC then
 				pod:RCEject(pod:GetPly())
 			else

--- a/lua/weapons/remotecontroller.lua
+++ b/lua/weapons/remotecontroller.lua
@@ -63,8 +63,11 @@ function SWEP:On()
 	if not hook.Run("CanTool", self:GetOwner(), WireLib.dummytrace(self.Linked), "remotecontroller") then return end
 
 	if self.Linked:HasPly() then
-		ply:ChatPrint("Pod is in use.")
-		return
+		if self.Linked.RC then
+			self.Linked:RCEject(self.Linked:GetPly())
+		else
+			self.Linked:GetPly():ExitVehicle()
+		end
 	end
 
 	self.Active = true

--- a/lua/weapons/remotecontroller.lua
+++ b/lua/weapons/remotecontroller.lua
@@ -60,13 +60,16 @@ end
 function SWEP:On()
 	local ply = self:GetOwner()
 
-	if not hook.Run("CanTool", self:GetOwner(), WireLib.dummytrace(self.Linked), "remotecontroller") then return end
-
 	if self.Linked:HasPly() then
-		if self.Linked.RC then
-			self.Linked:RCEject(self.Linked:GetPly())
+		if hook.Run("CanTool", ply, WireLib.dummytrace(self.Linked), "remotecontroller") then
+			if self.Linked.RC then
+				self.Linked:RCEject(self.Linked:GetPly())
+			else
+				self.Linked:GetPly():ExitVehicle()
+			end
 		else
-			self.Linked:GetPly():ExitVehicle()
+			ply:ChatPrint("Pod is in use.")
+			return
 		end
 	end
 

--- a/lua/weapons/remotecontroller.lua
+++ b/lua/weapons/remotecontroller.lua
@@ -60,6 +60,8 @@ end
 function SWEP:On()
 	local ply = self:GetOwner()
 
+	if not hook.Run("CanTool", self:GetOwner(), WireLib.dummytrace(self.Linked), "remotecontroller") then return end
+
 	if self.Linked:HasPly() then
 		ply:ChatPrint("Pod is in use.")
 		return
@@ -96,9 +98,7 @@ function SWEP:Think()
 
 	if self:GetOwner():KeyPressed(IN_USE) then
 		if not self.Active then
-			if hook.Run("CanTool", self:GetOwner(), WireLib.dummytrace(self.Linked), "remotecontroller") then
-				self:On()
-			end
+			self:On()
 		else
 			self:Off()
 		end

--- a/lua/weapons/remotecontroller.lua
+++ b/lua/weapons/remotecontroller.lua
@@ -62,11 +62,6 @@ function SWEP:On()
 
 	if not hook.Run("CanTool", self:GetOwner(), WireLib.dummytrace(self.Linked), "remotecontroller") then return end
 
-	if self.Linked:HasPly() then
-		ply:ChatPrint("Pod is in use.")
-		return
-	end
-
 	self.Active = true
 	self.OldMoveType = not ply:InVehicle() and ply:GetMoveType() or MOVETYPE_WALK
 	ply:SetMoveType(MOVETYPE_NONE)

--- a/lua/weapons/remotecontroller.lua
+++ b/lua/weapons/remotecontroller.lua
@@ -95,8 +95,10 @@ function SWEP:Think()
 	if not self.Linked then return end
 
 	if self:GetOwner():KeyPressed(IN_USE) then
-		if not self.Active and hook.Run("CanTool", self:GetOwner(), WireLib.dummytrace(self.Linked), "remotecontroller") then
-			self:On()
+		if not self.Active then
+			if hook.Run("CanTool", self:GetOwner(), WireLib.dummytrace(self.Linked), "remotecontroller") then
+				self:On()
+			end
 		else
 			self:Off()
 		end


### PR DESCRIPTION
The ability for anyone to effectively kick the current driver and take control of the vehicle seems unintended, and I have often seen it used maliciously. This patch should prevent the remote from activating if the pod controller is already in use.

Just pretend that the last pull request (#1198) never happened.