### PR TITLE
Fix local operator not forcing a declaration

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -477,6 +477,12 @@ function Parser:Stmt8()
 		self:Error("Invalid operator (local) can not be used after varible decleration.")
 	elseif self:AcceptRoamingToken("loc") then
 		self.localized = true
+
+		if not self:AcceptRoamingToken("var") then
+			self:Error("Variable name expected after local")
+		end
+
+		self:TrackBack()
 	end
 
 	if self:AcceptRoamingToken("var") then


### PR DESCRIPTION
Partially fixes #1200 

This forces a valid variable name to come after the local operator. Without this syntax like this is allowed

```
local print(1)
```