### PR TITLE
change check to allow returning \0

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -128,7 +128,7 @@ local utf8_byte = utf8.codepoint
 registerFunction("toChar", "n", "s", function(self, args)
 	local op1 = args[2]
 	local rv1 = op1[1](self, op1)
-	if rv1 < 1 then return "" end
+	if rv1 < 0 then return "" end
 	if rv1 > 255 then return "" end
 	return string_char(rv1)
 end)


### PR DESCRIPTION
lets you get the null character from toChar() #1419