### PR TITLE
Fixed E2 Compiler error

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -651,7 +651,7 @@ end
 
 function Compiler:InstrNUM(args)
 	self.prfcounter = self.prfcounter + 0.5
-	RunString("Compiler.native = function() return " .. args[3] .. " end")
+	RunString("E2Lib.Compiler.native = function() return " .. args[3] .. " end")
 	return { Compiler.native }, "n"
 end
 
@@ -678,14 +678,14 @@ end
 
 function Compiler:InstrSTR(args)
 	self.prfcounter = self.prfcounter + 1.0
-	RunString(string.format("Compiler.native = function() return %q end", args[3]))
+	RunString(string.format("E2Lib.Compiler.native = function() return %q end", args[3]))
 	return { Compiler.native }, "s"
 end
 
 function Compiler:InstrVAR(args)
 	self.prfcounter = self.prfcounter + 1.0
 	local tp, ScopeID = self:GetVariableType(args, args[3])
-	RunString(string.format("Compiler.native = function(self) return self.Scopes[%i][%q] end", ScopeID, args[3])) -- This Line!
+	RunString(string.format("E2Lib.Compiler.native = function(self) return self.Scopes[%i][%q] end", ScopeID, args[3])) -- This Line!
 	return { Compiler.native }, tp
 end
 


### PR DESCRIPTION
this error was caused by movement of base components into E2Lib, commit: https://github.com/wiremod/wire/commit/e483a4b3f965dab57b0d4aeb2097cf1b83f1f684