### PR TITLE
array:count returning 0, when array is nil

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/array.lua
+++ b/lua/entities/gmod_wire_expression2/core/array.lua
@@ -356,6 +356,7 @@ end
 --------------------------------------------------------------------------------
 __e2setcost(5)
 e2function number array:count()
+	if this == nil then retun 0 end
 	return #this
 end
 


### PR DESCRIPTION
The aray:count function is occasionally throwing "sv: Expression 2 (Chess): entities/gmod_wire_expression2/core/array.lua:323: attempt to get length of local 'this' (a nil value)" error.