### PR TITLE
E2 Ops rebalance based on some more quick benchmarking

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/array.lua
+++ b/lua/entities/gmod_wire_expression2/core/array.lua
@@ -136,7 +136,7 @@ registerCallback( "postinit", function()
 			-- Get functions
 			-- value = R[N,type], and value = R:<type>(N)
 			--------------------------------------------------------------------------------
-			__e2setcost(10)
+			__e2setcost(5)
 
 			local function getter( self, array, index, doremove )
 				if (!array or !index) then return fixdef( default ) end -- Make sure array and index are value
@@ -198,7 +198,7 @@ registerCallback( "postinit", function()
 			-- Push functions
 			-- Inserts the value at the end of the array
 			--------------------------------------------------------------------------------
-			__e2setcost(15)
+			__e2setcost(7)
 
 			registerFunction( "push" .. nameupperfirst, "r:" .. id, id, function(self,args)
 				local op1, op2 = args[2], args[3]
@@ -304,7 +304,7 @@ end)
 -- Pop
 -- Removes the last entry in the array
 --------------------------------------------------------------------------------
-__e2setcost(15)
+__e2setcost(2)
 e2function void array:pop()
 	table_remove( this )
 	self.GlobalScope.vclk[this] = true
@@ -314,7 +314,7 @@ end
 -- Remove
 -- Removes the specified entry in the array
 --------------------------------------------------------------------------------
-__e2setcost(15)
+__e2setcost(2)
 e2function void array:remove( index )
 	table_remove( this, index )
 	self.GlobalScope.vclk[this] = true
@@ -335,7 +335,7 @@ end
 -- Shift
 -- Removes the first entry in the array
 --------------------------------------------------------------------------------
-__e2setcost(15)
+__e2setcost(3)
 e2function void array:shift()
 	table_remove( this, 1 )
 	self.GlobalScope.vclk[this] = true
@@ -354,7 +354,7 @@ end
 -- Count
 -- Returns the number of entries in the array
 --------------------------------------------------------------------------------
-__e2setcost(5)
+__e2setcost(3)
 e2function number array:count()
 	return #this
 end

--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -152,7 +152,7 @@ end
 
 --------------------------------------------------------------------------------
 
-__e2setcost(30)
+__e2setcost(40)
 e2function entity propSpawn(string model, number frozen)
 	if not PropCore.ValidAction(self, nil, "spawn") then return nil end
 	return PropCore.CreateProp(self,model,self.entity:GetPos()+self.entity:GetUp()*25,self.entity:GetAngles(),frozen)
@@ -212,7 +212,7 @@ end
 
 --------------------------------------------------------------------------------
 
-__e2setcost(5)
+__e2setcost(10)
 e2function void entity:propDelete()
 	if not PropCore.ValidAction(self, this, "delete") then return end
 	this:Remove()
@@ -280,7 +280,7 @@ e2function void propDeleteAll()
 end
 
 
-__e2setcost(5)
+__e2setcost(10)
 
 --------------------------------------------------------------------------------
 e2function void entity:propManipulate(vector pos, angle rot, number freeze, number gravity, number notsolid)
@@ -418,6 +418,7 @@ end
 
 --------------------------------------------------------------------------------
 
+__e2setcost(20)
 e2function void entity:setPos(vector pos)
 	if not PropCore.ValidAction(self, this, "pos") then return end
 	PropCore.PhysManipulate(this, pos, nil, nil, nil, nil)
@@ -463,6 +464,7 @@ e2function void entity:parentTo(entity target)
 	this:SetParent(target)
 end
 
+__e2setcost(5)
 e2function void entity:deparent()
 	if not PropCore.ValidAction(self, this, "deparent") then return end
 	this:SetParent( nil )

--- a/lua/entities/gmod_wire_expression2/core/hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/hologram.lua
@@ -621,7 +621,7 @@ end
 
 -- -----------------------------------------------------------------------------
 
-__e2setcost(20) -- temporary
+__e2setcost(30) -- temporary
 
 
 
@@ -693,6 +693,7 @@ e2function entity holoCreate(index)
 	if IsValid(ret) then return ret end
 end
 
+__e2setcost(20)
 e2function void holoDelete(index)
 	local Holo = CheckIndex(self, index)
 	if not Holo then return end
@@ -727,7 +728,7 @@ e2function void holoReset(index, string model, vector scale, vector color, strin
 	reset_clholo(Holo, scale) -- Reset scale, clips, and visible status
 end
 
-__e2setcost(5)
+__e2setcost(2)
 
 e2function number holoCanCreate()
 	if (not checkOwner(self)) then return 0 end
@@ -754,7 +755,7 @@ end
 
 -- -----------------------------------------------------------------------------
 
-__e2setcost(5) -- temporary
+__e2setcost(15) -- temporary
 
 e2function void holoScale(index, vector scale)
 	local Holo = CheckIndex(self, index)
@@ -836,11 +837,12 @@ e2function vector holoBoneScale(index, string bone)
 
 	return {0,0,0}
 end
-
+__e2setcost(1)
 e2function number holoClipsAvailable()
 	return wire_holograms_max_clips:GetInt()
 end
 
+__e2setcost(15)
 e2function void holoClipEnabled(index, enabled) -- Clip at first index
 	local Holo = CheckIndex(self, index)
 	if not Holo then return end
@@ -926,6 +928,7 @@ e2function void holoAlpha(index, alpha)
 	Holo.ent:SetRenderMode(Holo.ent:GetColor().a == 255 and RENDERMODE_NORMAL or RENDERMODE_TRANSALPHA)
 end
 
+__e2setcost(10)
 e2function void holoShadow(index, has_shadow)
 	local Holo = CheckIndex(self, index)
 	if not Holo then return end
@@ -952,10 +955,12 @@ e2function array holoModelList()
 	return mlist
 end
 
+__e2setcost(1)
 e2function number holoModelAny()
 	return wire_holograms_modelany:GetInt()
 end
 
+__e2setcost(10)
 e2function void holoModel(index, string model)
 	local Holo = CheckIndex(self, index)
 	if not Holo then return end
@@ -1070,6 +1075,7 @@ local function Check_Parents(child, parent)
 	return true
 end
 
+__e2setcost(40)
 e2function void holoParent(index, otherindex)
 	local Holo = CheckIndex(self, index)
 	if not Holo then return end
@@ -1120,6 +1126,7 @@ end
 
 -- -----------------------------------------------------------------------------
 
+__e2setcost(2)
 e2function entity holoEntity(index)
 	local Holo = CheckIndex(self, index)
 	if Holo and IsValid(Holo.ent) then return Holo.ent end

--- a/lua/entities/gmod_wire_expression2/core/table.lua
+++ b/lua/entities/gmod_wire_expression2/core/table.lua
@@ -366,12 +366,11 @@ e2function number table:count()
 	return this.size
 end
 
+__e2setcost(3)
 -- Returns the number of elements in the array-part of the table
 e2function number table:ncount()
 	return #this.n
 end
-
-__e2setcost(3)
 
 __e2setcost(1)
 -- Returns 1 if any value exists at the specified index, else 0

--- a/lua/entities/gmod_wire_expression2/core/timer.lua
+++ b/lua/entities/gmod_wire_expression2/core/timer.lua
@@ -62,7 +62,7 @@ end)
 
 /******************************************************************************/
 
-__e2setcost(5) -- approximation
+__e2setcost(20)
 
 e2function void interval(rv1)
 	AddTimer(self, "interval", rv1)
@@ -72,10 +72,13 @@ e2function void timer(string rv1, rv2)
 	AddTimer(self, rv1, rv2)
 end
 
+__e2setcost(5)
+
 e2function void stoptimer(string rv1)
 	RemoveTimer(self, rv1)
 end
 
+__e2setcost(1)
 e2function number clk()
 	if self.data.timer.runner == "interval"
 	   then return 1 else return 0 end
@@ -144,7 +147,7 @@ local function luaDateToE2Table( time, utc )
 	
 	return ret
 end
-
+__e2setcost(10)
 -- Returns the server's current time formatted neatly in a table
 e2function table date()
 	return luaDateToE2Table()
@@ -177,6 +180,7 @@ end
 
 -----------------------------------------------------------------------------------
 
+__e2setcost(2)
 -- Returns the time in seconds
 e2function number time()
 	return os.time()


### PR DESCRIPTION
Array get/set/pop/shift lowered (to match tables)
Holograms raised (which doesn't even begin to cover the network costs...)
PropCore generally raised, including setPos/ang, propSpawn (still ought to be even higher...)
interval() significantly raised (creating timers seems expensive)
A few simple getters were made cheaper (curtime, convars)
Fixes #887
Fixes #1061