### PR TITLE
E2Editor: Editor Clipboard now shared between tabs

### DIFF
--- a/lua/wire/client/text_editor/texteditor.lua
+++ b/lua/wire/client/text_editor/texteditor.lua
@@ -152,25 +152,16 @@ function EDITOR:OpenContextMenu()
 
 	if self:HasSelection() then
 		menu:AddOption("Cut", function()
-			if self:HasSelection() then
-				self.clipboard = self:GetSelection()
-				self.clipboard = string_gsub(self.clipboard, "\n", "\r\n")
-				SetClipboardText(self.clipboard)
-				self:SetSelection()
-			end
+			self:Cut()
 		end)
 		menu:AddOption("Copy", function()
-			if self:HasSelection() then
-				self.clipboard = self:GetSelection()
-				self.clipboard = string_gsub(self.clipboard, "\n", "\r\n")
-				SetClipboardText(self.clipboard)
-			end
+			self:Copy()
 		end)
 	end
 
 	menu:AddOption("Paste", function()
-		if self.clipboard then
-			self:SetSelection(self.clipboard)
+		if self.CurrentMode.clipboard then
+			self:SetSelection(self.CurrentMode.clipboard)
 		else
 			self:SetSelection()
 		end
@@ -251,7 +242,7 @@ function EDITOR:OpenContextMenu()
 
 		str = str .. "[/color][/font][/code]"
 
-		self.clipboard = str
+		self.CurrentMode.clipboard = str
 		SetClipboardText( str )
 	end)
 
@@ -1698,8 +1689,8 @@ end
 
 function EDITOR:Copy()
 	if not self:HasSelection() then return end
-	self.clipboard = string_gsub(self:GetSelection(), "\n", "\r\n")
-	return SetClipboardText(self.clipboard)
+	self.CurrentMode.clipboard = string_gsub(self:GetSelection(), "\n", "\r\n")
+	return SetClipboardText(self.CurrentMode.clipboard)
 end
 
 function EDITOR:Cut()
@@ -1784,8 +1775,8 @@ function EDITOR:_OnKeyCodeTyped(code)
 		-- pasting is now handled by the textbox that is used to capture input
 		--[[
 		elseif code == KEY_V then
-			if self.clipboard then
-				self:SetSelection(self.clipboard)
+			if self.CurrentMode.clipboard then
+				self:SetSelection(self.CurrentMode.clipboard)
 			end
 		]]
 		elseif code == KEY_F then


### PR DESCRIPTION
Fixes #1028, which was specifically that the Context Menu clipboard wasn't shared between tabs - the system clipboard (ctrl-c/v) always worked

Because Glua can't read the clipboard, the editor stores the clipboard contents in a var, so the context menu's "Paste" can work. This PR moves that variable from the editor instance (which apparently each tab has its own instance) to the Editor class for that mode (E2, GPU, or default), since in the unlikely event someone is simultaneously using E2 and GPU, they probably don't want to share clipboards there (and it was easy)