### PR TITLE
Convert RunString to lambda function in compiler

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -685,8 +685,11 @@ end
 function Compiler:InstrVAR(args)
 	self.prfcounter = self.prfcounter + 1.0
 	local tp, ScopeID = self:GetVariableType(args, args[3])
-	RunString(string.format("E2Lib.Compiler.native = function(self) return self.Scopes[%i][%q] end", ScopeID, args[3])) -- This Line!
-	return { Compiler.native }, tp
+	local name = args[3]
+
+	return {function(self)
+		return self.Scopes[ScopeID][name]
+	end}, tp
 end
 
 function Compiler:InstrFEA(args)


### PR DESCRIPTION
Fixes #1150 

As far as I can tell everything will work the same, only difference is things like `math.huge` should be handled correctly. The `InstrSTR` should work the same, and did in my testing, though if someone else could do the same to confirm.

If you want I can also add the `math.huge` constant as an extra commit here, though I figured it'd be better in a separate pr.