### PR TITLE
Stop failing Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache:
     - $HOME/env
 
 before_install:
-  - pip install hererocks
+  - pip install --user hererocks
   - hererocks $HOME/env --luajit 2.0.3 --luarocks latest
   - source $HOME/env/bin/activate
 


### PR DESCRIPTION
Currently builds are failing with:
```
IOError: [Errno 13] Permission denied: '/usr/local/lib/python2.7/dist-packages/hererocks.py'
```

I don't know exactly when this started but this should fix it.