### PR TITLE
Add Entity:creationID()

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -89,6 +89,11 @@ e2function number entity:id()
 	return this:EntIndex()
 end
 
+e2function number entity:creationID()
+	if not IsValid(this) then return 0 end
+	return this:GetCreationID()
+end
+
 /******************************************************************************/
 // Functions getting string
 


### PR DESCRIPTION
https://wiki.garrysmod.com/page/Entity/GetCreationID

Asked a poll of 5 people. They preferred `creationID` to `creationId()` and `getCreationID()`... etc