### PR TITLE
Skip default textentry handler when Wire TextEditor handles the shortcut

### DIFF
--- a/lua/wire/client/text_editor/texteditor.lua
+++ b/lua/wire/client/text_editor/texteditor.lua
@@ -69,7 +69,7 @@ function EDITOR:Init()
 
 	self.TextEntry.OnLoseFocus = function (self) self.Parent:_OnLoseFocus() end
 	self.TextEntry.OnTextChanged = function (self) self.Parent:_OnTextChanged() end
-	self.TextEntry.OnKeyCodeTyped = function (self, code) self.Parent:_OnKeyCodeTyped(code) end
+	self.TextEntry.OnKeyCodeTyped = function (self, code) return self.Parent:_OnKeyCodeTyped(code) end
 
 	self.TextEntry.Parent = self
 
@@ -1750,6 +1750,7 @@ function EDITOR:DuplicateLine()
 end
 
 function EDITOR:_OnKeyCodeTyped(code)
+	local handled = true
 	self.Blink = RealTime()
 
 	local alt = input.IsKeyDown(KEY_LALT) or input.IsKeyDown(KEY_RALT)
@@ -1823,6 +1824,8 @@ function EDITOR:_OnKeyCodeTyped(code)
 			self:SetCaret({ #self.Rows, 1 })
 		elseif code == KEY_D then
 			self:DuplicateLine()
+		else
+			handled = false
 		end
 
 	else
@@ -1916,6 +1919,8 @@ function EDITOR:_OnKeyCodeTyped(code)
 			end
 		elseif code == KEY_F1 then
 			self:ContextHelp()
+		else
+			handled = false
 		end
 	end
 
@@ -1926,6 +1931,7 @@ function EDITOR:_OnKeyCodeTyped(code)
 			if mode == 4 and self.AC_Panel.Selected == 0 then self.AC_Panel.Selected = 1 end
 			return
 		end
+		handled = true
 	end
 
 	if code == KEY_TAB or (control and (code == KEY_I or code == KEY_O)) then
@@ -1952,13 +1958,16 @@ function EDITOR:_OnKeyCodeTyped(code)
 		end
 		-- signal that we want our focus back after (since TAB normally switches focus)
 		if code == KEY_TAB then self.TabFocus = true end
+		handled = true
 	end
 
-	if control then
-		self:OnShortcut(code)
+	if control and not handled then
+		handled = self:OnShortcut(code)
 	end
 
 	self:AC_Check()
+
+	return handled
 end
 
 ---------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
To save on code, we first assume to handle the command, and only set it to false when none of the main if chain applies.

Then we set it to true when additional commands such as autocomplete or inside OnShortcut apply.

This fixes race conditions between our and default shortcuts, such as in #1512.

I tested in on singleplayer, but I am on linux, so input from a windows user would be appreciated.