### PR TITLE
Fix GravGunPunt hook calling without a player

### DIFF
--- a/lua/entities/gmod_wire_forcer.lua
+++ b/lua/entities/gmod_wire_forcer.lua
@@ -68,7 +68,7 @@ function ENT:Think()
 	}
 
 	if not IsValid(trace.Entity) then return end
-	if not gamemode.Call( "GravGunPunt", self:GetPlayer(), trace.Entity ) then return end
+	if self:GetPlayer():IsValid() and not gamemode.Call( "GravGunPunt", self:GetPlayer(), trace.Entity ) then return end
 
 	if trace.Entity:GetMoveType() == MOVETYPE_VPHYSICS then
 		local phys = trace.Entity:GetPhysicsObject()

--- a/lua/entities/gmod_wire_forcer.lua
+++ b/lua/entities/gmod_wire_forcer.lua
@@ -68,7 +68,7 @@ function ENT:Think()
 	}
 
 	if not IsValid(trace.Entity) then return end
-	if self:GetPlayer():IsValid() and not gamemode.Call( "GravGunPunt", self:GetPlayer(), trace.Entity ) then return end
+	if IsValid(self:GetPlayer()) and not gamemode.Call( "GravGunPunt", self:GetPlayer(), trace.Entity ) then return end
 
 	if trace.Entity:GetMoveType() == MOVETYPE_VPHYSICS then
 		local phys = trace.Entity:GetPhysicsObject()


### PR DESCRIPTION
Should it be block forcer completely if no owner.
I think the compromise should be everywhere that no hook gets called, but if the player is _nil_ then allow, otherwise block. This way wiremod can be used as world props.