### PR TITLE
Add "array=entity:children()" E2 function (Fixes #1389)

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/constraint.lua
+++ b/lua/entities/gmod_wire_expression2/core/constraint.lua
@@ -157,3 +157,10 @@ e2function bone entity:parentBone()
 	local bonenum = this:GetParentPhysNum()
 	return getBone(ent, bonenum)
 end
+
+__e2setcost(20)
+
+--- Returns an '''array''' containing all the children of the entity - that is, every entity whose parent is this entity.
+e2function array entity:children()
+	return IsValid(this) and this:GetChildren() or {}
+end

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -908,6 +908,7 @@ E2Helper.Descriptions["isConstrainedTo(e:s)"] = "Returns the first entity E was 
 E2Helper.Descriptions["isConstrainedTo(e:sn)"] = "Returns the Nth entity E was constrained to with the given constraint type (see the types list below)"
 E2Helper.Descriptions["parent(e:)"] = "Returns the entity E is parented to"
 E2Helper.Descriptions["parentBone(e:)"] = "Returns the bone E is parented to"
+E2Helper.Descriptions["children(e:)"] = "Returns an array containing all the children of the entity - that is, every entity whose parent is this entity"
 
 -- Chat
 E2Helper.Descriptions["chatClk()"] = "Returns 1 if the chip is being executed because of a chat event. Returns 0 otherwise"


### PR DESCRIPTION
Fixes #1389.

This pull request (after merged) would add the following to Expression 2 gate:

![new](https://cloud.githubusercontent.com/assets/9789070/16093393/024dce8a-333c-11e6-9ac4-71a0c0a3de2d.png) Functions:

| Signature | Description | Cost |
| --- | --- | --- |
| `array=entity:children()` | Returns an array containing all the children of the entity - that is, every entity whose parent is this entity | 20 |