### PR TITLE
Use a minimal containerized Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,9 @@ before_install:
   - source $HOME/env/bin/activate
 
 install:
-  - luarocks install lanes
-  - luarocks install luacheck
+  - luarocks show lanes > /dev/null || luarocks install lanes
+  - luarocks show luacheck > /dev/null || luarocks install luacheck
+  - luarocks list --outdated --porcelain | awk '{ print $1, $3 }' | xargs --no-run-if-empty -n 2 luarocks install
 
 script:
   - git diff --check $TRAVIS_COMMIT_RANGE

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
   - source $HOME/env/bin/activate
 
 install:
+  - luarocks install lanes
   - luarocks install luacheck
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ dist: trusty
 sudo: false
 language: c
 
+branches:
+  only:
+    - master
+
 cache:
   directories:
     - $HOME/env

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,14 @@ dist: trusty
 sudo: false
 language: c
 
+cache:
+  directories:
+    - $HOME/env
+
 before_install:
   - pip install hererocks
-  - hererocks env --luajit 2.0.3 --luarocks latest
-  - source env/bin/activate
+  - hererocks $HOME/env --luajit 2.0.3 --luarocks latest
+  - source $HOME/env/bin/activate
 
 install:
   - luarocks install luacheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-language: python
+dist: trusty
+sudo: false
+language: c
 
 before_install:
   - pip install hererocks


### PR DESCRIPTION
These set of options should cause Travis to build using a fast-start Docker container, which should knock off a considerable amount of time off Travis builds.