### PR TITLE
Fix HTTP executing all owned E2s

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/http.lua
+++ b/lua/entities/gmod_wire_expression2/core/http.lua
@@ -46,10 +46,9 @@ e2function void httpRequest( string url )
 
 		run_on.clk = 1
 
-		for ent,eply in pairs( run_on.ents ) do
-			if IsValid( ent ) and ent.Execute and eply == ply then
-				ent:Execute()
-			end
+		local ent = self.entity
+		if IsValid(ent) and run_on.ents[ent] then
+			ent:Execute()
 		end
 
 		run_on.clk = 0
@@ -97,7 +96,7 @@ e2function string httpUrlDecode(string data)
 end
 
 e2function void runOnHTTP( number rohttp )
-	run_on.ents[self.entity] = ( rohttp != 0 ) and self.player or nil
+	run_on.ents[self.entity] = rohttp ~= 0 and true or nil
 end
 
 registerCallback( "destruct", function( self )


### PR DESCRIPTION
Fixes #1554 

Stops executing every owned E2 that has `runOnHTTP`.