### PR TITLE
Fix UDF name highlighting if name is a type

### DIFF
--- a/lua/wire/client/text_editor/modes/e2.lua
+++ b/lua/wire/client/text_editor/modes/e2.lua
@@ -288,11 +288,7 @@ function EDITOR:SyntaxColorLine(row)
       addToken( "notfound", returntype )
     end
     addToken( "comment", spaces )
-    if istype( funcname ) then -- Hey... this isn't a function name! :O
-    addToken( "typename", funcname )
-    else
-      addToken( "userfunction", funcname )
-    end
+    addToken( "userfunction", funcname )
 
     if not wire_expression2_funclist[funcname] then
       self.e2fs_functions[funcname] = row
@@ -318,14 +314,10 @@ function EDITOR:SyntaxColorLine(row)
     elseif self:NextPattern( "[a-z][a-zA-Z0-9_]*" ) then -- funcname
     local funcname = self.tokendata:match( "[a-z][a-zA-Z0-9_]*" )
 
-    if istype( funcname ) or funcname == "void" then -- Hey... this isn't a function name! :O
-    addToken( "typename", funcname )
-    else
-      addToken( "userfunction", funcname )
+    addToken( "userfunction", funcname )
 
-      if not wire_expression2_funclist[funcname] then
-        self.e2fs_functions[funcname] = row
-      end
+    if not wire_expression2_funclist[funcname] then
+      self.e2fs_functions[funcname] = row
     end
 
     self.tokendata = ""


### PR DESCRIPTION
This is showcased in #1200.

I'm not sure why this check is here, it was added in with the rest of the UDF system in d764fc18ef229003f19705cc8a215d97b5a99216. I don't see any issues with any of my E2s using UDFs after this change so I assume it was just a mistake?

Before: 
![](https://i.imgur.com/KLxcuVL.png)

After:
![](https://i.imgur.com/81FLtW9.png)

Side note: The formatting in these files should be cleaned up at some point.