### PR TITLE
Use Point filtering for gpulib screens

### DIFF
--- a/lua/wire/gpulib.lua
+++ b/lua/wire/gpulib.lua
@@ -344,7 +344,14 @@ if CLIENT then
 
 				surface.SetDrawColor(255,255,255,255)
 				surface.SetMaterial(WireGPU_matScreen)
+
+				render.PushFilterMag(TEXFILTER.POINT)
+				render.PushFilterMin(TEXFILTER.POINT)
+
 				self.DrawScreen(x, y, w, h, rotation or 0, scale or 0)
+
+				render.PopFilterMin()
+				render.PopFilterMag()
 
 				if postrenderfunction then postrenderfunction(pos, ang, res, aspect, monitor) end
 			end, debug.traceback)


### PR DESCRIPTION
With point filtering the borders around the pixels look more sharp. It turns for example on digitalscreen ![](https://u.teknik.io/fu6bz.jpg) to ![](https://u.teknik.io/5I7IW.jpg)  
This works of course on any gpulib screen, not only on digitalscreen