### PR TITLE
Add optional key type for foreach

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -315,6 +315,23 @@ function Parser:Stmt4()
 		end
 		local keyvar = self:GetTokenData()
 
+		local keytype
+
+		if self:AcceptRoamingToken("col") then
+			if not self:AcceptRoamingToken("fun") then
+				self:Error("Type expected after colon")
+			end
+
+			keytype = self:GetTokenData()
+			if keytype == "number" then keytype = "normal" end
+
+			if wire_expression_types[string.upper(keytype)] == nil then
+				self:Error("Unknown type: " .. keytype)
+			end
+
+			keytype = wire_expression_types[string.upper(keytype)][1]
+		end
+
 		if not self:AcceptRoamingToken("com") then
 			self:Error("Comma (,) expected after key variable")
 		end
@@ -348,7 +365,7 @@ function Parser:Stmt4()
 			self:Error("Missing right parenthesis after foreach statement")
 		end
 
-		local sfea = self:Instruction(trace, "fea", keyvar, valvar, valtype, tableexpr, self:Block("foreach statement"))
+		local sfea = self:Instruction(trace, "fea", keyvar, keytype, valvar, valtype, tableexpr, self:Block("foreach statement"))
 		loopdepth = loopdepth - 1
 		return sfea
 	end

--- a/lua/entities/gmod_wire_expression2/core/array.lua
+++ b/lua/entities/gmod_wire_expression2/core/array.lua
@@ -259,6 +259,42 @@ registerCallback( "postinit", function()
 				return getter( self, array, index, true )
 			end)
 
+			--------------------------------------------------------------------------------
+			-- Foreach operators
+			--------------------------------------------------------------------------------
+			__e2setcost(0)
+
+			registerOperator("fea", "n" .. id .. "r", "", function(self, args)
+				local keyname, valname = args[2], args[3]
+
+				local tbl = args[4]
+				tbl = tbl[1](self, tbl)
+
+				local statement = args[5]
+
+				for key, value in pairs(tbl) do
+					if not typecheck(value) then
+						self:PushScope()
+
+						self.prf = self.prf + 3
+
+						self.Scope.vclk[keyname] = true
+						self.Scope.vclk[valname] = true
+
+						self.Scope[keyname] = key
+						self.Scope[valname] = value
+
+						local ok, msg = pcall(statement[1], self, statement)
+
+						if not ok then
+							if msg == "break" then	self:PopScope() break
+							elseif msg ~= "continue" then self:PopScope() error(msg, 0) end
+						end
+
+						self:PopScope()
+					end
+				end
+			end)
 
 		end -- blocked check end
 	end

--- a/lua/entities/gmod_wire_expression2/core/core.lua
+++ b/lua/entities/gmod_wire_expression2/core/core.lua
@@ -108,49 +108,6 @@ registerOperator("for", "", "", function(self, args)
 
 end)
 
-registerOperator("fea","r","",function(self,args)
-	local keyname,valname,valtypeid = args[2],args[3],args[4]
-	local tbl = args[5]
-	tbl = tbl[1](self,tbl)
-	local statement = args[6]
-
-	local typechecker = wire_expression_types2[valtypeid][6]
-
-	local keys = {}
-	local count = 0
-	for key,value in pairs(tbl) do
-		if not typechecker(value) then
-			count = count + 1
-			keys[count] = key
-		end
-	end
-
-	for i=1,count do
-		self:PushScope()
-		local key = keys[i]
-		if tbl[key] ~= nil then
-			self.prf = self.prf + 3
-
-			self.Scope[keyname] = key
-			self.Scope[valname] = tbl[key]
-			self.Scope.vclk[keyname] = true
-			self.Scope.vclk[valname] = true
-
-			local ok, msg = pcall(statement[1], self, statement)
-			if not ok then
-				if msg == "break" then
-					self:PopScope()
-					break
-				elseif msg ~= "continue" then
-					self:PopScope()
-					error(msg, 0)
-				end
-			end
-		end
-		self:PopScope()
-	end
-end)
-
 __e2setcost(2) -- approximation
 
 registerOperator("brk", "", "", function(self, args)

--- a/lua/entities/gmod_wire_expression2/core/globalvars.lua
+++ b/lua/entities/gmod_wire_expression2/core/globalvars.lua
@@ -51,45 +51,6 @@ registerOperator("ass", "xgt", "xgt", function(self, args)
 	return rhs
 end)
 
-registerOperator("fea","xgt","",function(self,args)
-	local keyname,valname,valtypeid = args[2],args[3],args[4]
-	local tbl = args[5]
-	tbl = tbl[1](self,tbl)
-	local statement = args[6]
-
-	local len = valtypeid:len()
-
-	local keys = {}
-	local count = 0
-	for key,_ in pairs(tbl) do
-		if key:sub(1,len) == valtypeid then
-			count = count + 1
-			keys[count] = key
-		end
-	end
-
-	for i=1,count do
-		self:PushScope()
-		local key = keys[i]
-		if tbl[key] ~= nil then
-			self.prf = self.prf + 3
-
-			self.Scope.vclk[keyname] = true
-			self.Scope.vclk[valname] = true
-
-			self.Scope[keyname] = key:sub(len+1)
-			self.Scope[valname] = tbl[key]
-
-			local ok, msg = pcall(statement[1], self, statement)
-			if not ok then
-				if msg == "break" then self:PopScope() break
-				elseif msg ~= "continue" then self:PopScope() error(msg, 0) end
-			end
-		end
-		self:PopScope()
-	end
-end)
-
 e2function number operator_is( gtable tbl )
 	return istable(tbl) and 1 or 0
 end
@@ -194,6 +155,7 @@ registerCallback("postinit",function()
 			if (k == "NORMAL") then k = "NUMBER" end
 			k = upperfirst(k)
 
+			__e2setcost(5)
 
 			-- Table[index,type] functions
 			local function getf( self, args )
@@ -262,6 +224,44 @@ registerCallback("postinit",function()
 						end
 					end
 				end
+			end)
+
+			--------------------------------------------------------------------------------
+			-- gTable converts all numeric indexes to strings, so we can only support iterating string keys
+			--------------------------------------------------------------------------------
+			__e2setcost(1)
+
+			registerOperator("fea", "s" .. v[1] .. "xgt", "", function(self, args)
+				local keyname, valname = args[2], args[3]
+
+				local tbl = args[4]
+				tbl = tbl[1](self, tbl)
+
+				local statement = args[5]
+				local len = #v[1]
+
+				for key, value in pairs(tbl) do
+					if key:sub(1, len) == v[1] then
+						self:PushScope()
+
+						self.prf = self.prf + 3
+
+						self.Scope.vclk[keyname] = true
+						self.Scope.vclk[valname] = true
+
+						self.Scope[keyname] = key:sub(len + 1)
+						self.Scope[valname] = value
+
+						local ok, msg = pcall(statement[1], self, statement)
+
+						if not ok then
+							if msg == "break" then	self:PopScope() break
+							elseif msg ~= "continue" then self:PopScope() error(msg, 0) end
+						end
+
+						self:PopScope()
+					end
+				end			
 			end)
 
 		end -- allowed check

--- a/lua/entities/gmod_wire_expression2/core/table.lua
+++ b/lua/entities/gmod_wire_expression2/core/table.lua
@@ -289,43 +289,6 @@ end
 
 __e2setcost(nil)
 
-registerOperator("fea","t","",function(self,args)
-	local keyname,valname,valtypeid = args[2],args[3],args[4]
-	local tbl = args[5]
-	tbl = tbl[1](self,tbl)
-	local statement = args[6]
-
-	local keys = {}
-	local count = 0
-	for key,_ in pairs(tbl.s) do
-		if (tbl.stypes[key] == valtypeid) then
-			count = count + 1
-			keys[count] = key
-		end
-	end
-
-	for i=1, count do
-		self:PushScope()
-		local key = keys[i]
-		if tbl.s[key] ~= nil then
-			self.prf = self.prf + 3
-
-			self.Scope.vclk[keyname] = true
-			self.Scope.vclk[valname] = true
-
-			self.Scope[keyname] = key
-			self.Scope[valname] = tbl.s[key]
-
-			local ok, msg = pcall(statement[1], self, statement)
-			if not ok then
-				if msg == "break" then self:PopScope() break
-				elseif msg ~= "continue" then self:PopScope() error(msg, 0) end
-			end
-		end
-		self:PopScope()
-	end
-end)
-
 registerOperator( "kvtable", "", "t", function( self, args )
 	local ret = table.Copy( DEFAULT )
 
@@ -1155,6 +1118,74 @@ registerCallback( "postinit", function()
 			return rv2
 		end)
 
+		--------------------------------------------------------------------------------
+		-- Foreach operators
+		--------------------------------------------------------------------------------
+		__e2setcost(nil)
+
+		registerOperator("fea", "s" .. id .. "t", "", function(self, args)
+			local keyname, valname = args[2], args[3]
+
+			local tbl = args[4]
+			tbl = tbl[1](self, tbl)
+
+			local statement = args[5]
+
+			for key, value in pairs(tbl.s) do
+				if tbl.stypes[key] == id then
+					self:PushScope()
+
+					self.prf = self.prf + 3
+
+					self.Scope.vclk[keyname] = true
+					self.Scope.vclk[valname] = true
+
+					self.Scope[keyname] = key
+					self.Scope[valname] = value
+
+					local ok, msg = pcall(statement[1], self, statement)
+
+					if not ok then
+						if msg == "break" then	self:PopScope() break
+						elseif msg ~= "continue" then self:PopScope() error(msg, 0) end
+					end
+
+					self:PopScope()
+				end
+			end
+		end)
+
+		registerOperator("fea", "n" .. id .. "t", "", function(self, args)
+			local keyname, valname = args[2], args[3]
+
+			local tbl = args[4]
+			tbl = tbl[1](self, tbl)
+
+			local statement = args[5]
+
+			for key, value in pairs(tbl.n) do
+				if tbl.ntypes[key] == id then
+					self:PushScope()
+
+					self.prf = self.prf + 3
+
+					self.Scope.vclk[keyname] = true
+					self.Scope.vclk[valname] = true
+
+					self.Scope[keyname] = key
+					self.Scope[valname] = value
+
+					local ok, msg = pcall(statement[1], self, statement)
+
+					if not ok then
+						if msg == "break" then	self:PopScope() break
+						elseif msg ~= "continue" then self:PopScope() error(msg, 0) end
+					end
+
+					self:PopScope()
+				end
+			end
+		end)
 
 		end -- blocked check end
 

--- a/lua/wire/client/text_editor/modes/e2.lua
+++ b/lua/wire/client/text_editor/modes/e2.lua
@@ -204,7 +204,7 @@ function EDITOR:SyntaxColorLine(row)
   self:ResetTokenizer(row)
   self:NextCharacter()
 
-  -- 0=name 1=port 2=trigger 3=foreach
+  -- 0=name 1=port 2=trigger 3=foreach 4=foreachkey 5=foreachvalue
   local highlightmode = nil
 
   if self.blockcomment then
@@ -420,9 +420,12 @@ function EDITOR:SyntaxColorLine(row)
           tokenname = "typename"
         elseif highlightmode == 2 and (sstr == "all" or sstr == "none") then
           tokenname = "directive"
-        elseif highlightmode == 3 and istype(sstr) then
+        elseif (highlightmode == 4 or highlightmode == 5) and istype(sstr) then
           tokenname = "typename"
-          highlightmode = nil
+
+          if highlightmode == 5 then
+            highlightmode = nil
+          end
         else
           tokenname = "notfound"
         end
@@ -480,6 +483,11 @@ function EDITOR:SyntaxColorLine(row)
     elseif self:NextPattern("^[A-Z][a-zA-Z0-9_]*") then
       tokenname = "variable"
 
+      if highlightmode == 3 then
+        highlightmode = 4
+      elseif highlightmode == 4 then
+        highlightmode = 5
+      end
     elseif self.character == '"' then
       self:NextCharacter()
       while self.character do -- Find the ending "


### PR DESCRIPTION
Fixes #1060 

Will allow you to specify the type of key used when iterating a value. If no type is specified it'll fallback to the way this used to work. Because of the way I'm adding this it made more sense to separate different operator types.

There's one small bug in the text editor when using this. If you specify a key type the highlighting of the value type turns to that of a function. I looked around a bit and couldn't find out the cause of this.

![](https://i.imgur.com/2LWVkFa.png)

