### PR TITLE
Lower max force to stop crashes

### DIFF
--- a/lua/wire/wireshared.lua
+++ b/lua/wire/wireshared.lua
@@ -1004,8 +1004,9 @@ end
 -- Used by any applyForce function available to the user
 -- Ensures that the force is within the range of a float, to prevent
 -- physics engine crashes
-local min_force = -3.4E+38
-local max_force =  3.4E+38
+-- 2*maxmass*maxvelocity should be enough impulse to do whatever you want.
+local max_force = 100000*physenv.GetPerformanceSettings().MaxVelocity
+local min_force = -max_force
 function WireLib.checkForce(v)
 	if isvector(v) then
 		return 	min_force < v.x and v.x < max_force and

--- a/lua/wire/wireshared.lua
+++ b/lua/wire/wireshared.lua
@@ -1005,8 +1005,11 @@ end
 -- Ensures that the force is within the range of a float, to prevent
 -- physics engine crashes
 -- 2*maxmass*maxvelocity should be enough impulse to do whatever you want.
-local max_force = 100000*physenv.GetPerformanceSettings().MaxVelocity
-local min_force = -max_force
+local max_force, min_force
+hook.Add("InitPostEntity","WireForceLimit",function()
+	max_force = 100000*physenv.GetPerformanceSettings().MaxVelocity
+	min_force = -max_force
+end)
 function WireLib.checkForce(v)
 	if isvector(v) then
 		return 	min_force < v.x and v.x < max_force and


### PR DESCRIPTION
This should be enough impulse to reverse the direction of a max mass max velocity object. Right now, the current max force can cause crashes.