### PR TITLE
Fixes WireLib.GetVersion to respect load priority

### DIFF
--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1183,14 +1183,6 @@ function WireLib.GetVersion()
 	-- If we've already found our version just return that again
 	if cachedversion then return cachedversion end
 
-	-- Check if we're Workshop version first
-	for k, addon in pairs(engine.GetAddons()) do
-		if addon.wsid == "160250458" then
-			cachedversion = "Workshop"
-			return cachedversion
-		end
-	end
-
 	-- Find what our legacy folder is called
 	local wirefolder = "addons/wire"
 	if not file.Exists(wirefolder, "GAME") then
@@ -1216,6 +1208,14 @@ function WireLib.GetVersion()
 			end
 		else
 			cachedversion = "Extracted"
+		end
+	end
+
+	-- Check if we're Workshop version first
+	for k, addon in pairs(engine.GetAddons()) do
+		if addon.wsid == "160250458" then
+			cachedversion = "Workshop"
+			return cachedversion
 		end
 	end
 


### PR DESCRIPTION
This changes the function to respect load priority (when subscribed to workshop+using legacy install)
#1351