### PR TITLE
Add "steamidconv.lua" file to E2 includes

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/extloader.lua
+++ b/lua/entities/gmod_wire_expression2/core/extloader.lua
@@ -174,6 +174,7 @@ e2_include("datasignal.lua")
 e2_include("egpfunctions.lua")
 e2_include("functions.lua")
 e2_include("strfunc.lua")
+e2_include("steamidconv.lua")
 
 do
 	local list = file.Find("entities/gmod_wire_expression2/core/custom/*.lua", "LUA")


### PR DESCRIPTION
Added `steamidconv.lua` file to E2 includes as pointed out [by Divran](https://github.com/wiremod/wire/pull/1156#issuecomment-244859223), it was introduced in #1156.
