### PR TITLE
Fix Camera controller not resetting camera back to player's view

### DIFF
--- a/lua/entities/gmod_wire_cameracontroller.lua
+++ b/lua/entities/gmod_wire_cameracontroller.lua
@@ -628,6 +628,16 @@ function ENT:DisableCam( ply )
 
 		ply.CamController = nil
 	else
+		--disable for everyone
+		for K,ply in ipairs(self.Players) do
+			if IsValid(ply) then
+				self:SetFOV( ply, false )
+				self:SetFLIR( ply, false )
+				self:SyncSettings( ply, false )
+
+				ply.CamController = nil
+			end
+		end
 		self.Players = {}
 	end
 


### PR DESCRIPTION
When attached to vehicle, camera controller couldn't be disabled by setting Activated to 0. Also if player will set Activated to 0 and leave vehicle, camera wouldn't reattach back to player.