### PR TITLE
Fix definition of WireLib.DT.TABLE.Zero

### DIFF
--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -85,10 +85,10 @@ WireLib.DT = {
 		Zero = ""
 	},
 	TABLE = {
-		Zero = {}
+		Zero = {n={},ntypes={},s={},stypes={},size=0},
 	},
 	BIDIRTABLE = {
-		Zero = {},
+		Zero = {n={},ntypes={},s={},stypes={},size=0},
 		BiDir = true
 	},
 	ANY = {


### PR DESCRIPTION
A long time ago, the TABLE type was added to Wiremod, that was for
arbitrary Lua tables. Understandably, its zero element was `{}`, the
empty table.

Then E2 came along, and decided that all its tables should have a
different internal representation. It looks like:

    { n = {}, s = {}, ntypes = {}, stypes = {}, size = 0 }

... where n is a table of numeric-keyed fields, s is a table of
string-keyed fields, ntypes and stypes map a numeric/string key to the
E2 type id of the value, and size is a manually tracked size to avoid
calling table.Count. This definition is more restrictive (you can't use
entities as keys, for example), but allows for fast iteration over all
keys of a given type (a common E2 operation) and preserves E2 type
information, which is important.

These two representations of tables are incompatible. Fortunately, only
one place in Wiremod other than E2 (`gmod_wire_damage_detector`)
actually uses a table input/output, and it does so using the E2 table
format. So instead of doing complex and lossy conversions in E2 tables'
input and output serializers, we're just making the E2 table format the
canonical Wiremod table format. It's not necessarily fixed in stone; as
long as serialization is preserved we can change the internal
representation as we see fit.

Fixes #1574.