### PR TITLE
setName character limit

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/selfaware.lua
+++ b/lua/entities/gmod_wire_expression2/core/selfaware.lua
@@ -94,6 +94,9 @@ end)
 -- Set the name of the E2 itself
 e2function void setName( string name )
 	local e = self.entity
+	if( #name > 12000 ) then
+		name = string.sub( name, 1, 12000 )
+	end
 	if (e.name == name) then return end
 	if (name == "generic" or name == "") then
 		name = "generic"


### PR DESCRIPTION
Fixes some issues with setName causing net lag and server freezes due to large strings ( over 300 million characters ). Sets a limit of 12,000 characters.
Net Lag: Happens if you right click an E2 with a super long name
Server Freeze: Happens if you try to remotely download an E2 with a long name