### PR TITLE
Fix/Refactor physics restricting functions

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -71,7 +71,7 @@ function PropCore.CreateProp(self,model,pos,angles,freeze,isVehicle)
 
 	if not util.IsValidProp( model ) or not WireLib.CanModel(self.player, model) then return nil end
 
-	pos = E2Lib.clampPos( pos )
+	pos = WireLib.clampPos( pos )
 
 	local prop
 
@@ -106,7 +106,7 @@ function PropCore.CreateProp(self,model,pos,angles,freeze,isVehicle)
 
 	local phys = prop:GetPhysicsObject()
 	if IsValid( phys ) then
-		if angles ~= nil then E2Lib.setAng( phys, angles ) end
+		if angles ~= nil then WireLib.setAng( phys, angles ) end
 		phys:Wake()
 		if freeze > 0 then phys:EnableMotion( false ) end
 	end
@@ -137,8 +137,8 @@ end
 function PropCore.PhysManipulate(this, pos, rot, freeze, gravity, notsolid)
 	local phys = this:GetPhysicsObject()
 	if IsValid( phys ) then
-		if pos ~= nil then E2Lib.setPos( phys, Vector( pos[1],pos[2],pos[3] ) ) end
-		if rot ~= nil then E2Lib.setAng( phys,  Angle( rot[1],rot[2],rot[3] ) ) end
+		if pos ~= nil then WireLib.setPos( phys, Vector( pos[1],pos[2],pos[3] ) ) end
+		if rot ~= nil then WireLib.setAng( phys,  Angle( rot[1],rot[2],rot[3] ) ) end
 		if freeze ~= nil and this:GetUnFreezable() ~= true then phys:EnableMotion( freeze == 0 ) end
 		if gravity ~= nil then phys:EnableGravity( gravity ~= 0 ) end
 		if notsolid ~= nil then this:SetSolid( notsolid ~= 0 and SOLID_NONE or SOLID_VPHYSICS ) end

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -19,34 +19,11 @@ function E2Lib.getArguments(self, args)
 	return unpack(ret)
 end
 
-function E2Lib.isnan(n)
-	return n ~= n
-end
-local isnan = E2Lib.isnan
-
--- This function clamps the position before moving the entity
-local minx, miny, minz = -16384, -16384, -16384
-local maxx, maxy, maxz = 16384, 16384, 16384
-local clamp = math.Clamp
-function E2Lib.clampPos(pos)
-	pos.x = clamp(pos.x, minx, maxx)
-	pos.y = clamp(pos.y, miny, maxy)
-	pos.z = clamp(pos.z, minz, maxz)
-	return pos
-end
-
-function E2Lib.setPos(ent, pos)
-	if isnan(pos.x) or isnan(pos.y) or isnan(pos.z) then return end
-	return ent:SetPos(E2Lib.clampPos(pos))
-end
-
-local huge, abs = math.huge, math.abs
-function E2Lib.setAng(ent, ang)
-	if isnan(ang.pitch) or isnan(ang.yaw) or isnan(ang.roll) then return end
-	if abs(ang.pitch) == huge or abs(ang.yaw) == huge or abs(ang.roll) == huge then return false end -- SetAngles'ing inf crashes the server
-	return ent:SetAngles(ang)
-end
-
+-- Backwards compatibility
+E2Lib.isnan = WireLib.isnan
+E2Lib.clampPos = WireLib.clampPos
+E2Lib.setPos = WireLib.setPos
+E2Lib.setAng = WireLib.setAng
 
 function E2Lib.setMaterial(ent, material)
 	ent:SetMaterial(WireLib.IsValidMaterial(material))

--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -288,7 +288,7 @@ end
 
 e2function void setMass(mass)
 	if not validPhysics(self.entity) then return end
-	if E2Lib.isnan( mass ) then mass = 50000 end
+	if WireLib.isnan( mass ) then mass = 50000 end
 	local mass = Clamp(mass, 0.001, 50000)
 	local phys = self.entity:GetPhysicsObject()
 	phys:SetMass(mass)
@@ -298,7 +298,7 @@ e2function void entity:setMass(mass)
 	if not validPhysics(this) then return end
 	if not isOwner(self, this) then return end
 	if this:IsPlayer() then return end
-	if E2Lib.isnan( mass ) then mass = 50000 end
+	if WireLib.isnan( mass ) then mass = 50000 end
 	local mass = Clamp(mass, 0.001, 50000)
 	local phys = this:GetPhysicsObject()
 	phys:SetMass(mass)

--- a/lua/entities/gmod_wire_expression2/core/hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/hologram.lua
@@ -476,8 +476,8 @@ end)
 
 local function MakeHolo(Player, Pos, Ang, model)
 	local prop = ents.Create( "gmod_wire_hologram" )
-	E2Lib.setPos(prop, Pos)
-	E2Lib.setAng(prop, Ang)
+	WireLib.setPos(prop, Pos)
+	WireLib.setAng(prop, Ang)
 	prop:SetModel(model)
 	prop:SetPlayer(Player)
 	prop:SetNWInt("ownerid", Player:UserID())
@@ -529,8 +529,8 @@ local function CreateHolo(self, index, pos, scale, ang, color, model)
 
 	if IsValid(Holo.ent) then
 		prop = Holo.ent
-		E2Lib.setPos(prop, pos)
-		E2Lib.setAng(prop, ang)
+		WireLib.setPos(prop, pos)
+		WireLib.setAng(prop, ang)
 		prop:SetModel( model )
 	else
 		prop = MakeHolo(self.player, pos, ang, model, {}, {})
@@ -871,14 +871,14 @@ e2function void holoPos(index, vector position)
 	local Holo = CheckIndex(self, index)
 	if not Holo then return end
 
-	E2Lib.setPos(Holo.ent, Vector(position[1],position[2],position[3]))
+	WireLib.setPos(Holo.ent, Vector(position[1],position[2],position[3]))
 end
 
 e2function void holoAng(index, angle ang)
 	local Holo = CheckIndex(self, index)
 	if not Holo then return end
 
-	E2Lib.setAng(Holo.ent, Angle(ang[1],ang[2],ang[3]))
+	WireLib.setAng(Holo.ent, Angle(ang[1],ang[2],ang[3]))
 end
 
 -- -----------------------------------------------------------------------------

--- a/lua/entities/gmod_wire_expression2/core/ranger.lua
+++ b/lua/entities/gmod_wire_expression2/core/ranger.lua
@@ -99,7 +99,7 @@ local function ranger(self, rangertype, range, p1, p2, hulltype, mins, maxs, tra
 	end
 
 	-- clamp positions
-	tracedata.start = E2Lib.clampPos( tracedata.start )
+	tracedata.start = WireLib.clampPos( tracedata.start )
 	if tracedata.start:Distance( tracedata.endpos ) > 57000 then -- 57000 is slightly larger than the diagonal distance (min corner to max corner) of the source max map size
 		tracedata.endpos = tracedata.start + (tracedata.endpos - tracedata.start):GetNormal() * 57000
 	end
@@ -122,8 +122,8 @@ local function ranger(self, rangertype, range, p1, p2, hulltype, mins, maxs, tra
 
 		if not entities then -- unfortunately we have to add tons of ops if this happens
 							 -- If we didn't, it would be possible to crash servers with it.
-			tracedata.mins = E2Lib.clampPos( tracedata.mins )
-			tracedata.maxs = E2Lib.clampPos( tracedata.maxs )
+			tracedata.mins = WireLib.clampPos( tracedata.mins )
+			tracedata.maxs = WireLib.clampPos( tracedata.maxs )
 			self.prf = self.prf + tracedata.mins:Distance(tracedata.maxs) * 0.5
 		end
 

--- a/lua/wire/wireshared.lua
+++ b/lua/wire/wireshared.lua
@@ -1019,6 +1019,33 @@ function nicenumber.nicetime( n )
 	end
 end
 
+function WireLib.isnan(n)
+	return n ~= n
+end
+local isnan = WireLib.isnan
+
+-- This function clamps the position before moving the entity
+local minx, miny, minz = -16384, -16384, -16384
+local maxx, maxy, maxz = 16384, 16384, 16384
+local clamp = math.Clamp
+function WireLib.clampPos(pos)
+	pos.x = clamp(pos.x, minx, maxx)
+	pos.y = clamp(pos.y, miny, maxy)
+	pos.z = clamp(pos.z, minz, maxz)
+	return pos
+end
+
+function WireLib.setPos(ent, pos)
+	if isnan(pos.x) or isnan(pos.y) or isnan(pos.z) then return end
+	return ent:SetPos(WireLib.clampPos(pos))
+end
+
+local huge, abs = math.huge, math.abs
+function WireLib.setAng(ent, ang)
+	if isnan(ang.pitch) or isnan(ang.yaw) or isnan(ang.roll) then return end
+	if abs(ang.pitch) == huge or abs(ang.yaw) == huge or abs(ang.roll) == huge then return false end -- SetAngles'ing inf crashes the server
+	return ent:SetAngles(ang)
+end
 
 -- Used by any applyForce function available to the user
 -- Ensures that the force is within the range of a float, to prevent

--- a/lua/wire/wireshared.lua
+++ b/lua/wire/wireshared.lua
@@ -1029,6 +1029,7 @@ local minx, miny, minz = -16384, -16384, -16384
 local maxx, maxy, maxz = 16384, 16384, 16384
 local clamp = math.Clamp
 function WireLib.clampPos(pos)
+	pos = Vector(pos)
 	pos.x = clamp(pos.x, minx, maxx)
 	pos.y = clamp(pos.y, miny, maxy)
 	pos.z = clamp(pos.z, minz, maxz)
@@ -1057,9 +1058,9 @@ hook.Add("InitPostEntity","WireForceLimit",function()
 	min_force = -max_force
 end)
 
-
 -- Nan never equals itself, so if the value doesn't equal itself replace it with 0.
 function WireLib.clampForce( v )
+	v = Vector(v[1], v[2], v[3])
 	v[1] = v[1] == v[1] and math.Clamp( v[1], min_force, max_force ) or 0
 	v[2] = v[2] == v[2] and math.Clamp( v[2], min_force, max_force ) or 0
 	v[3] = v[3] == v[3] and math.Clamp( v[3], min_force, max_force ) or 0

--- a/lua/wire/wireshared.lua
+++ b/lua/wire/wireshared.lua
@@ -1045,6 +1045,10 @@ local huge, abs = math.huge, math.abs
 function WireLib.setAng(ent, ang)
 	if isnan(ang.pitch) or isnan(ang.yaw) or isnan(ang.roll) then return end
 	if abs(ang.pitch) == huge or abs(ang.yaw) == huge or abs(ang.roll) == huge then return false end -- SetAngles'ing inf crashes the server
+
+	ang = Angle(ang)
+	ang:Normalize()
+
 	return ent:SetAngles(ang)
 end
 


### PR DESCRIPTION
4f52615: `setAng` could've caused a crash if given really big numbers, this change causes it to wrap the number before giving it to the engine.

c7bbdc9: `clampPos` and `clampForce` would modify the input instead of creating a new vector.

a34399d: @Divran Wanted me to move these functions to `WireLib`. This makes sense to keep all of the physics related checks/restrictions in one place.