### PR TITLE
Wire Debugger: Add 'Debug' and 'Stop Debugging' to context menu

### DIFF
--- a/lua/weapons/gmod_tool/stools/wire_adv.lua
+++ b/lua/weapons/gmod_tool/stools/wire_adv.lua
@@ -46,18 +46,6 @@ TOOL.ClientConVar = {
 
 util.PrecacheSound("weapons/pistol/pistol_empty.wav")
 
------------------------------------------------------------------
--- Helper functions
------------------------------------------------------------------
-
-local function get_tool(ply, tool)
-	-- find toolgun
-	local gmod_tool = ply:GetWeapon("gmod_tool")
-	if not IsValid(gmod_tool) then return end
-
-	return gmod_tool:GetToolObject(tool)
-end
-
 local function get_active_tool(ply, tool)
 	-- find toolgun
 	local activeWep = ply:GetActiveWeapon()
@@ -200,29 +188,9 @@ if SERVER then
 			end
 		end
 	end)
-	
-	
-	if game.SinglePlayer() then -- wtfgarry (these functions don't get called clientside in single player so we need this hack to fix it)
-		util.AddNetworkString( "wire_adv_wtfgarry" )
-		local function send( ply, funcname )
-			net.Start( "wire_adv_wtfgarry" )
-				net.WriteString( funcname )
-			net.Send( ply )
-		end
-		
-		function TOOL:LeftClick() send( self:GetOwner(), "LeftClick" ) end
-		function TOOL:RightClick() send( self:GetOwner(), "RightClick" ) end
-		function TOOL:Reload() send( self:GetOwner(), "Reload" ) end
-	end
+
+	WireToolHelpers.SetupSingleplayerClickHacks(TOOL)
 elseif CLIENT then
-	if game.SinglePlayer() then -- wtfgarry
-		net.Receive( "wire_adv_wtfgarry", function( len )
-			local funcname = net.ReadString()
-			local tool = get_active_tool( LocalPlayer(), "wire_adv" )
-			if not tool then return end
-			tool[funcname]( tool, LocalPlayer():GetEyeTrace() )
-		end)
-	end
 
 	-----------------------------------------------------------------
 	-- Tool helper functions

--- a/lua/weapons/gmod_tool/stools/wire_debugger.lua
+++ b/lua/weapons/gmod_tool/stools/wire_debugger.lua
@@ -234,6 +234,7 @@ end
 
 
 if (SERVER) then
+	WireToolHelpers.SetupSingleplayerClickHacks(TOOL)
 
 	dbg_line_cache = {}
 


### PR DESCRIPTION
Extension of @shadowscion 's #1383 (which appears to be on a deleted repository, so I couldn't just extend the existing branch)
* Reduced code duplication in the 'remove entity from debugged list'
* `Components` is now tracked clientside as well, so the client can show 'Stop Debugging' instead of 'Debug' in the menu

I'm not totally pleased with this solution, as needing to track Components clientside is a bit more work than the fairly tiny #1383 ~~also in Singleplayer, for whatever reason, TOOL:LeftClick/right/reload don't fire Clientside, yet they fire on both Server+Client in multiplayer (apparently 'because its Predicted' https://wiki.garrysmod.com/page/TOOL/LeftClick , unsure if there's a sane workaround ), which means that if you Enable debugging via Properties, and then disable it via the tool, the Client will still show 'Disable Debugging' in Singleplayer. Not a dealbreaker, but unpleasant.~~ fixed via Divran's workaround