### PR TITLE
Disable remote controller on non-pod controllers and while in a vehicle

### DIFF
--- a/lua/weapons/remotecontroller.lua
+++ b/lua/weapons/remotecontroller.lua
@@ -61,11 +61,11 @@ function SWEP:On()
 	local ply = self:GetOwner()
 	local lnk = self.Linked
 	if IsValid(lnk) and (lnk:GetClass() = "gmod_wire_pod" or lnk:GetClass() == "gmod_wire_adv_pod") and lnk:HasPly() then
-		if hook.Run("CanTool", ply, WireLib.dummytrace(self.Linked), "remotecontroller") then
-			if self.Linked.RC then
-				self.Linked:RCEject(self.Linked:GetPly())
+		if hook.Run("CanTool", ply, WireLib.dummytrace(lnk), "remotecontroller") then
+			if lnk.RC then
+				lnk:RCEject(self.Linked:GetPly())
 			else
-				self.Linked:GetPly():ExitVehicle()
+				lnk:GetPly():ExitVehicle()
 			end
 		else
 			ply:ChatPrint("Pod is in use.")
@@ -78,8 +78,8 @@ function SWEP:On()
 	ply:SetMoveType(MOVETYPE_NONE)
 	ply:DrawViewModel(false)
 
-	if IsValid(self.Linked) then
-		self.Linked:PlayerEntered(ply, self)
+	if IsValid(lnk) then
+		lnk:PlayerEntered(ply, self)
 	end
 end
 

--- a/lua/weapons/remotecontroller.lua
+++ b/lua/weapons/remotecontroller.lua
@@ -60,7 +60,7 @@ end
 function SWEP:On()
 	local ply = self:GetOwner()
 	local lnk = self.Linked
-	if IsValid(lnk) and (lnk:GetClass() = "gmod_wire_pod" or lnk:GetClass() == "gmod_wire_adv_pod") and lnk:HasPly() then
+	if IsValid(lnk) and (lnk:GetClass() == "gmod_wire_pod" or lnk:GetClass() == "gmod_wire_adv_pod") and lnk:HasPly() then
 		if hook.Run("CanTool", ply, WireLib.dummytrace(lnk), "remotecontroller") then
 			if lnk.RC then
 				lnk:RCEject(self.Linked:GetPly())

--- a/lua/weapons/remotecontroller.lua
+++ b/lua/weapons/remotecontroller.lua
@@ -59,8 +59,8 @@ end
 
 function SWEP:On()
 	local ply = self:GetOwner()
-
-	if self.Linked:HasPly() then
+	local lnk = self.Linked
+	if IsValid(lnk) and (lnk:GetClass() = "gmod_wire_pod" or lnk:GetClass() == "gmod_wire_adv_pod") and lnk:HasPly() then
 		if hook.Run("CanTool", ply, WireLib.dummytrace(self.Linked), "remotecontroller") then
 			if self.Linked.RC then
 				self.Linked:RCEject(self.Linked:GetPly())


### PR DESCRIPTION
Makes sure the remote controller cannot be used on anything else besides pods
Disable using this in vehicles a.k.a

Fixes #1287