### PR TITLE
Hotfix for data plug/socket crash

### DIFF
--- a/lua/entities/gmod_wire_dataplug.lua
+++ b/lua/entities/gmod_wire_dataplug.lua
@@ -5,6 +5,11 @@ ENT.WireDebugName = "DataPlug"
 
 if CLIENT then return end -- No more client
 
+local Limit =  math.floor( ( 1 / engine.TickInterval() ) * 5 )
+local Reads  = 0
+local Writes = 0
+timer.Create( '', 1,0,function() Writes = 0 Reads = 0 end)
+
 function ENT:Initialize()
 	self:PhysicsInit( SOLID_VPHYSICS )
 	self:SetMoveType( MOVETYPE_VPHYSICS )
@@ -19,14 +24,18 @@ function ENT:Initialize()
 end
 
 function ENT:ReadCell( Address )
+	if( Reads > Limit ) then return false end
     if IsValid(self.MySocket) and self.MySocket.OwnMemory and self.MySocket.OwnMemory.ReadCell then
+    	Reads = Reads + 1
 		return self.MySocket.OwnMemory:ReadCell( Address )
 	end
 	return nil
 end
 
 function ENT:WriteCell( Address, value )
+	if( Writes > Limit ) then return false end
 	if IsValid(self.MySocket) and self.MySocket.OwnMemory and self.MySocket.OwnMemory.WriteCell then
+		Writes = Writes + 1
 		return self.MySocket.OwnMemory:WriteCell( Address, value )
 	end
 	return false


### PR DESCRIPTION
I wont give exact details but this stops a recursive loop which causes the server to crash. I implemented a simple limit of 5 Reads ands Writes per game tick, per plug, this shouldn't cause any issues with current contraptions. I don't know how to fix the code but this limit will stop a crash until someone can take a look at it.