### PR TITLE
Fix skin check in WireLib.CanModel

### DIFF
--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1071,7 +1071,7 @@ function WireLib.CanModel(player, model, skin)
 	if not util.IsValidModel(model) then return false end
 	if skin ~= nil then
 		local count = WireLib.NumModelSkins(model)
-		if count and count <= skin then return false end
+		if count and count < skin then return false end
 	end
 	if IsValid(player) and player:IsPlayer() and not hook.Run("PlayerSpawnObject", player, model, skin) then return false end
 	return true


### PR DESCRIPTION
Fixes #1325

We should only return false if it's more than the skin count, not if it's equal to.