### PR TITLE
Create a convar for the Cpu's max frequency

### DIFF
--- a/lua/entities/gmod_wire_cpu.lua
+++ b/lua/entities/gmod_wire_cpu.lua
@@ -10,7 +10,7 @@ local cpu_max_frequency = 1400000
 local wire_cpu_max_frequency = CreateConVar("wire_cpu_max_frequency", cpu_max_frequency, FCVAR_REPLICATED)
 
 cvars.AddChangeCallback("wire_cpu_max_frequency",function()
-	cpu_max_frequency = wire_cpu_max_frequency:GetInt()
+ 	cpu_max_frequency = math.Clamp(math.floor(wire_cpu_max_frequency:GetInt()),1,30000000)
 end)
 
 function ENT:Initialize()
@@ -25,7 +25,6 @@ function ENT:Initialize()
 	self.Clk = false -- whether the Clk input is on
 	self.VMStopped = false -- whether the VM has halted itself (e.g. by running off the end of the program)
 	self.Frequency = 2000
-
 	-- Create virtual machine
 	self.VM = CPULib.VirtualMachine()
 	self.VM.SerialNo = CPULib.GenerateSN("CPU")
@@ -195,6 +194,7 @@ function ENT:Run()
 end
 
 function ENT:Think()
+	if (not game.SinglePlayer()) and (self.Frequency > cpu_max_frequency) then self.Frequency = cpu_max_frequency end
 	self:Run()
 	if self.Clk and not self.VMStopped then self:NextThink(CurTime()) end
 	return true
@@ -267,7 +267,6 @@ function ENT:TriggerInput(iname, value)
 			self:NextThink(CurTime())
 		end
 	elseif iname == "Frequency" then
-		if (not game.SinglePlayer()) and (value > cpu_max_frequency) then self.Frequency = cpu_max_frequency return end
 		if value > 0 then self.Frequency = math.floor(value) end
 	elseif iname == "Reset" then   --VM may be nil
 		if self.VM.HWDEBUG ~= 0 then

--- a/lua/entities/gmod_wire_cpu.lua
+++ b/lua/entities/gmod_wire_cpu.lua
@@ -4,7 +4,19 @@ ENT.PrintName       = "Wire ZCPU"
 ENT.Author          = "Black Phoenix"
 ENT.WireDebugName	= "ZCPU"
 
+CreateConVar("wire_cpu_max_frequency", "1400000", {FCVAR_REPLICATED})
+
 if CLIENT then return end -- No more client
+
+cpu_max_frequency = nil
+
+do
+	function updateCPUMaxFrequency()
+		cpu_max_frequency = GetConVar("wire_cpu_max_frequency"):GetInt()
+	end
+	cvars.AddChangeCallback("wire_cpu_max_frequency",updateCPUMaxFrequency)
+	updateCPUMaxFrequency()
+end
 
 function ENT:Initialize()
 	self:PhysicsInit(SOLID_VPHYSICS)
@@ -260,7 +272,7 @@ function ENT:TriggerInput(iname, value)
 			self:NextThink(CurTime())
 		end
 	elseif iname == "Frequency" then
-		if (not game.SinglePlayer()) and (value > 1400000) then self.Frequency = 1400000 return end
+		if (not game.SinglePlayer()) and (value > cpu_max_frequency) then self.Frequency = cpu_max_frequency return end
 		if value > 0 then self.Frequency = math.floor(value) end
 	elseif iname == "Reset" then   --VM may be nil
 		if self.VM.HWDEBUG ~= 0 then

--- a/lua/entities/gmod_wire_cpu.lua
+++ b/lua/entities/gmod_wire_cpu.lua
@@ -8,7 +8,7 @@ CreateConVar("wire_cpu_max_frequency", "1400000", {FCVAR_REPLICATED})
 
 if CLIENT then return end -- No more client
 
-cpu_max_frequency = nil
+local cpu_max_frequency = nil
 
 do
 	local function updateCPUMaxFrequency()

--- a/lua/entities/gmod_wire_cpu.lua
+++ b/lua/entities/gmod_wire_cpu.lua
@@ -9,7 +9,7 @@ ENT.WireDebugName	= "ZCPU"
 if CLIENT then return end -- No more client
 
 local cpu_max_frequency = 1400000
-CreateConVar("wire_cpu_max_frequency", "1400000", FCVAR_REPLICATED)
+CreateConVar("wire_cpu_max_frequency", cpu_max_frequency, FCVAR_REPLICATED)
 
 cvars.AddChangeCallback("wire_cpu_max_frequency",function()
 	cpu_max_frequency = GetConVar("wire_cpu_max_frequency"):GetInt()

--- a/lua/entities/gmod_wire_cpu.lua
+++ b/lua/entities/gmod_wire_cpu.lua
@@ -11,7 +11,7 @@ if CLIENT then return end -- No more client
 cpu_max_frequency = nil
 
 do
-	function updateCPUMaxFrequency()
+	local function updateCPUMaxFrequency()
 		cpu_max_frequency = GetConVar("wire_cpu_max_frequency"):GetInt()
 	end
 	cvars.AddChangeCallback("wire_cpu_max_frequency",updateCPUMaxFrequency)

--- a/lua/entities/gmod_wire_cpu.lua
+++ b/lua/entities/gmod_wire_cpu.lua
@@ -4,17 +4,16 @@ ENT.PrintName       = "Wire ZCPU"
 ENT.Author          = "Black Phoenix"
 ENT.WireDebugName	= "ZCPU"
 
-CreateConVar("wire_cpu_max_frequency", "1400000", FCVAR_REPLICATED)
+
 
 if CLIENT then return end -- No more client
 
 local cpu_max_frequency = 1400000
+CreateConVar("wire_cpu_max_frequency", "1400000", FCVAR_REPLICATED)
 
 cvars.AddChangeCallback("wire_cpu_max_frequency",function()
 	cpu_max_frequency = GetConVar("wire_cpu_max_frequency"):GetInt()
 end)
-
-end
 
 function ENT:Initialize()
 	self:PhysicsInit(SOLID_VPHYSICS)

--- a/lua/entities/gmod_wire_cpu.lua
+++ b/lua/entities/gmod_wire_cpu.lua
@@ -4,18 +4,16 @@ ENT.PrintName       = "Wire ZCPU"
 ENT.Author          = "Black Phoenix"
 ENT.WireDebugName	= "ZCPU"
 
-CreateConVar("wire_cpu_max_frequency", "1400000", {FCVAR_REPLICATED})
+CreateConVar("wire_cpu_max_frequency", "1400000", FCVAR_REPLICATED)
 
 if CLIENT then return end -- No more client
 
-local cpu_max_frequency = nil
+local cpu_max_frequency = 1400000
 
-do
-	local function updateCPUMaxFrequency()
-		cpu_max_frequency = GetConVar("wire_cpu_max_frequency"):GetInt()
-	end
-	cvars.AddChangeCallback("wire_cpu_max_frequency",updateCPUMaxFrequency)
-	updateCPUMaxFrequency()
+cvars.AddChangeCallback("wire_cpu_max_frequency",function()
+	cpu_max_frequency = GetConVar("wire_cpu_max_frequency"):GetInt()
+end)
+
 end
 
 function ENT:Initialize()

--- a/lua/entities/gmod_wire_cpu.lua
+++ b/lua/entities/gmod_wire_cpu.lua
@@ -4,15 +4,13 @@ ENT.PrintName       = "Wire ZCPU"
 ENT.Author          = "Black Phoenix"
 ENT.WireDebugName	= "ZCPU"
 
-
-
 if CLIENT then return end -- No more client
 
 local cpu_max_frequency = 1400000
-CreateConVar("wire_cpu_max_frequency", cpu_max_frequency, FCVAR_REPLICATED)
+local wire_cpu_max_frequency = CreateConVar("wire_cpu_max_frequency", cpu_max_frequency, FCVAR_REPLICATED)
 
 cvars.AddChangeCallback("wire_cpu_max_frequency",function()
-	cpu_max_frequency = GetConVar("wire_cpu_max_frequency"):GetInt()
+	cpu_max_frequency = wire_cpu_max_frequency:GetInt()
 end)
 
 function ENT:Initialize()


### PR DESCRIPTION
Hello Wiremod Community
i wanted to added a little modification for the cpu.
To explain , i found frustrating being able to change the performance of the expression 2 by some convar and not being able to change this for the cpu , the cpu willing to be more powerfull than the expression 2, finding to be beaten by far by it on some server.
So instead of a hardcoded max frequency for the cpu , i've edited the code to be able to change a convar while in game who will change the max frequency of the cpu live, so the server owner can choose the max frequency. 
Whethever you would not accept the change , could you tell me why ?
Thanks you all
Mms92