### PR TITLE
simplified address bus setup

### DIFF
--- a/lua/entities/gmod_wire_addressbus.lua
+++ b/lua/entities/gmod_wire_addressbus.lua
@@ -26,16 +26,14 @@ function ENT:Initialize()
 	self:SetOverlayText("Data rate: 0 bps")
 end
 
-function ENT:Setup(Mem1st, Mem2st, Mem3st, Mem4st, Mem1sz, Mem2sz, Mem3sz, Mem4sz)
-	local starts = {Mem1st,Mem2st,Mem3st,Mem4st}
+function ENT:Setup(_,_,_,_,Mem1sz, Mem2sz, Mem3sz, Mem4sz)
 	local sizes =  {Mem1sz,Mem2sz,Mem3sz,Mem4sz}
 	for i = 1,4 do
-		starts[i] = tonumber(starts[i]) or 0
 		sizes[i] = tonumber(sizes[i]) or 0
 
-		self.MemStart[i] = starts[i]
-		self.MemEnd[i] = starts[i] + sizes[i] - 1
-		self["Mem"..i.."st"] = starts[i]
+		self.MemStart[i] = (self.MemEnd[i-1] or -1) + 1
+		self.MemEnd[i] = self.MemStart[i] + sizes[i] - 1
+		self["Mem"..i.."st"] = self.MemStart[i]
 		self["Mem"..i.."sz"] = sizes[i]
 	end
 end

--- a/lua/entities/gmod_wire_addressbus.lua
+++ b/lua/entities/gmod_wire_addressbus.lua
@@ -26,7 +26,7 @@ function ENT:Initialize()
 	self:SetOverlayText("Data rate: 0 bps")
 end
 
-function ENT:Setup(_,_,_,_,Mem1sz, Mem2sz, Mem3sz, Mem4sz)
+function ENT:Setup(Mem1sz, Mem2sz, Mem3sz, Mem4sz)
 	local sizes =  {Mem1sz,Mem2sz,Mem3sz,Mem4sz}
 	for i = 1,4 do
 		sizes[i] = tonumber(sizes[i]) or 0
@@ -91,4 +91,4 @@ function ENT:TriggerInput(iname, value)
 	end
 end
 
-duplicator.RegisterEntityClass("gmod_wire_addressbus", WireLib.MakeWireEnt, "Data", "Mem1st", "Mem2st", "Mem3st", "Mem4st", "Mem1sz", "Mem2sz", "Mem3sz", "Mem4sz")
+duplicator.RegisterEntityClass("gmod_wire_addressbus", WireLib.MakeWireEnt, "Data", "Mem1sz", "Mem2sz", "Mem3sz", "Mem4sz")

--- a/lua/wire/stools/addressbus.lua
+++ b/lua/wire/stools/addressbus.lua
@@ -14,15 +14,10 @@ TOOL.ClientConVar[ "addrspace1sz" ] = 0
 TOOL.ClientConVar[ "addrspace2sz" ] = 0
 TOOL.ClientConVar[ "addrspace3sz" ] = 0
 TOOL.ClientConVar[ "addrspace4sz" ] = 0
-TOOL.ClientConVar[ "addrspace1st" ] = 0
-TOOL.ClientConVar[ "addrspace2st" ] = 0
-TOOL.ClientConVar[ "addrspace3st" ] = 0
-TOOL.ClientConVar[ "addrspace4st" ] = 0
 
 if SERVER then
 	function TOOL:GetConVars()
-		return self:GetClientNumber( "addrspace1st" ), self:GetClientNumber( "addrspace2st" ), self:GetClientNumber( "addrspace3st" ), self:GetClientNumber( "addrspace4st" ),
-			   self:GetClientNumber( "addrspace1sz" ), self:GetClientNumber( "addrspace2sz" ), self:GetClientNumber( "addrspace3sz" ), self:GetClientNumber( "addrspace4sz" )
+		return self:GetClientNumber( "addrspace1sz" ), self:GetClientNumber( "addrspace2sz" ), self:GetClientNumber( "addrspace3sz" ), self:GetClientNumber( "addrspace4sz" )
 	end
 
 	-- Uses default WireToolObj:MakeEnt's WireLib.MakeWireEnt function
@@ -36,13 +31,9 @@ function TOOL:RightClick( trace )
 
 	if ( trace.Entity:IsValid() && trace.Entity:GetClass() == "gmod_wire_addressbus" ) then
 		ply:ConCommand("wire_addressbus_addrspace1sz "..(trace.Entity.MemEnd[1]-trace.Entity.MemStart[1]+1))
-		ply:ConCommand("wire_addressbus_addrspace1st "..(trace.Entity.MemStart[1]))
 		ply:ConCommand("wire_addressbus_addrspace2sz "..(trace.Entity.MemEnd[2]-trace.Entity.MemStart[2]+1))
-		ply:ConCommand("wire_addressbus_addrspace2st "..(trace.Entity.MemStart[2]))
 		ply:ConCommand("wire_addressbus_addrspace3sz "..(trace.Entity.MemEnd[3]-trace.Entity.MemStart[3]+1))
-		ply:ConCommand("wire_addressbus_addrspace3st "..(trace.Entity.MemStart[3]))
 		ply:ConCommand("wire_addressbus_addrspace4sz "..(trace.Entity.MemEnd[4]-trace.Entity.MemStart[4]+1))
-		ply:ConCommand("wire_addressbus_addrspace4st "..(trace.Entity.MemStart[4]))
 	end
 	return true
 end
@@ -51,12 +42,8 @@ function TOOL.BuildCPanel(panel)
 	WireToolHelpers.MakePresetControl(panel, "wire_addressbus")
 	ModelPlug_AddToCPanel(panel, "gate", "wire_addressbus", nil, 4)
 	
-	panel:NumSlider("1 offset", "wire_addressbus_addrspace1st", 0, 16777216, 0)
 	panel:NumSlider("1 size", 	"wire_addressbus_addrspace1sz", 0, 16777216, 0)
-	panel:NumSlider("2 offset", "wire_addressbus_addrspace2st", 0, 16777216, 0)
 	panel:NumSlider("2 size", 	"wire_addressbus_addrspace2sz", 0, 16777216, 0)
-	panel:NumSlider("3 offset", "wire_addressbus_addrspace3st", 0, 16777216, 0)
 	panel:NumSlider("3 size", 	"wire_addressbus_addrspace3sz", 0, 16777216, 0)
-	panel:NumSlider("4 offset", "wire_addressbus_addrspace4st", 0, 16777216, 0)
 	panel:NumSlider("4 size", 	"wire_addressbus_addrspace4sz", 0, 16777216, 0)
 end


### PR DESCRIPTION
Instead of asking for memory start point , which can result in memory access problem with cpu, the memory is self indexed considering of the component size given by the user.
For now i didn't updated the stool code , so i keep function declaration for compatibility , but the start point value is no longer used