### PR TITLE
Make E2Lib.getOwner CPPI wrapper check entity

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -178,6 +178,7 @@ function E2Lib.validPhysics(entity)
 	return false
 end
 
+-- This function gets wrapped when CPPI is detected, see very end of this file
 function E2Lib.getOwner(self, entity)
 	if entity == nil then return end
 	if entity == self.entity or entity == self.player then return self.player end
@@ -213,6 +214,7 @@ function E2Lib.abuse(ply)
 	error("abuse", 0)
 end
 
+-- This function gets replaced when CPPI is detected, see very end of this file
 function E2Lib.isFriend(owner, player)
 	return owner == player
 end
@@ -753,6 +755,7 @@ hook.Add("InitPostEntity", "e2lib", function()
 		if debug.getregistry().Entity.CPPIGetOwner then
 			local _getOwner = E2Lib.getOwner
 			E2Lib.replace_function("getOwner", function(self, entity)
+				if not IsValid(entity) then return end
 				if entity == self.entity or entity == self.player then return self.player end
 
 				local owner = entity:CPPIGetOwner()


### PR DESCRIPTION
E2Lib.getOwner would work "correctly" when CPPI was present, the function was given just a E2 *entity* instead of an e2context and nothing as target.

Calling `E2Lib.getOwner( targetE2ent )` (instead of `E2Lib.getOwner( self, entity )`) would result in `entity` and `targetE2ent.entity` being nil, and due to the line intended to catch the current E2 or the owner, it would correctly return the owner of the targeted E2. 
`if entity == self.entity or entity == self.player then return self.player end` => `if nil==nil or ...`

Calling E2Lib.getOwner( nonE2ent ) would not work and always return nil. The same would happen if CPPI wasn't present, due to `if entity == nil then return end` in the original function.

An alternative to "fixing" this "bug" would be to officially support the "simple" `E2Lib.getOwner( target )` in all cases (currently only works with CPPI and E2 as target).
