### PR TITLE
Save memory/reduce dupe size of DHDD

### DIFF
--- a/lua/entities/gmod_wire_dhdd.lua
+++ b/lua/entities/gmod_wire_dhdd.lua
@@ -36,7 +36,7 @@ function ENT:WriteCell( Address, value )
 	if Address < 0 or Address >= 262144 then return false end
 
 	if self.AllowWrite then
-		self.Memory[Address] = value!=0 and value or nil
+		self.Memory[Address] = value ~= 0 and value or nil
 	end
 	self:ShowOutputs()
 	return true

--- a/lua/entities/gmod_wire_dhdd.lua
+++ b/lua/entities/gmod_wire_dhdd.lua
@@ -36,7 +36,7 @@ function ENT:WriteCell( Address, value )
 	if Address < 0 or Address >= 262144 then return false end
 
 	if self.AllowWrite then
-		self.Memory[Address] = value
+		self.Memory[Address] = value!=0 and value or nil
 	end
 	self:ShowOutputs()
 	return true


### PR DESCRIPTION
Don't store zeros in table to make bit less memory usage and reduce dupe file size.