### PR TITLE
E2: Added 4 new entity-related functions

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -346,6 +346,26 @@ e2function number entity:isValidPhysics()
 	return E2Lib.validPhysics(this) and 1 or 0
 end
 
+e2function number entity:getEFlags()
+	-- https://wiki.garrysmod.com/page/Enums/EFL
+	return this:GetEFlags() or 0 -- this:GetSaveTable().m_iEFlags or 0
+end
+
+e2function number entity:isEFlagSet(flag)
+	-- https://wiki.garrysmod.com/page/Enums/EFL
+	return this:IsEFlagSet(flag) and 1 or 0
+end
+
+e2function number entity:getFlags()
+	-- https://wiki.garrysmod.com/page/Enums/FL
+	return this:GetFlags() or 0 -- this:GetSaveTable().m_fFlags or 0
+end
+
+e2function number entity:isFlagSet(flag)
+	-- https://wiki.garrysmod.com/page/Enums/FL
+	return this:IsFlagSet(flag) and 1 or 0
+end
+
 /******************************************************************************/
 // Functions getting angles
 

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -323,7 +323,10 @@ E2Helper.Descriptions["runOnPlayerDisconnect(n)"] = "If set to 0, the chip will 
 E2Helper.Descriptions["playerConnectClk()"] = "Returns 1 if the chip is being executed because of a player connect event. Returns 0 otherwise"
 E2Helper.Descriptions["lastConnectedPlayer()"] = "Returns the last player to connect."
 E2Helper.Descriptions["runOnPlayerConnect(n)"] = "If set to 0, the chip will no longer run on player connect events, otherwise it makes this chip execute when someone connects. Only needs to be called once, not in every execution"
-
+E2Helper.Descriptions["getEFlags(e:)"] = "Returns a bit flag of all engine flags of the entity"
+E2Helper.Descriptions["isEFlagSet(e:n)"] = "Checks if given engine flag is set or not"
+E2Helper.Descriptions["getFlags(e:)"] = "Returns all flags of given entity"
+E2Helper.Descriptions["isFlagSet(e:n)"] = "Checks if given flag is set or not"
 
 -- Attachment
 E2Helper.Descriptions["lookupAttachment(e:s)"] = "Returns Es attachment ID associated with attachmentName"


### PR DESCRIPTION
![new](https://user-images.githubusercontent.com/9789070/28845819-86859518-7709-11e7-8e33-a560bba62892.png) `number=entity:getEFlags()`: Returns a bit flag of all engine flags of the entity.

![new](https://user-images.githubusercontent.com/9789070/28845819-86859518-7709-11e7-8e33-a560bba62892.png) `number=entity:isEFlagSet(number)`: Checks if given engine flag is set or not.

![new](https://user-images.githubusercontent.com/9789070/28845819-86859518-7709-11e7-8e33-a560bba62892.png) `number=entity:getFlags()`: Returns all flags of given entity.

![new](https://user-images.githubusercontent.com/9789070/28845819-86859518-7709-11e7-8e33-a560bba62892.png) `number=entity:isFlagSet(number)`: Checks if given flag is set or not.

-----

Additionally I could also register [EFL](https://wiki.garrysmod.com/page/Enums/EFL)/[FL](https://wiki.garrysmod.com/page/Enums/FL) enums as E2 constants, just say so if you want me to (I should probably do it without asking to avoid *hardcoding* issues with E2s).