### PR TITLE
Add Trigger Latch gate

### DIFF
--- a/lua/wire/gates/memory.lua
+++ b/lua/wire/gates/memory.lua
@@ -43,6 +43,22 @@ GateActions["dlatch"] = {
 	end
 }
 
+GateActions["triggerlatch"] = {
+	name = "Trigger-Latch",
+	inputs = { "Data", "Clk" },
+	output = function(gate, Data, Clk)
+		gate.LatchStore = Data
+
+		return gate.LatchStore or 0
+	end,
+	reset = function(gate)
+		gate.LatchStore = 0
+	end,
+	label = function(Out, Data, Clk)
+		return "Trigger-Latch Data:"..Data.."  Clock:"..Clk.." = "..Out
+	end
+}
+
 GateActions["srlatch"] = {
 	name = "SR-Latch",
 	inputs = { "S", "R" },


### PR DESCRIPTION
Pretty much like the D-Latch gate except Clk doesn't have to be >0 so every input trigger saves the Data value. This is pretty useful in gate contraptions where you have generate a Clk (1/0) value from another triggered gate.