### PR TITLE
Stop running Luacheck on E2 extension files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ install:
 
 script:
   - git diff --check $TRAVIS_COMMIT_RANGE
-  - git diff --name-only $TRAVIS_COMMIT_RANGE | grep '\.lua$' | xargs --no-run-if-empty luacheck --std min+garrysmod+wiremod
+  - git diff --name-only $TRAVIS_COMMIT_RANGE | grep '\.lua$' | grep -v '^lua/entities/gmod_wire_expression2/core/' | xargs --no-run-if-empty luacheck --std min+garrysmod+wiremod


### PR DESCRIPTION
They use a custom preprocessor so don't contain standard Lua syntax.
This should stop Travis builds failing when somebody touches these files.
See #1087 for a discussion on this.