### PR TITLE
Allow rebound key to trigger pod Light output

### DIFF
--- a/lua/entities/gmod_wire_pod.lua
+++ b/lua/entities/gmod_wire_pod.lua
@@ -11,6 +11,8 @@ if CLIENT then
 				bind = "1"
 			elseif (bind == "invnext") then
 				bind = "2"
+			elseif bind == "impulse 100" then
+				bind = "3"
 			else return end
 			RunConsoleCommand("wire_pod_bind", bind )
 		end
@@ -249,6 +251,7 @@ concommand.Add("wire_pod_bind", function( ply,cmd,args )
 
 	if (bind == "1") then bind = "PrevWeapon"
 	elseif (bind == "2") then bind = "NextWeapon"
+	elseif bind == "3" then bind = "Light"
 	end
 
 	for _, pod in pairs( ents.FindByClass( "gmod_wire_pod" ) ) do
@@ -453,8 +456,6 @@ function ENT:Think()
 		WireLib.TriggerOutput(self, "Health", ply:Health())
 		WireLib.TriggerOutput(self, "Armor", ply:Armor())
 		if self:HasPod() then WireLib.TriggerOutput(self, "ThirdPerson", pod:GetThirdPersonMode() and 1 or 0) end
-
-		if not ply:IsBot() then WireLib.TriggerOutput(self, "Light", ply.keystate[KEY_F] and 1 or 0) end
 	end
 
 	self:NextThink( CurTime() )


### PR DESCRIPTION
This does change the behaviour to only output once when it's pressed, not
when it's held. This matches the behaviour of the NextWeapon and
PreviousWeapon outputs. (In future, they could all be updated to do
something clever with input.LookupBinding.)

Fixes #1453.