### PR TITLE
Run AdvDupe_FinishPasting for normal Duplicator

### DIFF
--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -795,7 +795,7 @@ E2Helper.Descriptions["toString(q:)"] = "Formats Q as a string"
 -- Selfaware
 E2Helper.Descriptions["first()"] = "Returns 1 if the expression was spawned or reset"
 E2Helper.Descriptions["duped()"] = "Returns 1 if the expression was duplicated"
-E2Helper.Descriptions["dupefinished()"] = "Returns 1 when the contraption has finished duping. (Only triggers on Adv Duplicator, not the normal duplicator)"
+E2Helper.Descriptions["dupefinished()"] = "Returns 1 when the contraption has finished duping."
 E2Helper.Descriptions["inputClk()"] = "Returns 1 if the expression was triggered by an input"
 E2Helper.Descriptions["last()"] = "Returns 1 if it is being called on the last execution of the expression gate before it is removed or reset. This execution must be requested with the runOnLast(1) command"
 E2Helper.Descriptions["removing()"] = "Returns 1 if this is the last() execution and caused by the entity being removed"

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1200,3 +1200,27 @@ function WireLib.IsValidMaterial(material)
 	return material
 end
 
+if not WireLib.PatchedDuplicator then
+	WireLib.PatchedDuplicator = true
+
+	local localPos
+
+	local oldSetLocalPos = duplicator.SetLocalPos
+	function duplicator.SetLocalPos(pos, ...)
+		localPos = pos
+		return oldSetLocalPos(pos, ...)
+	end
+
+	local oldPaste = duplicator.Paste
+	function duplicator.Paste(player, entityList, constraintList, ...)
+		local result = { oldPaste(player, entityList, constraintList, ...) }
+		local createdEntities, createdConstraints = result[1], result[2]
+		local data = {
+			EntityList = entityList, ConstraintList = constraintList,
+			CreatedEntities = createdEntities, CreatedConstraints = createdConstraints,
+			Player = player, HitPos = localPos,
+		}
+		hook.Run("AdvDupe_FinishPasting", {data}, 1)
+		return unpack(result)
+	end
+end


### PR DESCRIPTION
AdvDupe_FinishPasting is a hook that both advduplicator and advdupe2
call once the contraption has finished pasting. It's useful for E2s, as
running on "if (first() | duped())" means that it can run before your
contraption is only partially pasted. This means that for E2s that are
expecting to be pasted as part of a large contraption, it's only really
possible to use one of the non-standard duplicator tools, for
dupefinished()'s sake.

This patches the `duplicator` module to also call AdvDupe_FinishPasting
when it's done. It passes all the same data as advdupe2 does, which
means that it should be compatible with anything that's out there in the
wild.

The way the code is written also allows for the duplicator module
functions to start taking extra parameters and returning extra values
without breaking the code.

Fixes #1407. Closes #1515.