### PR TITLE
Wire Wheel: Fixed dupes not saving the updated torque

### DIFF
--- a/lua/entities/gmod_wire_wheel.lua
+++ b/lua/entities/gmod_wire_wheel.lua
@@ -33,9 +33,6 @@ function ENT:Setup(fwd, bck, stop, torque, direction, axis)
 	self:UpdateOverlayText()
 end
 
---[[---------------------------------------------------------
-   Sets the base torque
----------------------------------------------------------]]
 function ENT:UpdateOverlayText(speed)
 	local motor = self:GetMotor()
 	local friction = 0
@@ -48,9 +45,6 @@ function ENT:UpdateOverlayText(speed)
 		"\nSpeedMod: " .. math.floor( self.SpeedMod * 100 ) .. "%" )
 end
 
---[[---------------------------------------------------------
-   Sets the axis (world space)
----------------------------------------------------------]]
 function ENT:SetAxis( vec )
 	self.Axis = self:GetPos() + vec * 512
 	self.Axis = self:NearestPoint( self.Axis )
@@ -67,9 +61,9 @@ function ENT:SetMotor( Motor )
 end
 
 function ENT:GetMotor()
-	if (!self.Motor) then
+	if not self.Motor then
 		self.Motor = constraint.FindConstraintEntity( self, "Motor" )
-		if (!self.Motor or !self.Motor:IsValid()) then
+		if not IsValid(self.Motor) then
 			self.Motor = nil
 		end
 	end
@@ -81,18 +75,10 @@ function ENT:SetDirection( dir )
 	self.direction = dir
 end
 
-
---[[---------------------------------------------------------
-   Forward
----------------------------------------------------------]]
 function ENT:Forward( mul )
-	if ( !self:IsValid() ) then return false end
+	if not self:IsValid() then return false end
 	local Motor = self:GetMotor()
-	if ( Motor and !Motor:IsValid() ) then
-		Msg("Wheel doesn't have a motor!\n");
-		return false
-	elseif ( !Motor ) then return false
-	end
+	if not IsValid(Motor) then return false end
 
 	mul = mul or 1
 	local mdir = Motor.direction
@@ -107,10 +93,6 @@ function ENT:Forward( mul )
 	return true
 end
 
---[[---------------------------------------------------------
-   Name: TriggerInput
-   Desc: the inputs
----------------------------------------------------------]]
 function ENT:TriggerInput(iname, value)
 	if (iname == "A: Go") then
 		if ( value == self.fwd ) then self.Go = 1
@@ -147,11 +129,6 @@ function ENT:PhysicsUpdate( physobj )
 	physobj:SetVelocity(vel)
 end
 
-
-
---[[---------------------------------------------------------
-   Todo? Scale Motor:GetTable().direction?
----------------------------------------------------------]]
 function ENT:SetTorque( torque )
 	self.TorqueScale = torque / self.BaseTorque
 

--- a/lua/wire/stools/wheel.lua
+++ b/lua/wire/stools/wheel.lua
@@ -51,7 +51,7 @@ if SERVER then
 		local LPos1 = wheelEnt:GetPhysicsObject():WorldToLocal( wheelEnt:GetPos() + trace.HitNormal )
 		local LPos2 = targetPhys:WorldToLocal( trace.HitPos )
 
-		local constraint, axis = constraint.Motor( wheelEnt, trace.Entity, 0, trace.PhysicsBone, LPos1,	LPos2, friction, torque, 0, nocollide, false, ply, limit )
+		local constraint, axis = constraint.Motor( wheelEnt, trace.Entity, 0, trace.PhysicsBone, LPos1,	LPos2, friction, 1000, 0, nocollide, false, ply, limit )
 
 		undo.Create(self.WireClass)
 			undo.AddEntity( axis )
@@ -108,6 +108,7 @@ function TOOL.BuildCPanel( panel )
 									 Models = list.Get( "WheelModels" ) } )
 	panel:NumSlider("#tool.wheel.torque", "wire_wheel_torque", 10, 10000, 0)
 	panel:NumSlider("#tool.wheel.forcelimit", "wire_wheel_forcelimit", 0, 50000, 0)
-	panel:NumSlider("#tool.wheel.friction", "wire_wheel_friction", 0, 50, 2)
+	local frictionPanel = panel:NumSlider("#tool.wheel.friction", "wire_wheel_friction", 0, 50, 2)
+	frictionPanel:SetTooltip("How quickly the wheel comes to a stop. Note: An existing wheel's friction cannot be updated")
 	panel:CheckBox("#tool.wheel.nocollide", "wire_wheel_nocollide")
 end

--- a/lua/wire/stools/wheel.lua
+++ b/lua/wire/stools/wheel.lua
@@ -75,7 +75,7 @@ if SERVER then
 		return wheelEnt
 	end
 	
-	function TOOL:LeftClick_PostMake( ent, ply, trace ) end -- We're handling this in MakeEnt since theres a motor
+	function TOOL:LeftClick_PostMake(_, _, _) end -- We're handling this in MakeEnt since theres a motor
 end
 
 function TOOL:GetAngle(trace)
@@ -100,7 +100,7 @@ function TOOL.BuildCPanel( panel )
 	panel:NumSlider("#tool.wire_wheel.group", "wire_wheel_fwd", -10, 10, 0)
 	panel:NumSlider("#tool.wire_wheel.group_stop", "wire_wheel_stop", -10, 10, 0)
 	panel:NumSlider("#tool.wire_wheel.group_reverse", "wire_wheel_bck", -10, 10, 0)
-	//WireDermaExts.ModelSelect(panel, "wheel_model", list.Get( "WheelModels" ), 3, true) -- This doesn't seem to set the wheel_rx convars right
+	--WireDermaExts.ModelSelect(panel, "wheel_model", list.Get( "WheelModels" ), 3, true) -- This doesn't seem to set the wheel_rx convars right
 	panel:AddControl( "PropSelect", { Label = "#tool.wheel.model",
 									 ConVar = "wheel_model",
 									 Category = "Wheels",


### PR DESCRIPTION
Initial motor constraint's torque is now always 1000, which we then scale (up or down) to the desired value, since its not possible to change the constraint itself without removing/recreating it (which is a hassle to do perfectly). 
Old dupes will still work (albeit they were saved with their initial torque, so this doesn't fix old dupes)
Fixes #1132