### PR TITLE
Change deprecated network functions to new ones

### DIFF
--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -103,7 +103,7 @@ if CLIENT then
 	end
 	
 	local function getWireName( ent )
-		local name = ent:GetNetworkedString("WireName")
+		local name = ent:GetNWString("WireName")
 		if not name or name == "" then return ent.PrintName else return name end
 	end
 	
@@ -252,7 +252,7 @@ if CLIENT then
 	
 	-- Basic legacy GetOverlayText, is no longer used here but we leave it here in case other addons rely on it.
 	function ENT:GetOverlayText()
-		local name = self:GetNetworkedString("WireName")
+		local name = self:GetNWString("WireName")
 		if name == "" then name = self.PrintName end
 		local header = "- " .. name .. " -"
 		

--- a/lua/entities/gmod_wire_hologram.lua
+++ b/lua/entities/gmod_wire_hologram.lua
@@ -8,7 +8,7 @@ function ENT:SetPlayer(ply)
 	self:SetVar("Founder", ply)
 	self:SetVar("FounderIndex", ply:UniqueID())
 
-	self:SetNetworkedString("FounderName", ply:Nick())
+	self:SetNWString("FounderName", ply:Nick())
 end
 
 function ENT:GetPlayer()

--- a/lua/entities/gmod_wire_hudindicator/init.lua
+++ b/lua/entities/gmod_wire_hudindicator/init.lua
@@ -92,11 +92,11 @@ function ENT:HUDSetup(showinhud, huddesc, hudaddname, hudshowvalue, hudstyle, al
 
 		// Add name if desired
 		if (hudaddname) then
-			self:SetNetworkedString("WireName", huddesc)
-		elseif (self:GetNetworkedString("WireName") == huddesc) then
+			self:SetNWString("WireName", huddesc)
+		elseif (self:GetNWString("WireName") == huddesc) then
 			// Only remove it if the HUD Description was there
 			// because there might be another name on it
-			self:SetNetworkedString("WireName", "")
+			self:SetNWString("WireName", "")
 		end
 
 		// Adjust inputs accordingly

--- a/lua/entities/gmod_wire_indicator.lua
+++ b/lua/entities/gmod_wire_indicator.lua
@@ -75,7 +75,7 @@ function MakeWire7Seg( pl, Pos, Ang, Model, a, ar, ag, ab, aa, b, br, bg, bb, ba
 		Model = Model, frozen = frozen, nocollide = nocollide },
 		a, ar, ag, ab, aa, b, br, bg, bb, ba )
 		if IsValid(ent) then 
-			ent:SetNetworkedString("WireName", name) 
+			ent:SetNWString("WireName", name) 
 			duplicator.StoreEntityModifier( ent, "WireName", { name = name } )
 		end
 		return ent

--- a/lua/entities/gmod_wire_keypad.lua
+++ b/lua/entities/gmod_wire_keypad.lua
@@ -185,17 +185,17 @@ net.Receive("wire_keypad", function(netlen, ply)
 	local key = net.ReadUInt(4)
 	
 	if key == 10 then -- Reset
-		ent:SetNetworkedString("keypad_display", "")
+		ent:SetNWString("keypad_display", "")
 		ent:EmitSound("buttons/button14.wav")
 		ent.CurrentNum = 0
 	elseif key == 11 or ent.CurrentNum > 999 then -- Accept
 		local access = (ent.Password == util.CRC(ent.CurrentNum))
 		if access then
-			ent:SetNetworkedString("keypad_display", "y")
+			ent:SetNWString("keypad_display", "y")
 			Wire_TriggerOutput(ent, "Valid", 1)
 			ent:EmitSound("buttons/button9.wav")
 		else
-			ent:SetNetworkedString("keypad_display", "n")
+			ent:SetNWString("keypad_display", "n")
 			Wire_TriggerOutput(ent, "Invalid", 1)
 			ent:EmitSound("buttons/button8.wav")
 		end
@@ -203,7 +203,7 @@ net.Receive("wire_keypad", function(netlen, ply)
 		ent.CurrentNum = -1
 		timer.Create("wire_keypad_"..ent:EntIndex().."_"..tostring(access), 2, 1, function()
 			if IsValid(ent) then
-				ent:SetNetworkedString("keypad_display", "")
+				ent:SetNWString("keypad_display", "")
 				ent.CurrentNum = 0
 				if access then
 					Wire_TriggerOutput(ent, "Valid", 0)
@@ -216,9 +216,9 @@ net.Receive("wire_keypad", function(netlen, ply)
 		ent.CurrentNum = ent.CurrentNum * 10 + key
 		
 		if ent.Secure then
-			ent:SetNetworkedString("keypad_display", string.rep("*", string.len(ent.CurrentNum)))
+			ent:SetNWString("keypad_display", string.rep("*", string.len(ent.CurrentNum)))
 		else
-			ent:SetNetworkedString("keypad_display", tostring(ent.CurrentNum))
+			ent:SetNWString("keypad_display", tostring(ent.CurrentNum))
 		end
 		ent:EmitSound("buttons/button15.wav")
 	end

--- a/lua/entities/gmod_wire_thruster.lua
+++ b/lua/entities/gmod_wire_thruster.lua
@@ -9,11 +9,11 @@ WireLib.ThrusterNetEffects = {
 }
 
 function ENT:SetEffect( name )
-	self:SetNetworkedString( "Effect", name )
+	self:SetNWString( "Effect", name )
 	self.neteffect = WireLib.ThrusterNetEffects[ name ]
 end
 function ENT:GetEffect( name )
-	return self:GetNetworkedString( "Effect" )
+	return self:GetNWString( "Effect" )
 end
 
 function ENT:SetOn( boolon )

--- a/lua/entities/gmod_wire_vectorthruster.lua
+++ b/lua/entities/gmod_wire_vectorthruster.lua
@@ -5,11 +5,11 @@ ENT.RenderGroup 		= RENDERGROUP_BOTH -- TODO: this is only needed when they're a
 ENT.WireDebugName	= "Vector Thruster"
 
 function ENT:SetEffect( name )
-	self:SetNetworkedString( "Effect", name )
+	self:SetNWString( "Effect", name )
 	self.neteffect = WireLib.ThrusterNetEffects[ name ]
 end
 function ENT:GetEffect()
-	return self:GetNetworkedString( "Effect" )
+	return self:GetNWString( "Effect" )
 end
 
 function ENT:SetOn( boolon )

--- a/lua/weapons/gmod_tool/stools/wire_namer.lua
+++ b/lua/weapons/gmod_tool/stools/wire_namer.lua
@@ -15,7 +15,7 @@ TOOL.ClientConVar[ "name" ] = ""
 
 local function SetName( Player, Entity, Data )
 	if ( Data and Data.name ) then
-		Entity:SetNetworkedString("WireName", Data.name)
+		Entity:SetNWString("WireName", Data.name)
 		duplicator.StoreEntityModifier( Entity, "WireName", Data )
 	end
 end
@@ -28,7 +28,7 @@ function TOOL:LeftClick(trace)
 
 	local name = self:GetClientInfo("name")
 
-	//trace.Entity:SetNetworkedString("WireName", name)
+	//trace.Entity:SetNWString("WireName", name)
 
 	//made the WireName duplicatable entmod (TAD2020)
 	SetName( Player, trace.Entity, {name = name} )
@@ -41,7 +41,7 @@ function TOOL:RightClick(trace)
 	if (not trace.Entity:IsValid()) then return end
 	if (CLIENT) then return end
 
-	local name = trace.Entity:GetNetworkedString("WireName")
+	local name = trace.Entity:GetNWString("WireName")
 	if (not name) then return end
 
     self:GetOwner():ConCommand('wire_namer_name "' .. name .. '"')


### PR DESCRIPTION
- Changed [Entity:SetNetworkedString](http://wiki.garrysmod.com/page/Entity/SetNetworkedString) to [Entity:SetNWString](http://wiki.garrysmod.com/page/Entity/SetNWString)
- Changed [Entity:GetNetworkedString](http://wiki.garrysmod.com/page/Entity/GetNetworkedString) to [Entity:GetNWString](http://wiki.garrysmod.com/page/Entity/GetNWString)

Also removed trailing whitespace and lines with space only accidently. If it's somehow a big issue I'll remake the commit.
