### PR TITLE
Automatically save value in Highspeed Read gate

### DIFF
--- a/lua/wire/gates/highspeed.lua
+++ b/lua/wire/gates/highspeed.lua
@@ -24,14 +24,16 @@ GateActions["highspeed_read"] = {
 	inputs = { "Clk", "Memory", "Address" },
 	inputtypes = { "NORMAL", "WIRELINK", "NORMAL" },
 	output = function(gate, Clk, Memory, Address)
-		if not Memory then  return 0 end
-		if not Memory.ReadCell then return 0 end
-		if Clk <= 0 then return 0 end
+		if Clk <= 0 then return gate.Memory or 0 end
+		
+		Address = math.floor(Address or -1)
+		if not Memory or not Memory.ReadCell or Address < 0 then
+			gate.Memory = 0
+			return 0
+		end
 
-		Address = math.floor(Address)
-		if Address < 0 then return 0 end
-
-		return Memory:ReadCell(Address) or 0
+		gate.Memory = Memory:ReadCell(Address)
+		return gate.Memory or 0
 	end,
 	label = function(Out, Clk, Memory, Address)
 		return "Clock:"..Clk.." Memory:"..Memory.." Address:"..Address.." = "..Out


### PR DESCRIPTION
With this pr the output value in the highspeed read gate gets saved automatically for convenience since it's kinda difficult to setup a latch gate which saves the value after the read gate gets triggered (and clk is 1). I tested it and it should work with almost all contraptions which use this gate.