### PR TITLE
Fixed include of [huddraw.lua] as the file is lower case

### DIFF
--- a/lua/entities/gmod_wire_egp_hud/init.lua
+++ b/lua/entities/gmod_wire_egp_hud/init.lua
@@ -1,8 +1,8 @@
 AddCSLuaFile("cl_init.lua")
 AddCSLuaFile("shared.lua")
-include('shared.lua')
-AddCSLuaFile("HUDDraw.lua")
-include("HUDDraw.lua")
+include("shared.lua")
+AddCSLuaFile("huddraw.lua")
+include("huddraw.lua")
 
 ENT.WireDebugName = "E2 Graphics Processor HUD"
 


### PR DESCRIPTION
Fixed the propper default quotes to double ones
Fixed proper inclusion of huddraw.lua under Linux/UNIX/Mac