### PR TITLE
Add wire outputs "Capacity" and "DriveID" to HDD Flash EEPROM.

### DIFF
--- a/lua/entities/gmod_wire_hdd.lua
+++ b/lua/entities/gmod_wire_hdd.lua
@@ -17,7 +17,7 @@ function ENT:Initialize()
 	self:SetSolid(SOLID_VPHYSICS)
 	self:SetUseType(SIMPLE_USE)
 
-	self.Outputs = Wire_CreateOutputs(self, { "Data" })
+	self.Outputs = Wire_CreateOutputs(self, { "Data", "Capacity", "DriveID" })
 	self.Inputs = Wire_CreateInputs(self, { "Clk", "AddrRead", "AddrWrite", "Data" })
 
 	self.Clk = 0
@@ -53,6 +53,8 @@ function ENT:Setup(DriveID, DriveCap)
 	self.DriveID = DriveID
 	self.DriveCap = DriveCap
 	self:UpdateCap()
+	self:SetOverlayText(self.DriveCap.."kb".."\nWriteAddr:"..self.AWrite.."  Data:"..self.Data.."  Clock:"..self.Clk.."\nReadAddr:"..self.ARead.." = ".. self.Out)
+	Wire_TriggerOutput(self, "DriveID", self.DriveID) 
 end
 
 function ENT:GetStructName(name)
@@ -106,6 +108,8 @@ function ENT:UpdateCap()
 	end
 
 	self:GetCap()
+
+	Wire_TriggerOutput(self, "Capacity", self.DriveCap) 
 end
 
 function ENT:GetFloatTable(Text)


### PR DESCRIPTION
Also fixing hud not displaying after spawn before any action.
---------------------------
This changes will make possibility to do automatic detection and error check for custom scripts what use those flash as hdd bank. Without this information you need specify values manually to script and have no any error checking.