### PR TITLE
Fix UDF being treated as method if first argument is "This"

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -652,7 +652,7 @@ function Parser:Stmt10()
 		for I = 1, #Args do
 			local Arg = Args[I]
 			Sig = Sig .. wire_expression_types[Arg[2]][1]
-			if I == 1 and Arg[1] == "This" then
+			if I == 1 and Arg[1] == "This" and Type ~= '' then
 				Sig = Sig .. ":"
 			end
 		end


### PR DESCRIPTION
Fixes #1191 

If `Type` is an empty string then this shouldn't be treated as a method function.