### PR TITLE
Change holoModel to do skin check before setting the skin

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/hologram.lua
@@ -948,11 +948,11 @@ e2function void holoModel(index, string model, skin)
 	if not Holo then return end
 
 	skin = skin - skin % 1
-	Holo.ent:SetSkin(skin)
 
 	model = GetModel(model)
 	if not model or not WireLib.CanModel(self.player, model, skin) then return end
 
+	Holo.ent:SetSkin(skin)
 	Holo.ent:SetModel(model)
 end
 


### PR DESCRIPTION
Figured while I'm making the changes to the other checks and what not I'd change this.

Old method would set the skin before doing the sanity check. This could result in the skin being changed but not the model.

New method would set the skin and model after the sanity check. This follows correct logic.