### PR TITLE
string length check on setName

### DIFF
--- a/lua/entities/gmod_wire_dataplug.lua
+++ b/lua/entities/gmod_wire_dataplug.lua
@@ -5,6 +5,11 @@ ENT.WireDebugName = "DataPlug"
 
 if CLIENT then return end -- No more client
 
+local Limit =  math.floor( ( 1 / engine.TickInterval() ) * 5 )
+local Reads  = 0
+local Writes = 0
+timer.Create( '', 1,0,function() Writes = 0 Reads = 0 end)
+
 function ENT:Initialize()
 	self:PhysicsInit( SOLID_VPHYSICS )
 	self:SetMoveType( MOVETYPE_VPHYSICS )
@@ -19,18 +24,26 @@ function ENT:Initialize()
 end
 
 function ENT:ReadCell( Address )
+	if( Reads > Limit ) then return false end
     if IsValid(self.MySocket) and self.MySocket.OwnMemory and self.MySocket.OwnMemory.ReadCell then
+    	Reads = Reads + 1
 		return self.MySocket.OwnMemory:ReadCell( Address )
 	end
 	return nil
 end
 
+
 function ENT:WriteCell( Address, value )
-	if IsValid(self.MySocket) and self.MySocket.OwnMemory and self.MySocket.OwnMemory.WriteCell then
+	if( Writes > Limit ) then return false end
+	if IsValid(self.MySocket) and self.MySocket.OwnMemory and self.MySocket.OwnMemory.WriteCell then		
+		Writes = Writes + 1
 		return self.MySocket.OwnMemory:WriteCell( Address, value )
 	end
 	return false
 end
+
+
+
 
 function ENT:OnRemove()
 	self.BaseClass.OnRemove(self)
@@ -41,13 +54,16 @@ function ENT:OnRemove()
 end
 
 function ENT:TriggerInput(iname, value, iter)
+	
 	if (iname == "Memory") then
 		self.Memory = self.Inputs.Memory.Src
 		if (self.MySocket) and (self.MySocket:IsValid()) then
 			self.MySocket:SetMemory(self.Memory)
 		end
 	end
+	
 end
+
 
 function ENT:SetSocket(socket)
 	self.MySocket = socket

--- a/lua/entities/gmod_wire_datasocket.lua
+++ b/lua/entities/gmod_wire_datasocket.lua
@@ -125,6 +125,7 @@ end
 function ENT:AttachPlug( plug )
 	// Set references between them
 	plug:SetSocket(self)
+
 	self.MyPlug = plug
 
 	// Position plug

--- a/lua/entities/gmod_wire_expression2/core/selfaware.lua
+++ b/lua/entities/gmod_wire_expression2/core/selfaware.lua
@@ -94,6 +94,8 @@ end)
 -- Set the name of the E2 itself
 e2function void setName( string name )
 	local e = self.entity
+	if ( not IsValid( name ) ) then return end
+	if ( #name > 64 ) then return end
 	if (e.name == name) then return end
 	if (name == "generic" or name == "") then
 		name = "generic"


### PR DESCRIPTION
There were no limitations on the string length for setName, this allowed players to set a name millions of characters long causing net lag if someone right clicked on the E2 and could also freeze the server for 1-3seconds if someone tried to remotely download the E2 via remote uploaded.