### PR TITLE
Travis: Ignore whitespace errors in diffs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ install:
   - luarocks list --outdated --porcelain | awk '{ print $1, $3 }' | xargs --no-run-if-empty -n 2 luarocks install
 
 script:
-  - git diff --check $TRAVIS_COMMIT_RANGE
+  - git -c core.whitespace=-blank-at-eol,-blank-at-eof,-space-before-tab diff --check $TRAVIS_COMMIT_RANGE
   - git diff --name-only $TRAVIS_COMMIT_RANGE | grep '\.lua$' | grep -v '^lua/entities/gmod_wire_expression2/core/' | xargs --no-run-if-empty luacheck
   - luacheck .luacheckrc


### PR DESCRIPTION
Alternative to the conflict-ridden #1385 
Whitespace errors? What errors? I don't see any whitespace errors :)

This helps the "Travis checks failed" message on PR's be slightly more meaningful - though in the Repo's current state, its still pretty meaningless.