### PR TITLE
Fix wire keyboard IgnoreFirstKey hardcode to KEY_E

### DIFF
--- a/lua/entities/gmod_wire_keyboard/init.lua
+++ b/lua/entities/gmod_wire_keyboard/init.lua
@@ -59,7 +59,7 @@ function ENT:Initialize()
 	self:PhysicsInit(SOLID_VPHYSICS)
 	self:SetMoveType(MOVETYPE_VPHYSICS)
 	self:SetSolid(SOLID_VPHYSICS)
-	self:SetUseType(SIMPLE_USE)
+	self:SetUseType(ONOFF_USE)
 
 	self.Inputs = WireLib.CreateInputs(self, { "Kick", "Reset Output String" })
 	self.Outputs = WireLib.CreateOutputs(self, { "Memory", "Output [STRING]", "OutputChar [STRING]", "ActiveKeys [ARRAY]", "User [ENTITY]", "InUse" })
@@ -182,9 +182,6 @@ function ENT:PlayerAttach(ply)
 	-- Set the wire keyboard value on the player
 	ply.WireKeyboard = self
 
-	-- Ignore the first key (the "Use" key - default "e" - pressed when entering the keyboard)
-	self.IgnoreFirstKey = true
-
 	-- Reset tables
 	self.BufferLookup = {}
 	self.ActiveKeys = {}
@@ -218,7 +215,8 @@ function ENT:PlayerDetach()
 	self:TriggerOutputs()
 end
 
-function ENT:Use(ply)
+function ENT:Use(ply, _, type)
+	if type ~= USE_OFF then return end
 	if IsValid(self.Pod) then
 		ply:ChatPrint("This keyboard is linked to a pod. Please use the pod instead.")
 		return
@@ -380,13 +378,6 @@ end
 function ENT:Think()
 	if not IsValid(self.ply) then
 		self:NextThink(CurTime() + 0.3) -- Don't need to update as often
-		return true
-	end
-
-	if self.IgnoreFirstKey then -- Don't start listening to keys until Use is released
-		if not self.ply.keystate[KEY_E] then self.IgnoreFirstKey = nil end
-
-		self:NextThink(CurTime())
 		return true
 	end
 


### PR DESCRIPTION
Fixes #893.

This listens for when IN_USE is *released* on keyboard rather than pressed.