### PR TITLE
E2: Allow NULL and worldspawn to be used as entities

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -11,7 +11,7 @@ registerType("entity", "e", nil,
 		if not retval.EntIndex then error("Return value is neither nil nor an Entity, but a "..type(retval).."!",0) end
 	end,
 	function(v)
-		return not isentity(v) or not IsValid(v)
+		return not isentity(v)
 	end
 )
 


### PR DESCRIPTION
Currently, the typecheck for entities in E2 says that invalid entities such as NULL and worldspawn aren't entities at all. This means that they're skipped inconsistently in places.

Fixes #1388. Fixes #1350.