### PR TITLE
Add wirelink:writeArray/TableSimple

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/wirelink.lua
+++ b/lua/entities/gmod_wire_expression2/core/wirelink.lua
@@ -107,6 +107,17 @@ local function WriteArray(entity, address, data)
 	return free_address
 end
 
+local function writeArraySimple(entity, address, data)
+	local written = 0
+	for index, value in pairs(data) do
+		if type(value) == "number" then
+			if not entity:WriteCell(address + index - 1, value) then return 0 end
+			written = written + 1
+		end
+	end
+	return written
+end
+
 /******************************************************************************/
 
 registerType("wirelink", "xwl", nil,
@@ -649,4 +660,15 @@ e2function number wirelink:writeTable(address, table data )
 	local ret = WriteArray(this,address,data.n)
 	wa_lookup = nil
 	return ret
+end
+
+--- Writes only an array's numeric elements into a piece of memory, without null termination, returns number of elements written
+e2function number wirelink:writeArraySimple(address, array data)
+	if not validWirelink(self, this) or not this.WriteCell then return 0 end
+	return writeArraySimple(this, address, data)
+end
+
+e2function number wirelink:writeTableSimple(address, table data)
+	if not validWirelink(self, this) or not this.WriteCell then return 0 end
+	return writeArraySimple(this, address, data.n)
 end


### PR DESCRIPTION
Fixes #879 by adding functions that only writes the numeric values of an array/table into memory,
nothing more, nothing less.

(As suggested in #1192)

~~Useful side effect of implementation: by mixing in other types such as strings, it allows to leave certain memory cells at their previous value.
`WL:wirteArraySimple(10,array(0,"",0,"",0))` only overwrites every other cell~~

Edit: now uses index as offset to the start, WL:writeArraySimple(10,array(1=13,3=4)) will write 13 to Cell 10 and 4 to Cell 12, and return 2 (Number of cells written)