### PR TITLE
Remove randomness from base_wire_entity RB update

### DIFF
--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -225,7 +225,11 @@ if CLIENT then
 
 	function ENT:Think()
 		if (CurTime() >= (self.NextRBUpdate or 0)) then
-			self.NextRBUpdate = CurTime() + math.random(30,100)/10 --update renderbounds every 3 to 10 seconds
+			-- We periodically update the render bounds every 10 seconds - the
+			-- reasons why are mostly anecdotal, but in some circumstances
+			-- entities might 'forget' their renderbounds. Nobody really knows
+			-- if this is still needed or not.
+			self.NextRBUpdate = CurTime() + 10
 			Wire_UpdateRenderBounds(self)
 		end
 	end


### PR DESCRIPTION
Remove randomness from base_wire_entity RB update

If it's good enough to update randomly every 3 to 10 seconds, it's good
enough to update every 10 seconds. It'd still be better to have some
evidence of why this is needed, and I'd be happy for it to be removed in
future, but this at least makes things slightly less ugly and bizarre.

Fixes #581.