### PR TITLE
Update Von from v1.1.0 -> v1.3.4

### DIFF
--- a/lua/wire/von.lua
+++ b/lua/wire/von.lua
@@ -1,6 +1,10 @@
---[[
-	Copyright 2012-2013 Alexandru-Mihai Maftei
+--[[	vON 1.3.4
+
+	Copyright 2012-2014 Alexandru-Mihai Maftei
 					aka Vercas
+
+	GitHub Repository:
+		https://github.com/vercas/vON
 
 	You may use this for any purpose as long as:
 	-	You don't remove this copyright notice.
@@ -8,9 +12,10 @@
 	-	You properly credit the author (Vercas) if you publish your work based on (and/or using) this.
 
 	If you modify the code for any purpose, the above obligations still apply.
+	If you make any interesting modifications, try forking the GitHub repository instead.
 
 	Instead of copying this code over for sharing, rather use the link:
-		https://dl.dropbox.com/u/1217587/GMod/Lua/von%20for%20GMOD.lua
+		https://github.com/vercas/vON/blob/master/von.lua
 
 	The author may not be held responsible for any damage or losses directly or indirectly caused by
 	the use of vON.
@@ -24,39 +29,52 @@
 										Suggested an excellent new way of deserializing strings.
 										Lead me to finding an extreme flaw in string parsing.
 		-	pennerlord					Provided some performance tests to help me improve the code.
+		-	Chessnut					Reported bug with handling of nil values when deserializing array components.
+
+		-	People who contributed on the GitHub repository by reporting bugs, posting fixes, etc.
 
 -----------------------------------------------------------------------------------------------------------------------------
 
-	The value types supported in this release of vON are:
+	The vanilla types supported in this release of vON are:
 		-	table
 		-	number
 		-	boolean
 		-	string
 		-	nil
-		-	Entity
-		-	Player
+
+	The Garry's Mod-specific types supported in this release are:
 		-	Vector
 		-	Angle
+		+	Entities:
+			-	Entity
+			-	Vehicle
+			-	Weapon
+			-	NPC
+			-	Player
+			-	NextBot
 
-	These are the native Lua types one would normally serialize.
-	+ Some very common GMod Lua types.
+	These are the types one would normally serialize.
 
 -----------------------------------------------------------------------------------------------------------------------------
 
 	New in this version:
-		-	Fixed errors on vector and angle deserializing.
-		-	Added Player datatype.
-			It's saved just like an entity, by it's ID, except it's prefixed with "p" instead of "e"
-		-	Added errors on (de)serialization when passwing the wrong data type.
-		-	Removed two redundant arguments in the serialization functable.
-		-	Fixed distribution link pointing to the pure Lua version.
+		-	Fixed addition of extra entity types. I messed up really badly.
 --]]
 
+
+
 local _deserialize, _serialize, _d_meta, _s_meta, d_findVariable, s_anyVariable
-local sub, gsub, find, insert, concat, error, tonumber, tostring, type, next, getEnt, getPly = string.sub, string.gsub, string.find, table.insert, table.concat, error, tonumber, tostring, type, next, Entity, player.GetByID
+local sub, gsub, find, insert, concat, error, tonumber, tostring, type, next = string.sub, string.gsub, string.find, table.insert, table.concat, error, tonumber, tostring, type, next
+
+
+
+--[[    This section contains localized functions which (de)serialize
+        variables according to the types found.                          ]]
+
+
 
 --	This is kept away from the table for speed.
-function d_findVariable(s, i, len, lastType)
+function d_findVariable(s, i, len, lastType, jobstate)
 	local i, c, typeRead, val = i or 1
 
 	--	Keep looping through the string.
@@ -72,13 +90,18 @@ function d_findVariable(s, i, len, lastType)
 		--	If it just read a type definition, then a variable HAS to come after it.
 		if typeRead then
 			--	Attempt to deserialize a variable of the freshly read type.
-			val, i = _deserialize[lastType](s, i, len)
+			val, i = _deserialize[lastType](s, i, len, false, jobstate)
 			--	Return the value read, the index of the last processed character, and the type of the last read variable.
 			return val, i, lastType
 
 		--	@ means nil. It should not even appear in the output string of the serializer. Nils are useless to store.
 		elseif c == "@" then
 			return nil, i, lastType
+
+		--	$ means a table reference will follow - a number basically.
+		elseif c == "$" then
+			lastType = "table_reference"
+			typeRead = true
 
 		--	n means a number will follow. Base 10... :C
 		elseif c == "n" then
@@ -90,9 +113,14 @@ function d_findVariable(s, i, len, lastType)
 			lastType = "boolean"
 			typeRead = true
 
-		--	" means the start of a string.
-		elseif c == "\"" then
+		--	' means the start of a string.
+		elseif c == "'" then
 			lastType = "string"
+			typeRead = true
+
+		--	" means the start of a string prior to version 1.2.0.
+		elseif c == "\"" then
+			lastType = "oldstring"
 			typeRead = true
 
 		--	{ means the start of a table!
@@ -100,29 +128,51 @@ function d_findVariable(s, i, len, lastType)
 			lastType = "table"
 			typeRead = true
 
-		--	n means a number will follow. Base 10... :C
+
+--[[    Garry's Mod types go here    ]]
+
+		--	e means an entity ID will follow.
 		elseif c == "e" then
 			lastType = "Entity"
 			typeRead = true
-
-		--	n means a number will follow. Base 10... :C
-		elseif c == "p" then
-			lastType = "Player"
+--[[
+		--	c means a vehicle ID will follow.
+		elseif c == "c" then
+			lastType = "Vehicle"
 			typeRead = true
 
-		--	n means a number will follow. Base 10... :C
+		--	w means a weapon entity ID will follow.
+		elseif c == "w" then
+			lastType = "Weapon"
+			typeRead = true
+
+		--	x means a NPC ID will follow.
+		elseif c == "x" then
+			lastType = "NPC"
+			typeRead = true
+--]]
+		--	p means a player ID will follow.
+		--	Kept for backwards compatibility.
+		elseif c == "p" then
+			lastType = "Entity"
+			typeRead = true
+
+		--	v means a vector will follow. 3 numbers.
 		elseif c == "v" then
 			lastType = "Vector"
 			typeRead = true
 
-		--	n means a number will follow. Base 10... :C
+		--	a means an Euler angle will follow. 3 numbers.
 		elseif c == "a" then
 			lastType = "Angle"
 			typeRead = true
 
+--[[    Garry's Mod types end here    ]]
+
+
 		--	If no type has been found, attempt to deserialize the last type read.
 		elseif lastType then
-			val, i = _deserialize[lastType](s, i, len)
+			val, i = _deserialize[lastType](s, i, len, false, jobstate)
 			return val, i, lastType
 
 		--	This will occur if the very first character in the vON code is wrong.
@@ -136,30 +186,67 @@ function d_findVariable(s, i, len, lastType)
 end
 
 --	This is kept away from the table for speed.
---	Yeah, crapload of parameters.
-function s_anyVariable(data, lastType, isNumeric, isKey, isLast, nice, indent)
+--	Yeah, ton of parameters.
+function s_anyVariable(data, lastType, isNumeric, isKey, isLast, jobstate)
+	local tp = type(data)
+
+	if jobstate[1] and jobstate[2][data] then
+		tp = "table_reference"
+	end
 
 	--	Basically, if the type changes.
-	if lastType ~= type(data) then
+	if lastType ~= tp then
 		--	Remember the new type. Caching the type is useless.
-		lastType = type(data)
+		lastType = tp
 
-		--	Return the serialized data and the (new) last type.
-		--	The second argument, which is true now, means that the data type was just changed.
-		return _serialize[lastType](data, true, isNumeric, isKey, isLast, nice, indent), lastType
+		if _serialize[lastType] then
+			--	Return the serialized data and the (new) last type.
+			--	The second argument, which is true now, means that the data type was just changed.
+			return _serialize[lastType](data, true, isNumeric, isKey, isLast, false, jobstate), lastType
+		else
+			error("vON: No serializer defined for type \"" .. lastType .. "\"!")
+		end
 	end
 
 	--	Otherwise, simply serialize the data.
-	return _serialize[lastType](data, false, isNumeric, isKey, isLast, nice, indent), lastType
+	return _serialize[lastType](data, false, isNumeric, isKey, isLast, false, jobstate), lastType
 end
 
-_deserialize = {
 
+
+--[[    This section contains the tables with the functions necessary
+        for decoding basic Lua data types.                               ]]
+
+
+
+_deserialize = {
 --	Well, tables are very loose...
 --	The first table doesn't have to begin and end with { and }.
-	["table"] = function(s, i, len, unnecessaryEnd)
-		local ret, numeric, i, c, lastType, val, ind, expectValue, key = {}, true, i or 1
+	["table"] = function(s, i, len, unnecessaryEnd, jobstate)
+		local ret, numeric, i, c, lastType, val, ind, expectValue, key = {}, true, i or 1, nil, nil, nil, 1
 		--	Locals, locals, locals, locals, locals, locals, locals, locals and locals.
+
+		if sub(s, i, i) == "#" then
+			local e = find(s, "#", i + 2, true)
+
+			if e then
+				local id = tonumber(sub(s, i + 1, e - 1))
+
+				if id then
+					if jobstate[1][id] and not jobstate[2] then
+						error("vON: There already is a table of reference #" .. id .. "! Missing an option maybe?")
+					end
+
+					jobstate[1][id] = ret
+
+					i = e + 1
+				else
+					error("vON: Malformed table! Reference ID starting at char #" .. i .. " doesn't contain a number!")
+				end
+			else
+				error("vON: Malformed table! Cannot find end of reference ID start at char #" .. i .. "!")
+			end
+		end
 
 		--	Keep looping.
 		while true do
@@ -176,7 +263,7 @@ _deserialize = {
 			end
 
 			--	Cache the character.
-			c = sub(s,i,i)
+			c = sub(s, i, i)
 			--print(i, "table char:", c, tostring(unnecessaryEnd))
 
 			--	If it's the end of a table definition, return.
@@ -194,16 +281,18 @@ _deserialize = {
 			--	OK, now, if it's on the numeric component, simply add everything encountered.
 			elseif numeric then
 				--	Find a variable and it's value
-				val, i, lastType = d_findVariable(s, i, len, lastType)
+				val, i, lastType = d_findVariable(s, i, len, lastType, jobstate)
 				--	Add it to the table.
-				ret[#ret + 1] = val
+				ret[ind] = val
+
+				ind = ind + 1
 
 			--	Otherwise, if it's the key:value component...
 			else
 				--	If a value is expected...
 				if expectValue then
 					--	Read it.
-					val, i, lastType = d_findVariable(s, i, len, lastType)
+					val, i, lastType = d_findVariable(s, i, len, lastType, jobstate)
 					--	Add it?
 					ret[key] = val
 					--	Clean up.
@@ -222,7 +311,7 @@ _deserialize = {
 				--	Otherwise the key will be read.
 				else
 					--	I love multi-return and multi-assignement.
-					key, i, lastType = d_findVariable(s, i, len, lastType)
+					key, i, lastType = d_findVariable(s, i, len, lastType, jobstate)
 				end
 			end
 
@@ -232,19 +321,43 @@ _deserialize = {
 		return nil, i
 	end,
 
-
---	Numbers are weakly defined.
---	The declaration is not very explicit. It'll do it's best to parse the number.
---	Has various endings: \n, }, ~, : and ;, some of which will force the table deserializer to go one char backwards.
-	["number"] = function(s, i, len)
+--	Just a number which points to a table.
+	["table_reference"] = function(s, i, len, unnecessaryEnd, jobstate)
 		local i, a = i or 1
 		--	Locals, locals, locals, locals
 
 		a = find(s, "[;:}~]", i)
 
 		if a then
-			return tonumber(sub(s, i, a - 1)), a - 1
+			local n = tonumber(sub(s, i, a - 1))
+
+			if n then
+				return jobstate[1][n] or error("vON: Table reference does not point to a (yet) known table!"), a - 1
+			else
+				error("vON: Table reference definition does not contain a valid number!")
+			end
 		end
+
+		--	Using %D breaks identification of negative numbers. :(
+
+		error("vON: Number definition started... Found no end.")
+	end,
+
+
+--	Numbers are weakly defined.
+--	The declaration is not very explicit. It'll do it's best to parse the number.
+--	Has various endings: \n, }, ~, : and ;, some of which will force the table deserializer to go one char backwards.
+	["number"] = function(s, i, len, unnecessaryEnd, jobstate)
+		local i, a = i or 1
+		--	Locals, locals, locals, locals
+
+		a = find(s, "[;:}~]", i)
+
+		if a then
+			return tonumber(sub(s, i, a - 1)) or error("vON: Number definition does not contain a valid number!"), a - 1
+		end
+
+		--	Using %D breaks identification of negative numbers. :(
 
 		error("vON: Number definition started... Found no end.")
 	end,
@@ -252,7 +365,7 @@ _deserialize = {
 
 --	A boolean is A SINGLE CHARACTER, either 1 for true or 0 for false.
 --	Any other attempt at boolean declaration will result in a failure.
-	["boolean"] = function(s, i, len)
+	["boolean"] = function(s, i, len, unnecessaryEnd, jobstate)
 		local c = sub(s,i,i)
 		--	Only one character is needed.
 
@@ -270,10 +383,8 @@ _deserialize = {
 	end,
 
 
---	Strings are very easy to parse and also very explicit.
---	" simply marks the type of a string.
---	Then it is parsed until an unescaped " is countered.
-	["string"] = function(s, i, len)
+--	Strings prior to 1.2.0
+	["oldstring"] = function(s, i, len, unnecessaryEnd, jobstate)
 		local res, i, a = "", i or 1
 		--	Locals, locals, locals, locals
 
@@ -288,117 +399,41 @@ _deserialize = {
 					return res .. sub(s, i, a - 2), a
 				end
 			else
-				error("vON: String definition started... Found no end.")
+				error("vON: Old string definition started... Found no end.")
 			end
 		end
 	end,
 
-
---	Entities are stored simply by the ID. They're meant to be transfered, not stored anyway.
---	Exactly like a number definition, except it begins with "e".
-	["Entity"] = function(s, i, len)
-		local i, a = i or 1
+--	Strings after 1.2.0
+	["string"] = function(s, i, len, unnecessaryEnd, jobstate)
+		local res, i, a = "", i or 1
 		--	Locals, locals, locals, locals
 
-		a = find(s, "[;:}~]", i)
+		while true do
+			a = find(s, "\"", i, true)
 
-		if a then
-			return getEnt(tonumber(sub(s, i, a - 1))), a - 1
+			if a then
+				if sub(s, a - 1, a - 1) == "\\" then
+					res = res .. sub(s, i, a - 2) .. "\""
+					i = a + 1
+				else
+					return res .. sub(s, i, a - 1), a
+				end
+			else
+				error("vON: String definition started... Found no end.")
+			end
 		end
-
-		error("vON: Entity ID definition started... Found no end.")
 	end,
-
-
---	Exactly like a entity definition, except it begins with "p".
-	["Player"] = function(s, i, len)
-		local i, a = i or 1
-		--	Locals, locals, locals, locals
-
-		a = find(s, "[;:}~]", i)
-
-		if a then
-			return getEnt(tonumber(sub(s, i, a - 1))), a - 1
-		end
-
-		error("vON: Player ID definition started... Found no end.")
-	end,
-
-
---	A pair of 3 numbers separated by a comma (,).
-	["Vector"] = function(s, i, len)
-		local i, a, x, y, z = i or 1
-		--	Locals, locals, locals, locals
-
-		a = find(s, ",", i)
-
-		if a then
-			x = tonumber(sub(s, i, a - 1))
-			i = a + 1
-		end
-
-		a = find(s, ",", i)
-
-		if a then
-			y = tonumber(sub(s, i, a - 1))
-			i = a + 1
-		end
-
-		a = find(s, "[;:}~]", i)
-
-		if a then
-			z = tonumber(sub(s, i, a - 1))
-		end
-
-		if x and y and z then
-			return Vector(x, y, z), a - 1
-		end
-
-		error("vON: Vector definition started... Found no end.")
-	end,
-
-
---	A pair of 3 numbers separated by a comma (,).
-	["Angle"] = function(s, i, len)
-		local i, a, p, y, r = i or 1
-		--	Locals, locals, locals, locals
-
-		a = find(s, ",", i)
-
-		if a then
-			p = tonumber(sub(s, i, a - 1))
-			i = a + 1
-		end
-
-		a = find(s, ",", i)
-
-		if a then
-			y = tonumber(sub(s, i, a - 1))
-			i = a + 1
-		end
-
-		a = find(s, "[;:}~]", i)
-
-		if a then
-			r = tonumber(sub(s, i, a - 1))
-		end
-
-		if p and y and r then
-			return Angle(p, y, r), a - 1
-		end
-
-		error("vON: Angle definition started... Found no end.")
-	end
 }
 
 
-_serialize = {
 
+_serialize = {
 --	Uh. Nothing to comment.
---	Shitload of parameters.
---	Makes shit faster than simply passing it around in locals.
+--	Ton of parameters.
+--	Makes stuff faster than simply passing it around in locals.
 --	table.concat works better than normal concatenations WITH LARGE-ISH STRINGS ONLY.
-	["table"] = function(data, mustInitiate, isNumeric, isKey, isLast, first)
+	["table"] = function(data, mustInitiate, isNumeric, isKey, isLast, first, jobstate)
 		--print(string.format("data: %s; mustInitiate: %s; isKey: %s; isLast: %s; nice: %s; indent: %s; first: %s", tostring(data), tostring(mustInitiate), tostring(isKey), tostring(isLast), tostring(nice), tostring(indent), tostring(first)))
 
 		local result, keyvals, len, keyvalsLen, keyvalsProgress, val, lastType, newIndent, indentString = {}, {}, #data, 0, 0
@@ -408,10 +443,10 @@ _serialize = {
 		--	pairs(data) is slower than next, data as far as my tests tell me.
 		for k, v in next, data do
 			--	Skip the numeric keyz.
-			if type(k) ~= "number" or k < 1 or k > len then
-				keyvals[#keyvals + 1] = k
-			end
-		end
+			if type(k) ~= "number" or k < 1 or k > len or (k % 1 ~= 0) then	--	k % 1 == 0 is, as proven by personal benchmarks,
+				keyvals[#keyvals + 1] = k									--	the quickest way to check if a number is an integer.
+			end																--	k % 1 ~= 0 is the fastest way to check if a number
+		end																	--	is NOT an integer. > is proven slower.
 
 		keyvalsLen = #keyvals
 
@@ -420,10 +455,22 @@ _serialize = {
 			result[#result + 1] = "{"
 		end
 
+		if jobstate[1] and jobstate[1][data] then
+			if jobstate[2][data] then
+				error("vON: Table #" .. jobstate[1][data] .. " written twice..?")
+			end
+
+			result[#result + 1] = "#"
+			result[#result + 1] = jobstate[1][data]
+			result[#result + 1] = "#"
+
+			jobstate[2][data] = true
+		end
+
 		--	Add numeric values.
 		if len > 0 then
 			for i = 1, len do
-				val, lastType = s_anyVariable(data[i], lastType, true, false, i == len and not first, false, 0)
+				val, lastType = s_anyVariable(data[i], lastType, true, false, i == len and not first, jobstate)
 				result[#result + 1] = val
 			end
 		end
@@ -437,11 +484,11 @@ _serialize = {
 			for _i = 1, keyvalsLen do
 				keyvalsProgress = keyvalsProgress + 1
 
-				val, lastType = s_anyVariable(keyvals[_i], lastType, false, true, false, false, 0)
+				val, lastType = s_anyVariable(keyvals[_i], lastType, false, true, false, jobstate)
 
 				result[#result + 1] = val..":"
 
-				val, lastType = s_anyVariable(data[keyvals[_i]], lastType, false, false, keyvalsProgress == keyvalsLen and not first, false, 0)
+				val, lastType = s_anyVariable(data[keyvals[_i]], lastType, false, false, keyvalsProgress == keyvalsLen and not first, jobstate)
 
 				result[#result + 1] = val
 			end
@@ -455,10 +502,30 @@ _serialize = {
 		return concat(result)
 	end,
 
+--	Number which points to table.
+	["table_reference"] = function(data, mustInitiate, isNumeric, isKey, isLast, first, jobstate)
+		data = jobstate[1][data]
+
+		--	If a number hasn't been written before, add the type prefix.
+		if mustInitiate then
+			if isKey or isLast then
+				return "$"..data
+			else
+				return "$"..data..";"
+			end
+		end
+
+		if isKey or isLast then
+			return data
+		else
+			return data..";"
+		end
+	end,
+
 
 --	Normal concatenations is a lot faster with small strings than table.concat
 --	Also, not so branched-ish.
-	["number"] = function(data, mustInitiate, isNumeric, isKey, isLast)
+	["number"] = function(data, mustInitiate, isNumeric, isKey, isLast, first, jobstate)
 		--	If a number hasn't been written before, add the type prefix.
 		if mustInitiate then
 			if isKey or isLast then
@@ -469,21 +536,25 @@ _serialize = {
 		end
 
 		if isKey or isLast then
-			return "n"..data
+			return data
 		else
-			return "n"..data..";"
+			return data..";"
 		end
 	end,
 
 
 --	I hope gsub is fast enough.
-	["string"] = function(data, mustInitiate, isNumeric, isKey, isLast)
-		return "\"" .. gsub(data, "\"", "\\\"") .. "v\""
+	["string"] = function(data, mustInitiate, isNumeric, isKey, isLast, first, jobstate)
+		if sub(data, #data, #data) == "\\" then	--	Hah, old strings fix this best.
+			return "\"" .. gsub(data, "\"", "\\\"") .. "v\""
+		end
+
+		return "'" .. gsub(data, "\"", "\\\"") .. "\""
 	end,
 
 
 --	Fastest.
-	["boolean"] = function(data, mustInitiate, isNumeric, isKey, isLast)
+	["boolean"] = function(data, mustInitiate, isNumeric, isKey, isLast, first, jobstate)
 		--	Prefix if we must.
 		if mustInitiate then
 			if data then
@@ -502,108 +573,246 @@ _serialize = {
 
 
 --	Fastest.
-	["nil"] = function(data, mustInitiate, isNumeric, isKey, isLast)
+	["nil"] = function(data, mustInitiate, isNumeric, isKey, isLast, first, jobstate)
 		return "@"
 	end,
+}
 
 
+
+--[[    This section handles additions necessary for Garry's Mod.    ]]
+
+
+
+if gmod then	--	Luckily, a specific table named after the game is present in Garry's Mod.
+	local Entity = Entity
+
+
+
+	local extra_deserialize = {
+--	Entities are stored simply by the ID. They're meant to be transfered, not stored anyway.
+--	Exactly like a number definition, except it begins with "e".
+		["Entity"] = function(s, i, len, unnecessaryEnd, jobstate)
+			local i, a = i or 1
+			--	Locals, locals, locals, locals
+
+			a = find(s, "[;:}~]", i)
+
+			if a then
+				return Entity(tonumber(sub(s, i, a - 1))), a - 1
+			end
+
+			error("vON: Entity ID definition started... Found no end.")
+		end,
+
+
+--	A pair of 3 numbers separated by a comma (,).
+		["Vector"] = function(s, i, len, unnecessaryEnd, jobstate)
+			local i, a, x, y, z = i or 1
+			--	Locals, locals, locals, locals
+
+			a = find(s, ",", i)
+
+			if a then
+				x = tonumber(sub(s, i, a - 1))
+				i = a + 1
+			end
+
+			a = find(s, ",", i)
+
+			if a then
+				y = tonumber(sub(s, i, a - 1))
+				i = a + 1
+			end
+
+			a = find(s, "[;:}~]", i)
+
+			if a then
+				z = tonumber(sub(s, i, a - 1))
+			end
+
+			if x and y and z then
+				return Vector(x, y, z), a - 1
+			end
+
+			error("vON: Vector definition started... Found no end.")
+		end,
+
+
+--	A pair of 3 numbers separated by a comma (,).
+		["Angle"] = function(s, i, len, unnecessaryEnd, jobstate)
+			local i, a, p, y, r = i or 1
+			--	Locals, locals, locals, locals
+
+			a = find(s, ",", i)
+
+			if a then
+				p = tonumber(sub(s, i, a - 1))
+				i = a + 1
+			end
+
+			a = find(s, ",", i)
+
+			if a then
+				y = tonumber(sub(s, i, a - 1))
+				i = a + 1
+			end
+
+			a = find(s, "[;:}~]", i)
+
+			if a then
+				r = tonumber(sub(s, i, a - 1))
+			end
+
+			if p and y and r then
+				return Angle(p, y, r), a - 1
+			end
+
+			error("vON: Angle definition started... Found no end.")
+		end,
+	}
+
+	local extra_serialize = {
 --	Same as numbers, except they start with "e" instead of "n".
-	["Entity"] = function(data, mustInitiate, isNumeric, isKey, isLast)
-		data = data:EntIndex()
+		["Entity"] = function(data, mustInitiate, isNumeric, isKey, isLast, first, jobstate)
+			data = data:EntIndex()
 
-		if mustInitiate then
-			if isKey or isLast then
-				return "e"..data
-			else
-				return "e"..data..";"
+			if mustInitiate then
+				if isKey or isLast then
+					return "e"..data
+				else
+					return "e"..data..";"
+				end
 			end
-		end
 
-		if isKey or isLast then
-			return "e"..data
-		else
-			return "e"..data..";"
-		end
-	end,
-
-
---	Same as entities, except they start with "e" instead of "n".
-	["Player"] = function(data, mustInitiate, isNumeric, isKey, isLast)
-		data = data:EntIndex()
-
-		if mustInitiate then
 			if isKey or isLast then
-				return "p"..data
+				return data
 			else
-				return "p"..data..";"
+				return data..";"
 			end
-		end
-
-		if isKey or isLast then
-			return "p"..data
-		else
-			return "p"..data..";"
-		end
-	end,
+		end,
 
 
 --	3 numbers separated by a comma.
-	["Vector"] = function(data, mustInitiate, isNumeric, isKey, isLast)
-		if mustInitiate then
-			if isKey or isLast then
-				return "v"..data.x..","..data.y..","..data.z
-			else
-				return "v"..data.x..","..data.y..","..data.z..";"
+		["Vector"] = function(data, mustInitiate, isNumeric, isKey, isLast, first, jobstate)
+			if mustInitiate then
+				if isKey or isLast then
+					return "v"..data.x..","..data.y..","..data.z
+				else
+					return "v"..data.x..","..data.y..","..data.z..";"
+				end
 			end
-		end
 
-		if isKey or isLast then
-			return "v"..data.x..","..data.y..","..data.z
-		else
-			return "v"..data.x..","..data.y..","..data.z..";"
-		end
-	end,
+			if isKey or isLast then
+				return data.x..","..data.y..","..data.z
+			else
+				return data.x..","..data.y..","..data.z..";"
+			end
+		end,
 
 
 --	3 numbers separated by a comma.
-	["Angle"] = function(data, mustInitiate, isNumeric, isKey, isLast)
-		if mustInitiate then
-			if isKey or isLast then
-				return "a"..data.p..","..data.y..","..data.r
-			else
-				return "a"..data.p..","..data.y..","..data.r..";"
+		["Angle"] = function(data, mustInitiate, isNumeric, isKey, isLast, first, jobstate)
+			if mustInitiate then
+				if isKey or isLast then
+					return "a"..data.p..","..data.y..","..data.r
+				else
+					return "a"..data.p..","..data.y..","..data.r..";"
+				end
 			end
+
+			if isKey or isLast then
+				return data.p..","..data.y..","..data.r
+			else
+				return data.p..","..data.y..","..data.r..";"
+			end
+		end,
+	}
+
+	for k, v in pairs(extra_serialize) do
+		_serialize[k] = v
+	end
+
+	for k, v in pairs(extra_deserialize) do
+		_deserialize[k] = v
+	end
+
+	local extraEntityTypes = { "Vehicle", "Weapon", "NPC", "Player", "NextBot" }
+
+	for i = 1, #extraEntityTypes do
+		_serialize[extraEntityTypes[i]] = _serialize.Entity
+	end
+end
+
+
+
+--[[    This section exposes the functions of the library.    ]]
+
+
+
+local function checkTableForRecursion(tab, checked, assoc)
+	local id = checked.ID
+
+	if not checked[tab] and not assoc[tab] then
+		assoc[tab] = id
+		checked.ID = id + 1
+	else
+		checked[tab] = true
+	end
+
+	for k, v in pairs(tab) do
+		if type(k) == "table" and not checked[k] then
+			checkTableForRecursion(k, checked, assoc)
 		end
 
-		if isKey or isLast then
-			return "a"..data.p..","..data.y..","..data.r
-		else
-			return "a"..data.p..","..data.y..","..data.r..";"
+		if type(v) == "table" and not checked[v] then
+			checkTableForRecursion(v, checked, assoc)
 		end
 	end
-}
+end
+
+
 
 local _s_table = _serialize.table
 local _d_table = _deserialize.table
 
 _d_meta = {
-	__call = function(self, str)
+	__call = function(self, str, allowIdRewriting)
 		if type(str) == "string" then
-			return _d_table(str, nil, #str, true)
+			return _d_table(str, nil, #str, true, {{}, allowIdRewriting})
 		end
+
 		error("vON: You must deserialize a string, not a "..type(str))
 	end
 }
 _s_meta = {
-	__call = function(self, data)
+	__call = function(self, data, checkRecursion)
 		if type(data) == "table" then
-			return _s_table(data, nil, nil, nil, nil, true)
+			if checkRecursion then
+				local assoc, checked = {}, {ID = 1}
+
+				checkTableForRecursion(data, checked, assoc)
+
+				return _s_table(data, nil, nil, nil, nil, true, {assoc, {}})
+			end
+
+			return _s_table(data, nil, nil, nil, nil, true, {false})
 		end
+
 		error("vON: You must serialize a table, not a "..type(data))
 	end
 }
 
-WireLib.von = {}
 
-WireLib.von.deserialize = setmetatable(_deserialize,_d_meta)
-WireLib.von.serialize = setmetatable(_serialize,_s_meta)
+
+von = {
+	version = "1.3.4",
+	versionNumber = 1003004,	--	Reserving 3 digits per version component.
+
+	deserialize = setmetatable(_deserialize,_d_meta),
+	serialize = setmetatable(_serialize,_s_meta)
+}
+
+
+
+return von


### PR DESCRIPTION
Probably backwards compatible deserialization for Wire's purposes. I don't see anything in the deserialization code that should cause us any BC issues - there's a new shorter string syntax, but the old one's still there. A new nested table reference syntax, not having it won't hurt. Repeated numbers can now be stored shorter, but it still seems to parse the longer ones fine. I think it previously stored some Player/Vehicle/Weapon/Entities as the wrong type, but E2 would always be storing/retrieving plain Entities anyway, so shouldn't be an issue?

My test E2 of trying to decode/encode
```
vonEncode(table(5,6,entity(1),"hey", "this has a \" quote", table(7, owner())))
```
between versions works fine going from old -> new.
Would recommend someone who's actually stored lots of stuff with von tries decoding it with this (you can easily switch to new von by checking out this branch, and then running in console `lua_openscript wire/von.lua`)
Fixes #923