### PR TITLE
Pod Controller: Button pressing now works for anything with ENT:Use

### DIFF
--- a/lua/entities/gmod_wire_button.lua
+++ b/lua/entities/gmod_wire_button.lua
@@ -80,7 +80,7 @@ function ENT:TriggerInput(iname, value)
 	end
 end
 
-function ENT:Use(ply)
+function ENT:Use(ply, caller)
 	if (not ply:IsPlayer()) then return end
 	if (self.PrevUser) and (self.PrevUser:IsValid()) then return end
 	if self.OutputEntID then
@@ -90,6 +90,9 @@ function ENT:Use(ply)
 		if (self.toggle) then self:Switch(false) end
 
 		return
+	end
+	if IsValid(caller) and caller:GetClass() == "gmod_wire_pod" then
+		self.podpress = true
 	end
 
 	self:Switch(true)

--- a/lua/entities/gmod_wire_dynamic_button.lua
+++ b/lua/entities/gmod_wire_dynamic_button.lua
@@ -57,7 +57,7 @@ function ENT:TriggerInput(iname, value)
 	end
 end
 
-function ENT:Use(ply)
+function ENT:Use(ply, caller)
 	if (not ply:IsPlayer()) then return end
 	if (self.PrevUser) and (self.PrevUser:IsValid()) then return end
 	if self.OutputEntID then
@@ -67,6 +67,9 @@ function ENT:Use(ply)
 		if (self.toggle) then self:Switch(false) end
 
 		return
+	end
+	if IsValid(caller) and caller:GetClass() == "gmod_wire_pod" then
+		self.podpress = true
 	end
 
 	self:Switch(true)

--- a/lua/entities/gmod_wire_pod.lua
+++ b/lua/entities/gmod_wire_pod.lua
@@ -442,6 +442,10 @@ function ENT:Think()
 						button.EntToOutput = ply
 						button:Switch( true )
 					end
+				elseif button.Use then
+					-- Generic support (EGP screens, etc)
+					self.MouseDown = true
+					button:Use(ply, ply, USE_ON, 0)
 				end
 			elseif (!ply:KeyDown( IN_ATTACK ) and self.MouseDown) then
 				self.MouseDown = false

--- a/lua/entities/gmod_wire_pod.lua
+++ b/lua/entities/gmod_wire_pod.lua
@@ -421,33 +421,11 @@ function ENT:Think()
 		-- Button pressing
 		if (self.AllowButtons and distance < 82) then
 			local button = trace.Entity
-			if IsValid(button) and (ply:KeyDown( IN_ATTACK ) and !self.MouseDown) then
-				if button:GetClass() == "gmod_wire_lever" then
-					-- The parented lever doesn't have a great serverside hitbox, so this isn't flawless
-					self.MouseDown = true
-					button:Use(ply, ply, USE_ON, 0)
-				elseif button:GetClass() == "gmod_wire_button" || button:GetClass() == "gmod_wire_dynamic_button" then
-					self.MouseDown = true
-					if (button.toggle) then
-						if (button:GetOn()) then
-							button:Switch( false )
-						else
-							button.EntToOutput = ply
-							button.PrevUser = ply
-							button:Switch( true )
-						end
-					else
-						button.PrevUser = ply
-						button.podpress = true
-						button.EntToOutput = ply
-						button:Switch( true )
-					end
-				elseif button.Use then
-					-- Generic support (EGP screens, etc)
-					self.MouseDown = true
-					button:Use(ply, ply, USE_ON, 0)
-				end
-			elseif (!ply:KeyDown( IN_ATTACK ) and self.MouseDown) then
+			if IsValid(button) and (ply:KeyDown( IN_ATTACK ) and not self.MouseDown) and button.Use then
+				-- Generic support (Buttons, Dynamic Buttons, Levers, EGP screens, etc)
+				self.MouseDown = true
+				button:Use(ply, self, USE_ON, 0)
+			elseif not ply:KeyDown( IN_ATTACK ) and self.MouseDown then
 				self.MouseDown = false
 			end
 		end


### PR DESCRIPTION
For example, now you can press EGP buttons while sitting down, making touchscreens much more useful.