### PR TITLE
Added connect and disconnect events that can be used e2 wise. 

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -575,10 +575,9 @@ hook.Add("PlayerDisconnected","Exp2RunOnLeave", function(ply)
 	runByLeave = 0
 end)
 
-
 __e2setcost(3)
 
-e2function void runOnConnect(activate)
+e2function void runOnPlayerConnect(activate)
 	if activate ~= 0 then
 		spawnAlert[self.entity] = true
 	else
@@ -586,15 +585,15 @@ e2function void runOnConnect(activate)
 	end
 end
 
-e2function number connectClk()
+e2function number connectedPlayerClk()
 	return runBySpawn
 end
 
-e2function entity lastConnected()
+e2function entity lastConnectedPlayer()
 	return lastJoined
 end
 
-e2function void runOnDisconnect(activate)
+e2function void runOnPlayerDisconnect(activate)
 	if activate ~= 0 then
 		leaveAlert[self.entity] = true
 	else
@@ -602,10 +601,10 @@ e2function void runOnDisconnect(activate)
 	end
 end
 
-e2function number disconnectClk()
+e2function number disconnectedPlayerClk()
 	return runByLeave
 end
 
-e2function entity lastDisconnected()
+e2function entity lastDisconnectedPlayer()
 	return lastLeft
 end

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -577,6 +577,7 @@ end)
 
 
 __e2setcost(3)
+
 e2function void runOnConnect(activate)
 	if activate ~= 0 then
 		spawnAlert[self.entity] = true
@@ -584,9 +585,11 @@ e2function void runOnConnect(activate)
 		spawnAlert[self.entity] = nil
 	end
 end
+
 e2function number connectClk()
 	return runBySpawn
 end
+
 e2function entity lastConnected()
 	return lastJoined
 end
@@ -598,9 +601,11 @@ e2function void runOnDisconnect(activate)
 		leaveAlert[self.entity] = nil
 	end
 end
+
 e2function number disconnectClk()
 	return runByLeave
 end
+
 e2function entity lastDisconnected()
 	return lastLeft
 end

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -264,8 +264,8 @@ keys_lookup[113] = "mouse_wheel_down"
 registerCallback("destruct",function(self)
 	KeyAlert[self.entity] = nil
     --Used futher below. Didn't want to create more then one of these per file
-    if SpawnAlert[self.entity] then SpawnAlert[self.entity] = nil; end
-    if LeaveAlert[self.entity] then LeaveAlert[self.entity] = nil; end
+    if spawnAlert[self.entity] then spawnAlert[self.entity] = nil; end
+    if leaveAlert[self.entity] then leaveAlert[self.entity] = nil; end
 end)
 
 local function UpdateKeys(ply, key)
@@ -586,9 +586,6 @@ e2function number joinClk()
 	return runBySpawn
 end
 e2function entity lastJoined()
-	if not IsValid(lastJoined) then return nil end
-	if not lastJoined:IsPlayer() then return nil end
-
 	return lastJoined
 end
 
@@ -603,8 +600,5 @@ e2function number disconnectClk()
 	return runByLeave
 end
 e2function entity lastDisconnected()
-	if not IsValid(lastLeft) then return nil end
-	if not lastLeft:IsPlayer() then return nil end
-
 	return lastLeft
 end

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -263,6 +263,9 @@ keys_lookup[113] = "mouse_wheel_down"
 
 registerCallback("destruct",function(self)
 	KeyAlert[self.entity] = nil
+    --Used futher below. Didn't want to create more then one of these per file
+    if SpawnAlert[self.entity] then SpawnAlert[self.entity] = nil; end
+    if LeaveAlert[self.entity] then LeaveAlert[self.entity] = nil; end
 end)
 
 local function UpdateKeys(ply, key)
@@ -532,4 +535,76 @@ e2function ranger entity:eyeTraceCursor()
 	local ret = this:GetEyeTrace()
 	ret.RealStartPos = this:GetShootPos()
 	return ret
+end
+
+/******************************************************************************/
+
+local SpawnAlert = {}
+local runBySpawn = 0
+local LastJoined = nil
+
+local LeaveAlert = {}
+local runByLeave = 0
+local LastLeft = nil
+
+hook.Add("PlayerInitialSpawn","Exp2RunOnJoin", function(ply)
+	runBySpawn = 1
+    LastJoined = ply
+	for e,_ in pairs(SpawnAlert) do
+		if IsValid(e) then
+			e:Execute()
+		else
+			SpawnAlert[e] = nil
+		end
+	end
+	runBySpawn = 0
+end)
+
+hook.Add("PlayerDisconnected","Exp2RunOnLeave", function(ply)
+	runByLeave = 1
+    LastLeft = ply
+	for e,_ in pairs(LeaveAlert) do
+		if IsValid(e) then
+			e:Execute()
+		else
+			LeaveAlert[e] = nil
+		end
+	end
+	runByLeave = 0
+end)
+
+
+__e2setcost(3)
+e2function void runOnJoin(activate)
+	if activate ~= 0 then
+		SpawnAlert[self.entity] = true
+	else
+		SpawnAlert[self.entity] = nil
+	end
+end
+e2function number joinClk()
+	return runBySpawn
+end
+e2function entity lastJoined()
+	if not IsValid(LastJoined) then return nil end
+	if not LastJoined:IsPlayer() then return nil end
+
+	return LastJoined
+end
+
+e2function void runOnDisconnect(activate)
+	if activate ~= 0 then
+		LeaveAlert[self.entity] = true
+	else
+		LeaveAlert[self.entity] = nil
+	end
+end
+e2function number disconnectClk()
+	return runByLeave
+end
+e2function entity lastDisconnected()
+	if not IsValid(LastLeft) then return nil end
+	if not LastLeft:IsPlayer() then return nil end
+
+	return LastLeft
 end

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -4,6 +4,16 @@
 
 local IsValid = IsValid
 local isOwner = E2Lib.isOwner
+
+
+local spawnAlert = {}
+local runBySpawn = 0
+local lastJoined = NULL
+
+local leaveAlert = {}
+local runByLeave = 0
+local lastLeft = NULL
+
 registerCallback("e2lib_replace_function", function(funcname, func, oldfunc)
 	if funcname == "isOwner" then
 		isOwner = func
@@ -196,11 +206,11 @@ e2function number entity:keyUse()
 end
 
 e2function number entity:keyReload()
-    return (IsValid(this) and this:IsPlayer() and this:KeyDown(IN_RELOAD)) and 1 or 0
+	return (IsValid(this) and this:IsPlayer() and this:KeyDown(IN_RELOAD)) and 1 or 0
 end
 
 e2function number entity:keyZoom()
-    return (IsValid(this) and this:IsPlayer() and this:KeyDown(IN_ZOOM)) and 1 or 0
+	return (IsValid(this) and this:IsPlayer() and this:KeyDown(IN_ZOOM)) and 1 or 0
 end
 
 e2function number entity:keyWalk()
@@ -263,9 +273,9 @@ keys_lookup[113] = "mouse_wheel_down"
 
 registerCallback("destruct",function(self)
 	KeyAlert[self.entity] = nil
-    --Used futher below. Didn't want to create more then one of these per file
-    if spawnAlert[self.entity] then spawnAlert[self.entity] = nil; end
-    if leaveAlert[self.entity] then leaveAlert[self.entity] = nil; end
+	--Used futher below. Didn't want to create more then one of these per file
+	spawnAlert[self.entity] = nil
+	leaveAlert[self.entity] = nil
 end)
 
 local function UpdateKeys(ply, key)
@@ -539,17 +549,9 @@ end
 
 --[[--------------------------------------------------------------------------------------------]]--
 
-local spawnAlert = {}
-local runBySpawn = 0
-local lastJoined = nil
-
-local leaveAlert = {}
-local runByLeave = 0
-local lastLeft = nil
-
 hook.Add("PlayerInitialSpawn","Exp2RunOnJoin", function(ply)
 	runBySpawn = 1
-    lastJoined = ply
+	lastJoined = ply
 	for e,_ in pairs(spawnAlert) do
 		if IsValid(e) then
 			e:Execute()
@@ -562,7 +564,7 @@ end)
 
 hook.Add("PlayerDisconnected","Exp2RunOnLeave", function(ply)
 	runByLeave = 1
-    lastLeft = ply
+	lastLeft = ply
 	for e,_ in pairs(leaveAlert) do
 		if IsValid(e) then
 			e:Execute()
@@ -575,17 +577,17 @@ end)
 
 
 __e2setcost(3)
-e2function void runOnJoin(activate)
+e2function void runOnConnect(activate)
 	if activate ~= 0 then
 		spawnAlert[self.entity] = true
 	else
 		spawnAlert[self.entity] = nil
 	end
 end
-e2function number joinClk()
+e2function number connectClk()
 	return runBySpawn
 end
-e2function entity lastJoined()
+e2function entity lastConnected()
 	return lastJoined
 end
 

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -585,7 +585,7 @@ e2function void runOnPlayerConnect(activate)
 	end
 end
 
-e2function number connectedPlayerClk()
+e2function number playerConnectClk()
 	return runBySpawn
 end
 
@@ -601,7 +601,7 @@ e2function void runOnPlayerDisconnect(activate)
 	end
 end
 
-e2function number disconnectedPlayerClk()
+e2function number playerDisconnectClk()
 	return runByLeave
 end
 

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -537,24 +537,24 @@ e2function ranger entity:eyeTraceCursor()
 	return ret
 end
 
-/******************************************************************************/
+--[[--------------------------------------------------------------------------------------------]]--
 
-local SpawnAlert = {}
+local spawnAlert = {}
 local runBySpawn = 0
-local LastJoined = nil
+local lastJoined = nil
 
-local LeaveAlert = {}
+local leaveAlert = {}
 local runByLeave = 0
-local LastLeft = nil
+local lastLeft = nil
 
 hook.Add("PlayerInitialSpawn","Exp2RunOnJoin", function(ply)
 	runBySpawn = 1
-    LastJoined = ply
-	for e,_ in pairs(SpawnAlert) do
+    lastJoined = ply
+	for e,_ in pairs(spawnAlert) do
 		if IsValid(e) then
 			e:Execute()
 		else
-			SpawnAlert[e] = nil
+			spawnAlert[e] = nil
 		end
 	end
 	runBySpawn = 0
@@ -562,12 +562,12 @@ end)
 
 hook.Add("PlayerDisconnected","Exp2RunOnLeave", function(ply)
 	runByLeave = 1
-    LastLeft = ply
-	for e,_ in pairs(LeaveAlert) do
+    lastLeft = ply
+	for e,_ in pairs(leaveAlert) do
 		if IsValid(e) then
 			e:Execute()
 		else
-			LeaveAlert[e] = nil
+			leaveAlert[e] = nil
 		end
 	end
 	runByLeave = 0
@@ -577,34 +577,34 @@ end)
 __e2setcost(3)
 e2function void runOnJoin(activate)
 	if activate ~= 0 then
-		SpawnAlert[self.entity] = true
+		spawnAlert[self.entity] = true
 	else
-		SpawnAlert[self.entity] = nil
+		spawnAlert[self.entity] = nil
 	end
 end
 e2function number joinClk()
 	return runBySpawn
 end
 e2function entity lastJoined()
-	if not IsValid(LastJoined) then return nil end
-	if not LastJoined:IsPlayer() then return nil end
+	if not IsValid(lastJoined) then return nil end
+	if not lastJoined:IsPlayer() then return nil end
 
-	return LastJoined
+	return lastJoined
 end
 
 e2function void runOnDisconnect(activate)
 	if activate ~= 0 then
-		LeaveAlert[self.entity] = true
+		leaveAlert[self.entity] = true
 	else
-		LeaveAlert[self.entity] = nil
+		leaveAlert[self.entity] = nil
 	end
 end
 e2function number disconnectClk()
 	return runByLeave
 end
 e2function entity lastDisconnected()
-	if not IsValid(LastLeft) then return nil end
-	if not LastLeft:IsPlayer() then return nil end
+	if not IsValid(lastLeft) then return nil end
+	if not lastLeft:IsPlayer() then return nil end
 
-	return LastLeft
+	return lastLeft
 end

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -313,6 +313,13 @@ E2Helper.Descriptions["setTrails(e:nnnsvn)"] = "StartSize, EndSize, Length, Mate
 E2Helper.Descriptions["setTrails(e:nnnsvnnn)"] = "StartSize, EndSize, Length, Material, Color (RGB), Alpha, AttachmentID, Additive. Adds a trail to E with the specified attributes"
 E2Helper.Descriptions["removeTrails(e:)"] = "Removes the trail from E"
 E2Helper.Descriptions["runOnKeys(en)"] = "If set to 1, E2 will run when specified player presses/releases their key"
+E2Helper.Descriptions["disconnectClk()"] = "Returns 1 if the chip is being executed because of a disconnect event. Returns 0 otherwise"
+E2Helper.Descriptions["lastDisconnected()"] = "Returns the last player to disconnect. Must be done while in a disconnectClk() as anytime after the player object is gone."
+E2Helper.Descriptions["runOnDisconnect(n)"] = "If set to 0, the chip will no longer run on disconnect events, otherwise it makes this chip execute when someone disconnects. Only needs to be called once, not in every execution"
+E2Helper.Descriptions["joinClk()"] = "Returns 1 if the chip is being executed because of a connect event. Returns 0 otherwise"
+E2Helper.Descriptions["lastJoined()"] = "Returns the last player to connect."
+E2Helper.Descriptions["runOnJoin(n)"] = "If set to 0, the chip will no longer run on connect events, otherwise it makes this chip execute when someone connects. Only needs to be called once, not in every execution"
+
 
 -- Attachment
 E2Helper.Descriptions["lookupAttachment(e:s)"] = "Returns Es attachment ID associated with attachmentName"

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -313,12 +313,12 @@ E2Helper.Descriptions["setTrails(e:nnnsvn)"] = "StartSize, EndSize, Length, Mate
 E2Helper.Descriptions["setTrails(e:nnnsvnnn)"] = "StartSize, EndSize, Length, Material, Color (RGB), Alpha, AttachmentID, Additive. Adds a trail to E with the specified attributes"
 E2Helper.Descriptions["removeTrails(e:)"] = "Removes the trail from E"
 E2Helper.Descriptions["runOnKeys(en)"] = "If set to 1, E2 will run when specified player presses/releases their key"
-E2Helper.Descriptions["disconnectClk()"] = "Returns 1 if the chip is being executed because of a disconnect event. Returns 0 otherwise"
-E2Helper.Descriptions["lastDisconnected()"] = "Returns the last player to disconnect. Must be done while in a disconnectClk() as anytime after the player object is gone."
-E2Helper.Descriptions["runOnDisconnect(n)"] = "If set to 0, the chip will no longer run on disconnect events, otherwise it makes this chip execute when someone disconnects. Only needs to be called once, not in every execution"
-E2Helper.Descriptions["connectClk()"] = "Returns 1 if the chip is being executed because of a connect event. Returns 0 otherwise"
-E2Helper.Descriptions["lastConnected()"] = "Returns the last player to connect."
-E2Helper.Descriptions["runOnConnect(n)"] = "If set to 0, the chip will no longer run on connect events, otherwise it makes this chip execute when someone connects. Only needs to be called once, not in every execution"
+E2Helper.Descriptions["disconnectedPlayerClk()"] = "Returns 1 if the chip is being executed because of a player disconnect event. Returns 0 otherwise"
+E2Helper.Descriptions["lastDisconnectedPlayer()"] = "Returns the last player to disconnect. Must be done while in a disconnectClk() as anytime after the player object is gone."
+E2Helper.Descriptions["runOnPlayerDisconnect(n)"] = "If set to 0, the chip will no longer run on player disconnect events, otherwise it makes this chip execute when someone disconnects. Only needs to be called once, not in every execution"
+E2Helper.Descriptions["connectedPlayerClk()"] = "Returns 1 if the chip is being executed because of a player connect event. Returns 0 otherwise"
+E2Helper.Descriptions["lastConnectedPlayer()"] = "Returns the last player to connect."
+E2Helper.Descriptions["runOnPlayerConnect(n)"] = "If set to 0, the chip will no longer run on player connect events, otherwise it makes this chip execute when someone connects. Only needs to be called once, not in every execution"
 
 
 -- Attachment

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -313,10 +313,10 @@ E2Helper.Descriptions["setTrails(e:nnnsvn)"] = "StartSize, EndSize, Length, Mate
 E2Helper.Descriptions["setTrails(e:nnnsvnnn)"] = "StartSize, EndSize, Length, Material, Color (RGB), Alpha, AttachmentID, Additive. Adds a trail to E with the specified attributes"
 E2Helper.Descriptions["removeTrails(e:)"] = "Removes the trail from E"
 E2Helper.Descriptions["runOnKeys(en)"] = "If set to 1, E2 will run when specified player presses/releases their key"
-E2Helper.Descriptions["disconnectedPlayerClk()"] = "Returns 1 if the chip is being executed because of a player disconnect event. Returns 0 otherwise"
+E2Helper.Descriptions["playerDisconnectClk()"] = "Returns 1 if the chip is being executed because of a player disconnect event. Returns 0 otherwise"
 E2Helper.Descriptions["lastDisconnectedPlayer()"] = "Returns the last player to disconnect. Must be done while in a disconnectClk() as anytime after the player object is gone."
 E2Helper.Descriptions["runOnPlayerDisconnect(n)"] = "If set to 0, the chip will no longer run on player disconnect events, otherwise it makes this chip execute when someone disconnects. Only needs to be called once, not in every execution"
-E2Helper.Descriptions["connectedPlayerClk()"] = "Returns 1 if the chip is being executed because of a player connect event. Returns 0 otherwise"
+E2Helper.Descriptions["playerConnectClk()"] = "Returns 1 if the chip is being executed because of a player connect event. Returns 0 otherwise"
 E2Helper.Descriptions["lastConnectedPlayer()"] = "Returns the last player to connect."
 E2Helper.Descriptions["runOnPlayerConnect(n)"] = "If set to 0, the chip will no longer run on player connect events, otherwise it makes this chip execute when someone connects. Only needs to be called once, not in every execution"
 

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -316,9 +316,9 @@ E2Helper.Descriptions["runOnKeys(en)"] = "If set to 1, E2 will run when specifie
 E2Helper.Descriptions["disconnectClk()"] = "Returns 1 if the chip is being executed because of a disconnect event. Returns 0 otherwise"
 E2Helper.Descriptions["lastDisconnected()"] = "Returns the last player to disconnect. Must be done while in a disconnectClk() as anytime after the player object is gone."
 E2Helper.Descriptions["runOnDisconnect(n)"] = "If set to 0, the chip will no longer run on disconnect events, otherwise it makes this chip execute when someone disconnects. Only needs to be called once, not in every execution"
-E2Helper.Descriptions["joinClk()"] = "Returns 1 if the chip is being executed because of a connect event. Returns 0 otherwise"
-E2Helper.Descriptions["lastJoined()"] = "Returns the last player to connect."
-E2Helper.Descriptions["runOnJoin(n)"] = "If set to 0, the chip will no longer run on connect events, otherwise it makes this chip execute when someone connects. Only needs to be called once, not in every execution"
+E2Helper.Descriptions["connectClk()"] = "Returns 1 if the chip is being executed because of a connect event. Returns 0 otherwise"
+E2Helper.Descriptions["lastConnected()"] = "Returns the last player to connect."
+E2Helper.Descriptions["runOnConnect(n)"] = "If set to 0, the chip will no longer run on connect events, otherwise it makes this chip execute when someone connects. Only needs to be called once, not in every execution"
 
 
 -- Attachment


### PR DESCRIPTION
Connection is only after a player has fully spawned in since anytime before it can be kinda iffy to get the player object. Disconnect works as well with the fact that the entity can only be used while disconnectClk() is true since the player object only resides in that moment of time. Any time after will return a null entity.