### PR TITLE
Kill some unused vars, localize some globals

### DIFF
--- a/lua/entities/gmod_wire_cameracontroller.lua
+++ b/lua/entities/gmod_wire_cameracontroller.lua
@@ -273,8 +273,6 @@ if CLIENT then
 			-- If we switched on, set current positions and angles
 			if not enabled then
 				-- Copy them
-				curpos = Vector(pos.x,pos.y,pos.z)
-				curang = Angle(ang.p,ang.y,ang.r)
 				smoothpos = Vector(pos.x,pos.y,pos.z)
 				smoothang = Angle(ang.p,ang.y,ang.r)
 				curdistance = distance

--- a/lua/entities/gmod_wire_cd_lock.lua
+++ b/lua/entities/gmod_wire_cd_lock.lua
@@ -76,9 +76,7 @@ function ENT:Think()
 end
 
 function ENT:AttachDisk(disk)
-	//Position disk
-	local min = disk:OBBMins()
-	local max = disk:OBBMaxs()
+	--Position disk
 
 	local newpos = self:LocalToWorld(Vector(0, 0, 0))
 	local lockAng = self:GetAngles()

--- a/lua/entities/gmod_wire_clutch.lua
+++ b/lua/entities/gmod_wire_clutch.lua
@@ -40,7 +40,7 @@ end
 ---------------------------------------------------------]]
 
 function ENT:ClutchExists( Ent1, Ent2 )
-	for k, v in pairs( self.clutch_ballsockets ) do
+	for k, _ in pairs( self.clutch_ballsockets ) do
 		if  ( Ent1 == k.Ent1 and Ent2 == k.Ent2 ) or
 			( Ent1 == k.Ent2 and Ent2 == k.Ent1 ) then
 			return true
@@ -54,7 +54,7 @@ end
 -- Returns an array with each entry as a table containing Ent1, Ent2
 function ENT:GetConstrainedPairs()
 	local ConstrainedPairs = {}
-	for k, v in pairs( self.clutch_ballsockets ) do
+	for k, _ in pairs( self.clutch_ballsockets ) do
 		if IsValid( k ) then
 			table.insert( ConstrainedPairs, {Ent1 = k.Ent1, Ent2 = k.Ent2} )
 		else
@@ -132,7 +132,7 @@ end
 
 function ENT:OnRemove()
 	
-	for k, v in pairs( self.clutch_ballsockets ) do
+	for k, _ in pairs( self.clutch_ballsockets ) do
 		
 		self:RemoveClutch( k )
 		
@@ -174,8 +174,8 @@ function ENT:UpdateFriction()
 	-- Update all registered ball socket constraints
 	local numconstraints = 0	-- Used to calculate the delay between inputs
 
-	for k, v in pairs( clutch_ballsockets ) do
-		if !IsValid( k ) then
+	for k, _ in pairs( clutch_ballsockets ) do
+		if not IsValid( k ) then
 			self:RemoveClutch( k )
 
 		else
@@ -254,7 +254,8 @@ end
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
 	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
-	for k, v in pairs( info.constrained_pairs ) do
+	local Ent1, Ent2
+	for _, v in pairs( info.constrained_pairs ) do
 		Ent1 = GetEntByID(v.Ent1)
 		Ent2 = GetEntByID(v.Ent2, game.GetWorld())
 

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -522,7 +522,7 @@ function Compiler:InstrSET(args)
 
 		local rt = self:GetOperator(args, "idx", { tp, tp1, tp2 })
 
-		return { rt[1], ex, ex1, ex2, ScopeID }, rt[2]
+		return { rt[1], ex, ex1, ex2, nil }, rt[2]
 	else
 		if tp2 ~= args[6] then
 			self:Error("Indexing type mismatch, specified [" .. tps_pretty({ args[6] }) .. "] but value is [" .. tps_pretty({ tp2 }) .. "]", args)
@@ -783,7 +783,7 @@ function Compiler:InstrRETURNVOID(args)
 		self:Error("Return type mismatch: " .. tps_pretty(self.func_ret) .. " expected got, void", args)
 	end
 
-	return { self:GetOperator(args, "return", {})[1], Value, Type }
+	return { self:GetOperator(args, "return", {})[1], nil, nil }
 end
 
 function Compiler:InstrKVTABLE(args)
@@ -833,6 +833,7 @@ function Compiler:InstrSWITCH(args)
 
 	local cases = {}
 	local Cases = args[4]
+	local default
 	for i = 1, #Cases do
 		local case, block, prf_eq, eq = Cases[i][1], Cases[i][2], 0, nil
 		if case then -- The default will not have one

--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -564,7 +564,7 @@ function Parser:Stmt10()
 
 		local Name, Return, Type
 		local NameToken, ReturnToken, TypeToken
-		local Args, Temp, Arg = {}, {}, 1
+		local Args, Temp = {}, {}
 
 
 		-- Errors are handeled after line 49, both 'fun' and 'var' tokens are used for accurate error reports.
@@ -722,8 +722,6 @@ function Parser:Stmt11()
 end
 
 function Parser:FunctionArgs(Temp, Args)
-	local sig = ""
-
 	if self:HasTokens() and not self:AcceptRoamingToken("rpa") then
 		while true do
 
@@ -922,7 +920,7 @@ function Parser:SwitchBlock() -- Shhh this is a secret. Do not tell anybody abou
 	if self:HasTokens() and not self:AcceptRoamingToken("rpa") then
 
 		if not self:AcceptRoamingToken("case") and not self:AcceptRoamingToken("default") then
-			self:Error("Case Operator (case) expected in case block.", token)
+			self:Error("Case Operator (case) expected in case block.", self:GetToken())
 		end
 
 		self:TrackBack()
@@ -958,7 +956,7 @@ function Parser:SwitchBlock() -- Shhh this is a secret. Do not tell anybody abou
 	end
 
 	if not self:AcceptRoamingToken("rcb") then
-		self:Error("Right curly bracket (}) missing, to close statement block", token)
+		self:Error("Right curly bracket (}) missing, to close statement block", self:GetToken())
 	end
 
 	return cases
@@ -1028,7 +1026,7 @@ function Parser:Expr2()
 		local exprtrue = self:Expr1()
 
 		if not self:AcceptRoamingToken("col") then -- perhaps we want to make sure there is space around this (method bug)
-			self:Error("Conditional operator (:) must appear after expression to complete conditional", token)
+			self:Error("Conditional operator (:) must appear after expression to complete conditional", self:GetToken())
 		end
 
 		return self:Instruction(trace, "cnd", expr, exprtrue, self:Expr1())
@@ -1294,7 +1292,7 @@ function Parser:Expr16()
 						local token = self:GetToken()
 
 						local key = self:Expr1()
-						local token = self:GetToken()
+						token = self:GetToken()
 
 						if self:AcceptRoamingToken("ass") then
 							if self:AcceptRoamingToken("rpa") then

--- a/lua/entities/gmod_wire_expression2/base/preprocessor.lua
+++ b/lua/entities/gmod_wire_expression2/base/preprocessor.lua
@@ -67,7 +67,6 @@ function PreProcessor:FindComments(line)
 					end
 				end
 			elseif char == '"' then -- We found a string
-				local before = line:sub(found - 1, found - 1)
 				count = count + 1
 				ret[count] = { type = "string", pos = found }
 				pos = found + 1

--- a/lua/entities/gmod_wire_expression2/core/cl_console.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_console.lua
@@ -5,7 +5,7 @@ local convars = {
 
 local function CreateCVars()
 	for name,default in pairs(convars) do
-		current_cvar = CreateClientConVar(name, default, true, true)
+		local current_cvar = CreateClientConVar(name, default, true, true)
 		local value = current_cvar:GetString() or default
 		RunConsoleCommand(name, value)
 	end

--- a/lua/entities/gmod_wire_expression2/core/cl_debug.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_debug.lua
@@ -12,8 +12,6 @@ net.Receive("wire_expression2_printColor", function( len, ply )
 	if chip and not chips[chip] then
 		chips[chip] = true
 		-- printColorDriver is used for the first time on us by this chip
-		WireLib.AddNotify(msg1, NOTIFY_GENERIC, 7, NOTIFYSOUND_DRIP3)
-		WireLib.AddNotify(msg2, NOTIFY_GENERIC, 7)
 		chat.AddText(Color(255,0,0),"While in somone's seat/car/whatever, printColorDriver can be used to 100% realistically fake people talking, including admins.")
 		chat.AddText(Color(255,0,0),"Don't trust a word you hear while in a seat after seeing this message!")
 	end

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -4,7 +4,7 @@ E2Lib = {}
 
 local type = type
 local function checkargtype(argn, value, argtype)
-	if type(value) ~= argtype then error(string.format("bad argument #%d to 'E2Lib.%s' (%s expected, got %s)", argn, debug.getinfo(2, "n").name, argtype, type(text)), 2) end
+	if type(value) ~= argtype then error(string.format("bad argument #%d to 'E2Lib.%s' (%s expected, got %s)", argn, debug.getinfo(2, "n").name, argtype, type(value)), 2) end
 end
 
 -- -------------------------- Helper functions -----------------------------
@@ -246,11 +246,11 @@ local table_length_lookup = {
 function E2Lib.guess_type(value)
 	if IsValid(value) then return "e" end
 	if value.EntIndex then return "e" end
-	local vtype = type(v)
+	local vtype = type(value)
 	if type_lookup[vtype] then return type_lookup[vtype] end
 	if vtype == "table" then
-		if table_length_lookup[#v] then return table_length_lookup[#v] end
-		if v.HitPos then return "xrd" end
+		if table_length_lookup[#value] then return table_length_lookup[#value] end
+		if value.HitPos then return "xrd" end
 	end
 
 	for typeid, v in pairs(wire_expression_types2) do

--- a/lua/entities/gmod_wire_expression2/core/init.lua
+++ b/lua/entities/gmod_wire_expression2/core/init.lua
@@ -19,19 +19,6 @@ if SERVER then
 	end)
 end
 
--- Removes a typecheck from a function identified by the given signature.
-local function removecheck(signature)
-	local entry = wire_expression2_funcs[signature]
-	local oldfunc, signature, rets, func, cost = entry.oldfunc, unpack(entry)
-
-	if not oldfunc then return end
-	func = oldfunc
-	oldfunc = nil
-
-	entry[3] = func
-	entry.oldfunc = oldfunc
-end
-
 --- This function ensures that the given function shows up by the given name in stack traces.
 --- It does so by eval'ing a generated block of code which invokes the actual function.
 --- Tail recursion optimization is specifically avoided by introducing a local variable in the generated code block.

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -378,7 +378,7 @@ function ENT:ResetContext()
 		end
 	end
 
-	for k, v in pairs(self.dvars) do
+	for k, _ in pairs(self.dvars) do
 		self.GlobalScope["$" .. k] = self.GlobalScope[k]
 	end
 
@@ -524,11 +524,12 @@ hook.Add("EntityRemoved", "Wire_Expression2_Player_Disconnected", function(ent)
 	if (ret == 0 or (ret == 2 and not wire_expression2_ShouldFreezeChip(ent))) then
 		return
 	end
-	for k, v in ipairs(ents.FindByClass("gmod_wire_expression2")) do
+	for _, v in ipairs(ents.FindByClass("gmod_wire_expression2")) do
 		if (v.player == ent) then
 			v:SetOverlayText(v.name .. "\n(Owner disconnected.)")
+			local oldColor = v:GetColor()
 			v:SetColor(Color(255, 0, 0, v:GetColor().a))
-			v.disconnectPaused = { r, g, b, a }
+			v.disconnectPaused = oldColor
 			v.error = true
 		end
 	end
@@ -632,7 +633,7 @@ local function enableEmergencyShutdown()
 					current_ram > halt_max_amount:GetInt() * 1000 then -- or if the current ram goes over a set limit
 
 					local e2s = ents.FindByClass("gmod_wire_expression2") -- find all E2s and halt them
-					for k,v in pairs( e2s ) do
+					for _,v in pairs( e2s ) do
 						if not v.error then
 							-- immediately clear any memory the E2 may be holding
 							v:PCallHook("destruct")


### PR DESCRIPTION
Mostly just listening to my IDE's luacheck - though the Garry syntax really breaks that. We should just do a mass regex replace once the PR count is lower.