### PR TITLE
Wirelib: Improve Think hook performance

### DIFF
--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -46,12 +46,7 @@ end
 local Inputs = {}
 local Outputs = {}
 local CurLink = {}
-
-hook.Add("Think", "WireLib_Think", function()
-	for idx,port in pairs(Outputs) do
-		port.TriggerLimit = 4
-	end
-end)
+local CurTime = CurTime
 
 -- helper function that pcalls an input
 function WireLib.TriggerInput(ent, name, value, ...)
@@ -505,7 +500,14 @@ function WireLib.TriggerOutput(ent, oname, value, iter)
 
 	local output = ent.Outputs[oname]
 	if (output) and (value ~= output.Value or output.Type == "ARRAY" or output.Type == "TABLE") then
-		if (output.TriggerLimit <= 0) then return end
+		local timeOfFrame = CurTime()
+		if timeOfFrame ~= output.TriggerTime then
+			-- Reset the TriggerLimit every frame
+			output.TriggerLimit = 4
+			output.TriggerTime = timeOfFrame
+		elseif output.TriggerLimit <= 0 then
+			return
+		end
 		output.TriggerLimit = output.TriggerLimit - 1
 
 		output.Value = value


### PR DESCRIPTION
By replacing Think iterating over all wire ents with a slightly more expensive TriggerOutput, I believe this is a better alternative to #1023 as it appears to precisely maintain previous behaviour of 4 outputs per frame.

This is going under the assumption that CurTime() is fast - benching it, 40,000 runs of CurTime() take 1ms (which is 70x slower than a basic `x = 1 + 2` or `if (x < 3) then end`), probably fast enough.
Its also under the assumption that all calls to CurTime() within the same frame will return the same value - testing suggests so, but I'm not 100% confident on that.

Thanks @Python1320 for noticing the perf issue and starting this discussion!
Closes #1023 