### PR TITLE
Small keyboard fixes

### DIFF
--- a/lua/entities/gmod_wire_keyboard/init.lua
+++ b/lua/entities/gmod_wire_keyboard/init.lua
@@ -21,32 +21,36 @@ for i = 97, 122 do -- a -> z
 end
 
 local unprintable_chars = {}
+unprintable_chars[0] = true
 for i=17,20 do unprintable_chars[i] = true end -- arrow keys
 for i=127,177 do unprintable_chars[i] = true end -- backspace, numpad, ctrl, alt, shift, break, F1-F12, scroll/num/caps lock, and more
 
+-- These keys output a numeric code that's different to their ASCII code - they
+-- are numpad keys, and using a different code lets contraptions differentiate
+-- between eg. pressing 0 on the number row and 0 on the numpad. The codes are
+-- defined in remap.lua.
 local convertable_chars = {
-	[128] = 49, -- numpad 1
-	[129] = 50, -- numpad 2
-	[130] = 51, -- numpad 3
-	[131] = 52, -- numpad 4
-	[132] = 53, -- numpad 5
-	[133] = 54, -- numpad 6
-	[134] = 55, -- numpad 7
-	[135] = 56, -- numpad 8
-	[136] = 57, -- numpad 9
-	[137] = 58, -- numpad 4
-	[138] = 47, -- /
-	[139] = 42, -- *
-	[140] = 45, -- -
-	[141] = 43, -- +
-	[142] = 10, -- \n
-	[143] = 46, -- .
+	[128] = "0",
+	[129] = "1",
+	[130] = "2",
+	[131] = "3",
+	[132] = "4",
+	[133] = "5",
+	[134] = "6",
+	[135] = "7",
+	[136] = "8",
+	[137] = "9",
+	[138] = "/",
+	[139] = "*",
+	[140] = "-",
+	[141] = "+",
+	[142] = "\n",
+	[143] = ".",
 }
 
 local function getPrintableChar( key )
-	if key == 0 then return "" end
-	if unprintable_chars[key] and not convertable_chars[key] then return "" end
-	if convertable_chars[key] then key = convertable_chars[key] end
+	if convertable_chars[key] then return convertable_chars[key] end
+	if unprintable_chars[key] then return "" end
 	if key == 13 then key = 10 end -- convert newline '13' into newlne '10' to make it work properly
 	return utf8.char(key)
 end

--- a/lua/entities/gmod_wire_keyboard/init.lua
+++ b/lua/entities/gmod_wire_keyboard/init.lua
@@ -348,11 +348,11 @@ end
 
 function ENT:RemoveFromBufferByPosition(bufferpos)
 	if self.Buffer[0] <= 0 then return end
-	local key = table.remove(self.Buffer, bufferpos)
+	table.remove(self.Buffer, bufferpos)
 	self.Buffer[0] = self.Buffer[0] - 1
 
 	-- Move all remaining keys down one step
-	for key_enum,positions in pairs(self.BufferLookup) do
+	for _, positions in pairs(self.BufferLookup) do
 		for k,pos in pairs(positions) do
 			if bufferpos < pos then
 				positions[k] = positions[k] - 1
@@ -389,16 +389,16 @@ function ENT:Think()
 	local leavekey = self.ply:GetInfoNum("wire_keyboard_leavekey", KEY_LALT)
 
 	-- Remove lifted up keys from our ActiveKeys
-	for key_enum, bool in pairs(self.ActiveKeys) do
+	for key_enum, _ in pairs(self.ActiveKeys) do
 		if not self.ply.keystate[key_enum] then
 			self:KeyReleased(key_enum)
 		end
 	end
 
 	-- Check for newly pressed keys and add them to our ActiveKeys
-	for key_enum, bool in pairs(self.ply.keystate) do
+	for key_enum, _ in pairs(self.ply.keystate) do
 		if key_enum == leavekey then
-			if leavekey ~= KEY_ALT or not self:IsPressedEnum(KEY_LCONTROL) then -- if LCONTROL and LALT are being pressed, then the player is trying to use the "ALT GR" key which is available for some languages
+			if leavekey ~= KEY_LALT or not self:IsPressedEnum(KEY_LCONTROL) then -- if LCONTROL and LALT are being pressed, then the player is trying to use the "ALT GR" key which is available for some languages
 				self:PlayerDetach() -- Pressing the leave key quits the keyboard
 				break
 			end

--- a/lua/entities/gmod_wire_keyboard/remap.lua
+++ b/lua/entities/gmod_wire_keyboard/remap.lua
@@ -131,7 +131,7 @@ remap[KEY_SCROLLLOCKTOGGLE]	= 177
 	remap[KEY_XSTICK2_RIGHT] 	= 223
 ]]
 
-local remap = Wire_Keyboard_Remap_default[KEY_LSHIFT]
+remap = Wire_Keyboard_Remap_default[KEY_LSHIFT]
 remap[KEY_A] = "A"
 remap[KEY_B] = "B"
 remap[KEY_C] = "C"
@@ -167,7 +167,7 @@ Wire_Keyboard_Remap.American = {}
 Wire_Keyboard_Remap.American = table.Copy(Wire_Keyboard_Remap_default)
 Wire_Keyboard_Remap.American[KEY_RSHIFT] = Wire_Keyboard_Remap.American[KEY_LSHIFT]
 
-local remap = Wire_Keyboard_Remap.American.normal
+remap = Wire_Keyboard_Remap.American.normal
 remap[KEY_LBRACKET] 	= "["
 remap[KEY_RBRACKET] 	= "]"
 remap[KEY_SEMICOLON] 	= ";"
@@ -180,7 +180,7 @@ remap[KEY_BACKSLASH] 	= "\\"
 remap[KEY_MINUS] 		= "-"
 remap[KEY_EQUAL] 		= "="
 
-local remap = Wire_Keyboard_Remap.American[KEY_LSHIFT]
+remap = Wire_Keyboard_Remap.American[KEY_LSHIFT]
 remap[KEY_0] = ")"
 remap[KEY_1] = "!"
 remap[KEY_2] = "@"
@@ -211,17 +211,17 @@ Wire_Keyboard_Remap.British = table.Copy(Wire_Keyboard_Remap.American)
 Wire_Keyboard_Remap.British[KEY_LCONTROL] = {}
 Wire_Keyboard_Remap.British[KEY_RSHIFT] = Wire_Keyboard_Remap.British[KEY_LSHIFT]
 
-local remap = Wire_Keyboard_Remap.British.normal
+remap = Wire_Keyboard_Remap.British.normal
 remap[KEY_BACKQUOTE] = "'"
 remap[KEY_APOSTROPHE] = "#"
 
-local remap = Wire_Keyboard_Remap.British[KEY_LSHIFT]
+remap = Wire_Keyboard_Remap.British[KEY_LSHIFT]
 remap[KEY_2] = '"'
 remap[KEY_3] = "£"
 remap[KEY_APOSTROPHE] = "~"
 remap[KEY_BACKQUOTE] = "@"
 
-local remap = Wire_Keyboard_Remap.British[KEY_LCONTROL]
+remap = Wire_Keyboard_Remap.British[KEY_LCONTROL]
 remap[KEY_4] = "€"
 remap[KEY_A] = "á"
 remap[KEY_E] = "é"
@@ -238,7 +238,7 @@ Wire_Keyboard_Remap.Swedish = table.Copy(Wire_Keyboard_Remap_default)
 Wire_Keyboard_Remap.Swedish[KEY_LCONTROL] = {} -- Should be KEY_RALT, but that didn't work correctly
 Wire_Keyboard_Remap.Swedish[KEY_RSHIFT] = Wire_Keyboard_Remap.Swedish[KEY_LSHIFT]
 
-local remap = Wire_Keyboard_Remap.Swedish.normal
+remap = Wire_Keyboard_Remap.Swedish.normal
 remap[KEY_LBRACKET] 	= "´"
 remap[KEY_RBRACKET] 	= "å"
 remap[KEY_BACKQUOTE] 	= "¨"
@@ -251,7 +251,7 @@ remap[KEY_BACKSLASH] 	= "§"
 remap[KEY_MINUS] 		= "-"
 remap[KEY_EQUAL] 		= "+"
 
-local remap = Wire_Keyboard_Remap.Swedish[KEY_LSHIFT]
+remap = Wire_Keyboard_Remap.Swedish[KEY_LSHIFT]
 remap[KEY_0] = "="
 remap[KEY_1] = "!"
 remap[KEY_2] = '"'
@@ -274,7 +274,7 @@ remap[KEY_BACKSLASH] 	= "½"
 remap[KEY_MINUS] 		= "_"
 remap[KEY_EQUAL] 		= "?"
 
-local remap = Wire_Keyboard_Remap.Swedish[KEY_LCONTROL]
+remap = Wire_Keyboard_Remap.Swedish[KEY_LCONTROL]
 remap[KEY_2] = "@"
 remap[KEY_3] = "£"
 remap[KEY_4] = "$"
@@ -294,18 +294,18 @@ Wire_Keyboard_Remap.Norwegian = {}
 Wire_Keyboard_Remap.Norwegian = table.Copy(Wire_Keyboard_Remap.Swedish)
 Wire_Keyboard_Remap.Norwegian[KEY_RSHIFT] = Wire_Keyboard_Remap.Norwegian[KEY_LSHIFT]
 
-local remap = Wire_Keyboard_Remap.Norwegian.normal
+remap = Wire_Keyboard_Remap.Norwegian.normal
 remap[KEY_BACKQUOTE] 	= "ø"
 remap[KEY_APOSTROPHE] 	= "æ"
 remap[KEY_BACKSLASH] 	= "|"
 remap[KEY_LBRACKET] 	= "\\"
 
-local remap = Wire_Keyboard_Remap.Norwegian[KEY_LSHIFT]
+remap = Wire_Keyboard_Remap.Norwegian[KEY_LSHIFT]
 remap[KEY_BACKQUOTE] 	= "Ø"
 remap[KEY_APOSTROPHE] 	= "Æ"
 remap[KEY_BACKSLASH] 	= "§"
 
-local remap = Wire_Keyboard_Remap.Norwegian[KEY_LCONTROL]
+remap = Wire_Keyboard_Remap.Norwegian[KEY_LCONTROL]
 remap[KEY_EQUAL] = nil
 remap[KEY_M] = "µ"
 remap[KEY_LBRACKET] 		= "´"
@@ -319,7 +319,7 @@ Wire_Keyboard_Remap.German				= table.Copy(Wire_Keyboard_Remap_default)
 Wire_Keyboard_Remap.German[KEY_LCONTROL]			= {} -- Should be KEY_RALT, but that didn't work correctly
 Wire_Keyboard_Remap.German[KEY_RSHIFT]	= Wire_Keyboard_Remap.German[KEY_LSHIFT]
 
-local remap = Wire_Keyboard_Remap.German.normal
+remap = Wire_Keyboard_Remap.German.normal
 remap[KEY_LBRACKET]		= "ß"
 remap[KEY_RBRACKET]		= "´"
 remap[KEY_SEMICOLON]	= "ü"
@@ -332,7 +332,7 @@ remap[KEY_BACKSLASH]	= "^"
 remap[KEY_MINUS]		= "-"
 remap[KEY_EQUAL]		= "+"
 
-local remap = Wire_Keyboard_Remap.German[KEY_LSHIFT]
+remap = Wire_Keyboard_Remap.German[KEY_LSHIFT]
 remap[KEY_0]	= "="
 remap[KEY_1]	= "!"
 remap[KEY_2]	= '"'
@@ -355,7 +355,7 @@ remap[KEY_BACKSLASH]	= "°"
 remap[KEY_MINUS]		= "_"
 remap[KEY_EQUAL]		= "*"
 
-local remap = Wire_Keyboard_Remap.German[KEY_LCONTROL]
+remap = Wire_Keyboard_Remap.German[KEY_LCONTROL]
 remap[KEY_0]	= "}"
 remap[KEY_2]	= '²'
 remap[KEY_3]	= "³"

--- a/lua/entities/gmod_wire_keyboard/remap.lua
+++ b/lua/entities/gmod_wire_keyboard/remap.lua
@@ -212,14 +212,15 @@ Wire_Keyboard_Remap.British[KEY_LCONTROL] = {}
 Wire_Keyboard_Remap.British[KEY_RSHIFT] = Wire_Keyboard_Remap.British[KEY_LSHIFT]
 
 remap = Wire_Keyboard_Remap.British.normal
-remap[KEY_BACKQUOTE] = "'"
-remap[KEY_APOSTROPHE] = "#"
+remap[KEY_BACKQUOTE] = "`"
+remap[KEY_BACKSLASH] = "#"
 
 remap = Wire_Keyboard_Remap.British[KEY_LSHIFT]
 remap[KEY_2] = '"'
 remap[KEY_3] = "£"
-remap[KEY_APOSTROPHE] = "~"
-remap[KEY_BACKQUOTE] = "@"
+remap[KEY_APOSTROPHE] = "@"
+remap[KEY_BACKQUOTE] = "¬"
+remap[KEY_BACKSLASH] = "~"
 
 remap = Wire_Keyboard_Remap.British[KEY_LCONTROL]
 remap[KEY_4] = "€"


### PR DESCRIPTION
This fixes two issues:
* Numpad numbers produce the wrong text string result
* In the British layout, incorrect punctuation characters are produced