### PR TITLE
Don't maintain an E2 runtime stack

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/analyzer.lua
+++ b/lua/entities/gmod_wire_expression2/base/analyzer.lua
@@ -1,0 +1,211 @@
+--[[
+A semantic analyzer for E2 abstract syntax trees.
+Currently, the analyzer resolves the scope of variables, and assigns a unique
+number to every local variable in the program. These numbers are then used to
+reference local variables in the current stack frame.
+
+After the Analyzer pass, each AST node that references a variable will have been
+annotated with its ID.
+--]]
+
+AddCSLuaFile()
+
+local analyzerDebug = CreateConVar("wire_expression2_analyzer_debug", 0,
+    "Print an E2's abstract syntax tree after analyzing"
+)
+
+local Analyzer = {}
+
+E2Lib.Analyzer = {}
+
+--- Analyze the E2 abstract syntax tree.
+-- @return true and the tree annotated with extra information, or false and an
+--         error message.
+function E2Lib.Analyzer.Execute(root, includes)
+    local analyzer = setmetatable({
+        Locals = {}, -- a mappings from local name to ID
+        NextLocalId = 1, -- a counter to assign each local variable a unique ID
+
+        Includes = includes, -- a mapping from filename to AST root
+    }, { __index = Analyzer })
+    local ok, message = xpcall(Analyzer.Process, E2Lib.errorHandler, analyzer, root)
+    if ok and analyzerDebug:GetBool() then
+        print(E2Lib.Parser.DumpTree(root))
+    end
+    return ok, message
+end
+
+function Analyzer:Error(tree, message, ...)
+    error(string.format(message, ...) ..
+        string.format(" at line %i, char %i", tree[2][1], tree[2][2]))
+end
+
+--- Define the given name in the current scope.
+-- If the name exists in a parent scope, this new definition will shadow the
+-- old one, and the old variable will be accessible when this scope is exited.
+-- If the name exists in the current scope, this new definition will entirely
+-- replace the old one, and the old definition will no longer be accessible.
+-- @return a unique ID corresponding to this definition.
+function Analyzer:DefineLocal(name)
+    local id = self.NextLocalId
+    self.NextLocalId = self.NextLocalId + 1
+    self.Locals[name] = id
+    return id
+end
+
+--- Lookup the given name in the current scope.
+-- If the name isn't found in a local scope, then it refers to a global variable
+-- @return a number corresponding to the local variable, or name if it's a global variable.
+function Analyzer:Resolve(name)
+    local id = self.Locals[name]
+    if id then
+        return id
+    end
+
+    return name
+end
+
+
+--- Execute function `func` in with a scope that's a child of the current scope.
+function Analyzer:WithChildScope(func)
+    local oldScope = self.Locals
+    self.Locals = setmetatable({}, { __index = oldScope })
+    func()
+    self.Locals = oldScope
+end
+
+--- Execute function `func` in with a scope that's unrelated to the current scope.
+function Analyzer:WithFreshScope(func)
+    local oldScope = self.Locals
+    self.Locals = {}
+    func()
+    self.Locals = oldScope
+end
+
+--- Analyze an AST node and all its descendents.
+function Analyzer:Process(tree)
+    local action = self.Actions[tree[1]] or self.Actions.__generic
+    action(self, tree)
+    return tree
+end
+
+Analyzer.Actions = {}
+
+function Analyzer.Actions.__generic(self, tree)
+    for i = 3, #tree do
+        local child = tree[i]
+        if type(child) == "table" and child.__instruction then
+            self:Process(tree[i])
+        end
+    end
+end
+
+function Analyzer.Actions.assl(self, tree)
+    local name, expression = tree[3], tree[4]
+    self:Process(expression)
+    tree.Id = self:DefineLocal(name)
+end
+
+function Analyzer.Actions.var(self, tree)
+    local name = tree[3]
+    tree.Id = self:Resolve(name)
+end
+
+function Analyzer.Actions.ass(self, tree)
+    self.Actions.var(self, tree)
+    local expression = tree[4]
+    self:Process(expression)
+end
+
+Analyzer.Actions.inc = Analyzer.Actions.var
+Analyzer.Actions.dec = Analyzer.Actions.var
+Analyzer.Actions.trg = Analyzer.Actions.var
+Analyzer.Actions.dlt = Analyzer.Actions.var
+Analyzer.Actions.iwc = Analyzer.Actions.var
+
+Analyzer.Actions["for"] = function(self, tree)
+    local var, start, stop, step, block = tree[3], tree[4], tree[5], tree[6], tree[7]
+    self:Process(start)
+    self:Process(stop)
+    if step then
+        self:Process(step)
+    end
+    self:WithChildScope(function()
+        tree.Id = self:DefineLocal(var)
+        self:Process(block)
+    end)
+end
+
+function Analyzer.Actions.whl(self, tree)
+    local condition, block = tree[3], tree[4]
+    self:Process(condition)
+    self:WithChildScope(function()
+        self:Process(block)
+    end)
+end
+
+Analyzer.Actions["if"] = function(self, tree)
+    local condition, thenBlock, elseBlock = tree[3], tree[4], tree[5]
+    self:Process(condition)
+    self:WithChildScope(function()
+        self:Process(thenBlock)
+    end)
+    self:WithChildScope(function()
+        self:Process(elseBlock)
+    end)
+end
+
+function Analyzer.Actions.fea(self, tree)
+    local key, value, table, block = tree[3], tree[5], tree[7], tree[8]
+    self:Process(table)
+    self:WithChildScope(function()
+        tree.KeyId = self:DefineLocal(key)
+        tree.ValueId = self:DefineLocal(value)
+        self:Process(block)
+    end)
+end
+
+Analyzer.Actions["function"] = function(self, tree)
+    local args, block = tree[6], tree[7]
+    self:WithFreshScope(function()
+        for _, arg in pairs(args) do
+            local name = arg[1]
+            arg.Id = self:DefineLocal(name)
+        end
+        self:Process(block)
+    end)
+end
+
+function Analyzer.Actions.switch(self, tree)
+    local expression, cases = tree[3], tree[4]
+    self:Process(expression)
+    for _, case in pairs(cases) do
+        local value = case[1]
+        if value then self:Process(value) end
+    end
+    self:WithChildScope(function()
+    for _, case in pairs(cases) do
+        local block = case[2]
+        self:Process(block)
+    end
+    end)
+end
+
+function Analyzer.Actions.inclu(self, tree)
+    local filename = tree[3]
+
+    local include = self.Includes[filename]
+
+    if not include or not include[1] then
+        self:Error(tree, "Problem including file '%s'", filename)
+    end
+
+    local root = include[1]
+
+    if not include.Analyzed then
+        include.Analyzed = true
+        self:WithFreshScope(function()
+            self:Process(root)
+        end)
+    end
+end

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -32,7 +32,6 @@ function Compiler:Process(root, inputs, outputs, persist, delta, includes) -- To
 	self.includes = includes or {}
 	self.prfcounter = 0
 	self.prfcounters = {}
-	self.tvars = {}
 	self.funcs = {}
 	self.dvars = {}
 	self.funcs_ret = {}

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -608,12 +608,21 @@ end
 
 function Compiler:InstrVAR(args)
 	self.prfcounter = self.prfcounter + 1.0
-	local op, id = args[3], args.Id
-	local tp, ScopeID = self:GetVariableType(op, id, args)
+	local name, id = args[3], args.Id
+	local type = self:GetVariableType(name, id, args)
 
-	return {function(self)
-		return self.Scopes[ScopeID][id]
-	end}, tp
+	local func
+	if isnumber(id) then -- local
+		func = function(self)
+			return self.Scope[id]
+		end
+	else -- global
+		func = function(self)
+			return self.GlobalScope[id]
+		end
+	end
+
+	return { func }, type
 end
 
 function Compiler:InstrFEA(args)

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -390,7 +390,7 @@ function Compiler:InstrCND(args)
 end
 
 
-function Compiler:InstrFUN(args)
+function Compiler:InstrCALL(args)
 	local exprs = { false }
 
 	local tps = {}
@@ -407,7 +407,7 @@ function Compiler:InstrFUN(args)
 	return exprs, rt[2]
 end
 
-function Compiler:InstrSFUN(args)
+function Compiler:InstrSCALL(args)
 	local exprs = { false }
 
 	local fexp, ftp = self:Evaluate(args, 1)
@@ -423,7 +423,7 @@ function Compiler:InstrSFUN(args)
 		exprs[#exprs + 1] = ex
 	end
 
-	local rtsfun = self:GetOperator(args, "sfun", {})[1]
+	local rtsfun = self:GetOperator(args, "scall", {})[1]
 
 	local typeids_str = table.concat(tps, "")
 

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -173,12 +173,6 @@ function Compiler:HasOperator(instr, name, tps)
 	return a and true or false
 end
 
-function Compiler:AssertOperator(instr, name, alias, tps)
-	if not self:HasOperator(instr, name, tps) then
-		self:Error("No such operator: " .. op_find(alias) .. "(" .. tps_pretty(tps) .. ")", instr)
-	end
-end
-
 function Compiler:GetOperator(instr, name, tps)
 	local pars = table.concat(tps)
 	local a = wire_expression2_funcs["op:" .. name .. "(" .. pars .. ")"]
@@ -629,7 +623,6 @@ function Compiler:InstrDLT(args)
 	end
 
 	self.dvars[op] = true
-	self:AssertOperator(args, "sub", "dlt", { tp, tp })
 	local rt = self:GetOperator(args, "sub", { tp, tp })
 	local rtvar = self:GetOperator(args, "var", {})
 	return { rt[1], { rtvar[1], op, ScopeID }, { rtvar[1], "$" .. op, ScopeID } }, rt[2]

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -613,7 +613,9 @@ end
 
 function Compiler:InstrTRG(args)
 	local op = args[3]
-	local tp = self:GetVariableType(args, op)
+	if not self.inputs[op] then
+		self:Error("Triggered operator (~" .. E2Lib.limitString(op, 10) .. ") can only be used on inputs", args)
+	end
 	local rt = self:GetOperator(args, "trg", {})
 	return { rt[1], op }, rt[2]
 end
@@ -637,11 +639,9 @@ function Compiler:InstrIWC(args)
 	local op = args[3]
 
 	if self.inputs[op] then
-		local tp = self:GetVariableType(args, op)
 		local rt = self:GetOperator(args, "iwc", {})
 		return { rt[1], op }, rt[2]
 	elseif self.outputs[op] then
-		local tp = self:GetVariableType(args, op)
 		local rt = self:GetOperator(args, "owc", {})
 		return { rt[1], op }, rt[2]
 	else
@@ -707,15 +707,14 @@ end
 
 function Compiler:InstrFUNCTION(args)
 
-	local Sig, Return, Type, Args, Block = args[3], args[4], args[5], args[6], args[7]
+	local Sig, Return, Args = args[3], args[4], args[6]
 	Return = Return or ""
-	Type = Type or ""
 
 	local OldScopes = self:SaveScopes()
 	self:InitScope() -- Create a new Scope Enviroment
 	self:PushScope()
 
-	for K, D in pairs(Args) do
+	for _, D in pairs(Args) do
 		local Name, Type = D[1], wire_expression_types[D[2]][1]
 		self:SetLocalVariableType(Name, Type, args)
 	end

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -394,8 +394,8 @@ function Compiler:InstrFUN(args)
 	local exprs = { false }
 
 	local tps = {}
-	for i = 1, #args[4] do
-		local ex, tp = self:Evaluate(args[4], i - 2)
+	for i = 2, #args - 2 do
+		local ex, tp = self:Evaluate(args, i)
 		tps[#tps + 1] = tp
 		exprs[#exprs + 1] = ex
 	end
@@ -417,8 +417,8 @@ function Compiler:InstrSFUN(args)
 	end
 
 	local tps = {}
-	for i = 1, #args[4] do
-		local ex, tp = self:Evaluate(args[4], i - 2)
+	for i = 2, #args - 2 do
+		local ex, tp = self:Evaluate(args, i)
 		tps[#tps + 1] = tp
 		exprs[#exprs + 1] = ex
 	end
@@ -438,8 +438,8 @@ function Compiler:InstrMTO(args)
 	local ex, tp = self:Evaluate(args, 2)
 	exprs[#exprs + 1] = ex
 
-	for i = 1, #args[5] do
-		local ex, tp = self:Evaluate(args[5], i - 2)
+	for i = 3, #args - 2 do
+		local ex, tp = self:Evaluate(args, i)
 		tps[#tps + 1] = tp
 		exprs[#exprs + 1] = ex
 	end

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -296,6 +296,7 @@ end
 
 function Compiler:InstrFOR(args)
 	local var = args[3]
+	assert(args.Id)
 
 	local estart, tp1 = self:Evaluate(args, 2)
 	local estop, tp2 = self:Evaluate(args, 3)
@@ -481,6 +482,7 @@ function Compiler:InstrMTO(args)
 end
 
 function Compiler:InstrASS(args)
+	assert(args.Id)
 	local op = args[3]
 	local ex, tp = self:Evaluate(args, 2)
 	local ScopeID = self:SetGlobalVariableType(op, tp, args)
@@ -497,6 +499,7 @@ function Compiler:InstrASS(args)
 end
 
 function Compiler:InstrASSL(args)
+	assert(args.Id)
 	local op = args[3]
 	local ex, tp = self:Evaluate(args, 2)
 	local ScopeID = self:SetLocalVariableType(op, tp, args)
@@ -681,12 +684,15 @@ function Compiler:InstrVAR(args)
 	local tp, ScopeID = self:GetVariableType(args, args[3])
 	local name = args[3]
 
+	assert(args.Id)
+
 	return {function(self)
 		return self.Scopes[ScopeID][name]
 	end}, tp
 end
 
 function Compiler:InstrFEA(args)
+	assert(args.KeyId and args.ValueId)
 	-- local sfea = self:Instruction(trace, "fea", keyvar, keytype, valvar, valtype, tableexpr, self:Block("foreach statement"))
 	local keyvar, keytype, valvar, valtype = args[3], args[4], args[5], args[6]
 	local tableexpr, tabletp = self:Evaluate(args, 5)
@@ -738,6 +744,7 @@ function Compiler:InstrFUNCTION(args)
 
 	for _, D in pairs(Args) do
 		local Name, Type = D[1], wire_expression_types[D[2]][1]
+		assert(D.Id)
 		self:SetLocalVariableType(Name, Type, args)
 	end
 

--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -1296,7 +1296,6 @@ function Parser:Expr16()
 				local kvtable = false
 
 				local key = self:Expr1()
-				local token = self:GetToken()
 
 				if self:AcceptRoamingToken("ass") then
 					if self:AcceptRoamingToken("rpa") then
@@ -1312,10 +1311,8 @@ function Parser:Expr16()
 
 				if kvtable then
 					while self:AcceptRoamingToken("com") do
-						local token = self:GetToken()
-
 						local key = self:Expr1()
-						token = self:GetToken()
+						local token = self:GetToken()
 
 						if self:AcceptRoamingToken("ass") then
 							if self:AcceptRoamingToken("rpa") then

--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -1248,7 +1248,7 @@ function Parser:Expr15()
 
 				stype = wire_expression_types[string.upper(longtp)][1]
 			end
-			expr = self:Instruction(trace, "sfun", expr, stype, unpack(exprs))
+			expr = self:Instruction(trace, "scall", expr, stype, unpack(exprs))
 		else
 			break
 		end
@@ -1285,7 +1285,7 @@ function Parser:Expr16()
 		local token = self:GetToken()
 
 		if self:AcceptRoamingToken("rpa") then
-			return self:Instruction(trace, "fun", fun)
+			return self:Instruction(trace, "call", fun)
 		else
 
 			local exprs = {}
@@ -1342,7 +1342,7 @@ function Parser:Expr16()
 				self:Error("Right parenthesis ()) missing, to close function argument list", token)
 			end
 
-			return self:Instruction(trace, "fun", fun, unpack(exprs))
+			return self:Instruction(trace, "call", fun, unpack(exprs))
 		end
 	end
 

--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -1159,7 +1159,7 @@ function Parser:Expr15()
 			local token = self:GetToken()
 
 			if self:AcceptRoamingToken("rpa") then
-				expr = self:Instruction(trace, "mto", fun, expr, {})
+				expr = self:Instruction(trace, "mto", fun, expr)
 			else
 				local exprs = { self:Expr1() }
 
@@ -1171,7 +1171,7 @@ function Parser:Expr15()
 					self:Error("Right parenthesis ()) missing, to close method argument list", token)
 				end
 
-				expr = self:Instruction(trace, "mto", fun, expr, exprs)
+				expr = self:Instruction(trace, "mto", fun, expr, unpack(exprs))
 			end
 			--elseif self:AcceptRoamingToken("col") then
 			--	self:Error("Method operator (:) must not be preceded by whitespace")
@@ -1228,6 +1228,8 @@ function Parser:Expr15()
 				end
 			end
 
+			local stype = ""
+
 			if self:AcceptRoamingToken("lsb") then
 				if not self:AcceptRoamingToken("fun") then
 					self:Error("Return type operator ([]) requires a lower case type [type]")
@@ -1244,12 +1246,9 @@ function Parser:Expr15()
 					self:Error("Return type operator ([]) does not support the type [" .. longtp .. "]")
 				end
 
-				local stype = wire_expression_types[string.upper(longtp)][1]
-
-				expr = self:Instruction(trace, "sfun", expr, exprs, stype)
-			else
-				expr = self:Instruction(trace, "sfun", expr, exprs, "")
+				stype = wire_expression_types[string.upper(longtp)][1]
 			end
+			expr = self:Instruction(trace, "sfun", expr, stype, unpack(exprs))
 		else
 			break
 		end
@@ -1286,7 +1285,7 @@ function Parser:Expr16()
 		local token = self:GetToken()
 
 		if self:AcceptRoamingToken("rpa") then
-			return self:Instruction(trace, "fun", fun, {})
+			return self:Instruction(trace, "fun", fun)
 		else
 
 			local exprs = {}
@@ -1343,7 +1342,7 @@ function Parser:Expr16()
 				self:Error("Right parenthesis ()) missing, to close function argument list", token)
 			end
 
-			return self:Instruction(trace, "fun", fun, exprs)
+			return self:Instruction(trace, "fun", fun, unpack(exprs))
 		end
 	end
 

--- a/lua/entities/gmod_wire_expression2/base/preprocessor.lua
+++ b/lua/entities/gmod_wire_expression2/base/preprocessor.lua
@@ -43,7 +43,7 @@ function PreProcessor:HandlePPCommand(comment)
 end
 
 function PreProcessor:FindComments(line)
-	local ret, count, pos, found = {}, 0, 1, nil
+	local ret, count, pos, found = {}, 0, 1
 	repeat
 		found = line:find('[#"\\]', pos)
 		if found then -- We found something
@@ -209,8 +209,7 @@ function PreProcessor:ParseDirectives(line)
 		end
 	elseif directive == "trigger" then
 		local trimmed = string.Trim(value)
-		if trimmed == "" then
-		elseif trimmed == "all" then
+		if trimmed == "all" then
 			if self.directives.trigger[1] ~= nil then
 				self:Error("Directive (@trigger) conflicts with previous directives")
 			end
@@ -220,7 +219,7 @@ function PreProcessor:ParseDirectives(line)
 				self:Error("Directive (@trigger) conflicts with previous directives")
 			end
 			self.directives.trigger[1] = false
-		else
+		elseif trimmed ~= "" then
 			if self.directives.trigger[1] ~= nil and #self.directives.trigger[2] == 0 then
 				self:Error("Directive (@trigger) conflicts with previous directives")
 			end
@@ -377,7 +376,7 @@ function PreProcessor:GetFunction(args, type)
 	thistype = gettype(thistype)
 
 	local tps = {thistype .. colon}
-	for i, argtype in ipairs(string.Explode(",", argtypes)) do
+	for _, argtype in ipairs(string.Explode(",", argtypes)) do
 		argtype = gettype(argtype)
 		table.insert(tps, argtype)
 	end

--- a/lua/entities/gmod_wire_expression2/cl_init.lua
+++ b/lua/entities/gmod_wire_expression2/cl_init.lua
@@ -70,6 +70,10 @@ function wire_expression2_validate(buffer)
 		if error then return error end
 	end
 
+	-- invoke analyzer
+	status, tree = E2Lib.Analyzer.Execute(tree, scripts)
+	if not status then return tree end
+
 	-- invoke compiler
 	local status, script, instance = E2Lib.Compiler.Execute(tree, inports[3], outports[3], persists[3], dvars, scripts)
 	if not status then return script end

--- a/lua/entities/gmod_wire_expression2/core/angle.lua
+++ b/lua/entities/gmod_wire_expression2/core/angle.lua
@@ -105,12 +105,6 @@ end
 
 /******************************************************************************/
 
-registerOperator("dlt", "a", "a", function(self, args)
-	local op1, scope = args[2], args[3]
-	local rv1, rv2 = self.Scopes[scope][op1], self.Scopes[scope]["$" .. op1]
-	return { rv1[1] - rv2[1], rv1[2] - rv2[2], rv1[3] - rv2[3] }
-end)
-
 __e2setcost(2)
 
 e2function angle operator_neg(angle rv1)

--- a/lua/entities/gmod_wire_expression2/core/angle.lua
+++ b/lua/entities/gmod_wire_expression2/core/angle.lua
@@ -44,16 +44,6 @@ end
 
 /******************************************************************************/
 
-registerOperator("ass", "a", "a", function(self, args)
-	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
-	self.Scopes[scope][op1] = rv2
-	self.Scopes[scope].vclk[op1] = true
-	return rv2
-end)
-
-/******************************************************************************/
-
 e2function number operator_is(angle rv1)
 	if rv1[1] != 0 || rv1[2] != 0 || rv1[3] != 0
 	   then return 1 else return 0 end

--- a/lua/entities/gmod_wire_expression2/core/array.lua
+++ b/lua/entities/gmod_wire_expression2/core/array.lua
@@ -45,7 +45,8 @@ registerType("array", "r", {},
 	end,
 	function(v)
 		return !istable(v)
-	end
+	end,
+	E2Lib.MutableReferenceType
 )
 
 --------------------------------------------------------------------------------
@@ -82,33 +83,6 @@ registerOperator( "kvarray", "", "r", function( self, args )
 
 	return ret
 end)
-
---------------------------------------------------------------------------------
--- = operator
---------------------------------------------------------------------------------
-registerOperator("ass", "r", "r", function(self, args)
-	local lhs, op2, scope = args[2], args[3], args[4]
-	local      rhs = op2[1](self, op2)
-
-	local Scope = self.Scopes[scope]
-	if !Scope.lookup then Scope.lookup = {} end
-	local lookup = Scope.lookup
-
-	--remove old lookup entry
-	if (lookup[rhs]) then lookup[rhs][lhs] = nil end
-
-	--add new
-	if (!lookup[rhs]) then
-		lookup[rhs] = {}
-	end
-	lookup[rhs][lhs] = true
-
-	Scope[lhs] = rhs
-	Scope.vclk[lhs] = true
-	return rhs
-end)
-
-
 
 --------------------------------------------------------------------------------
 -- IS operator

--- a/lua/entities/gmod_wire_expression2/core/array.lua
+++ b/lua/entities/gmod_wire_expression2/core/array.lua
@@ -252,9 +252,6 @@ registerCallback( "postinit", function()
 
 						self.prf = self.prf + 3
 
-						self.Scope.vclk[keyname] = true
-						self.Scope.vclk[valname] = true
-
 						self.Scope[keyname] = key
 						self.Scope[valname] = value
 

--- a/lua/entities/gmod_wire_expression2/core/array.lua
+++ b/lua/entities/gmod_wire_expression2/core/array.lua
@@ -45,8 +45,7 @@ registerType("array", "r", {},
 	end,
 	function(v)
 		return !istable(v)
-	end,
-	E2Lib.MutableReferenceType
+	end
 )
 
 --------------------------------------------------------------------------------
@@ -117,7 +116,7 @@ registerCallback( "postinit", function()
 				local ret
 				if (doremove) then
 					ret = table_remove( array, index )
-					self.GlobalScope.vclk[array] = true
+					self.IndirectTriggerQueued[array] = true
 				else
 					ret = array[floor(index)]
 				end
@@ -151,7 +150,7 @@ registerCallback( "postinit", function()
 				else
 					array[floor(index)] = value
 				end
-				self.GlobalScope.vclk[array] = true
+				self.IndirectTriggerQueued[array] = true
 				return value
 			end
 
@@ -278,7 +277,7 @@ end)
 __e2setcost(2)
 e2function void array:pop()
 	table_remove( this )
-	self.GlobalScope.vclk[this] = true
+	self.IndirectTriggerQueued[this] = true
 end
 
 --------------------------------------------------------------------------------
@@ -288,7 +287,7 @@ end
 __e2setcost(2)
 e2function void array:remove( index )
 	table_remove( this, index )
-	self.GlobalScope.vclk[this] = true
+	self.IndirectTriggerQueued[this] = true
 end
 
 --------------------------------------------------------------------------------
@@ -299,7 +298,7 @@ end
 e2function void array:unset( index )
 	if this[index] == nil then return end
 	this[index] = nil
-	self.GlobalScope.vclk[this] = true
+	self.IndirectTriggerQueued[this] = true
 end
 
 --------------------------------------------------------------------------------
@@ -309,7 +308,7 @@ end
 __e2setcost(3)
 e2function void array:shift()
 	table_remove( this, 1 )
-	self.GlobalScope.vclk[this] = true
+	self.IndirectTriggerQueued[this] = true
 end
 
 --------------------------------------------------------------------------------

--- a/lua/entities/gmod_wire_expression2/core/array.lua
+++ b/lua/entities/gmod_wire_expression2/core/array.lua
@@ -247,8 +247,6 @@ registerCallback( "postinit", function()
 
 				for key, value in pairs(tbl) do
 					if not typecheck(value) then
-						self:PushScope()
-
 						self.prf = self.prf + 3
 
 						self.Scope[keyname] = key
@@ -257,11 +255,9 @@ registerCallback( "postinit", function()
 						local ok, msg = pcall(statement[1], self, statement)
 
 						if not ok then
-							if msg == "break" then	self:PopScope() break
-							elseif msg ~= "continue" then self:PopScope() error(msg, 0) end
+							if msg == "break" then break end
+							if msg ~= "continue" then error(msg, 0) end
 						end
-
-						self:PopScope()
 					end
 				end
 			end)

--- a/lua/entities/gmod_wire_expression2/core/bone.lua
+++ b/lua/entities/gmod_wire_expression2/core/bone.lua
@@ -88,15 +88,6 @@ e2function number operator_is(bone b)
 	if not isValidBone(b) then return 0 else return 1 end
 end
 
---- B = B
-registerOperator("ass", "b", "b", function(self, args)
-	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
-	self.Scopes[scope][op1] = rv2
-	self.Scopes[scope].vclk[op1] = true
-	return rv2
-end)
-
 --- B == B
 e2function number operator==(bone lhs, bone rhs)
 	if lhs == rhs then return 1 else return 0 end

--- a/lua/entities/gmod_wire_expression2/core/complex.lua
+++ b/lua/entities/gmod_wire_expression2/core/complex.lua
@@ -89,15 +89,6 @@ end
 
 __e2setcost(2)
 
-registerOperator("ass", "c", "c", function(self, args)
-	local lhs, op2, scope = args[2], args[3], args[4]
-	local      rhs = op2[1](self, op2)
-
-	self.Scopes[scope][lhs] = rhs
-	self.Scopes[scope].vclk[lhs] = true
-	return rhs
-end)
-
 e2function number operator_is(complex z)
 	if (z[1]==0) && (z[2]==0) then return 0 else return 1 end
 end

--- a/lua/entities/gmod_wire_expression2/core/core.lua
+++ b/lua/entities/gmod_wire_expression2/core/core.lua
@@ -94,7 +94,6 @@ registerOperator("for", "", "", function(self, args)
 	for I=rstart,rend+rdelta,rstep do
 		self:PushScope()
 		self.Scope[var] = I
-		self.Scope.vclk[var] = true
 
 		local ok, msg = pcall(op4[1], self, op4)
 		if not ok then

--- a/lua/entities/gmod_wire_expression2/core/core.lua
+++ b/lua/entities/gmod_wire_expression2/core/core.lua
@@ -478,11 +478,11 @@ registerOperator("include", "", "", function(self, args)
 	if Include and Include[2] then
 		local Script = Include[2]
 
-		local OldScopes = self:SaveScopes()
-		self:InitScope() -- Create a new Scope Enviroment
+		local oldScope = self.Scope
+		self:SetScope({})
 
 		Script[1](self, Script)
 
-		self:LoadScopes(OldScopes)
+		self:SetScope(oldScope)
 	end
 end)

--- a/lua/entities/gmod_wire_expression2/core/core.lua
+++ b/lua/entities/gmod_wire_expression2/core/core.lua
@@ -47,15 +47,13 @@ registerOperator("whl", "", "", function(self, args)
 
 	self.prf = self.prf + args[4] + 3
 	while op1[1](self, op1) ~= 0 do
-		self:PushScope()
 		local ok, msg = pcall(op2[1], self, op2)
 		if not ok then
-			if msg == "break" then self:PopScope() break
-			elseif msg ~= "continue" then self:PopScope() error(msg, 0) end
+			if msg == "break" then break end
+			if msg ~= "continue" then error(msg, 0) end
 		end
 
 		self.prf = self.prf + args[4] + 3
-		self:PopScope()
 	end
 end)
 
@@ -92,17 +90,15 @@ registerOperator("for", "", "", function(self, args)
 
 	self.prf = self.prf + 3
 	for I=rstart,rend+rdelta,rstep do
-		self:PushScope()
 		self.Scope[var] = I
 
 		local ok, msg = pcall(op4[1], self, op4)
 		if not ok then
-			if msg == "break" then self:PopScope() break
-			elseif msg ~= "continue" then self:PopScope() error(msg, 0) end
+			if msg == "break" then break end
+			if msg ~= "continue" then error(msg, 0) end
 		end
 
 		self.prf = self.prf + 3
-		self:PopScope()
 	end
 
 end)
@@ -128,16 +124,13 @@ registerOperator("if", "n", "", function(self, args)
 	local ok, result
 
 	if op1[1](self, op1) ~= 0 then
-		self:PushScope()
 		local op2 = args[4]
 		ok, result = pcall(op2[1],self, op2)
 	else
-		self:PushScope() -- for else statments, elseif staments will run the if opp again
 		local op3 = args[5]
 		ok, result = pcall(op3[1],self, op3)
 	end
 
-	self:PopScope()
 	if not ok then
 		error(result,0)
 	end
@@ -454,8 +447,6 @@ __e2setcost(3) -- approximation
 registerOperator("switch", "", "", function(self, args)
 	local cases, startcase = args[3], args[4]
 
-	self:PushScope()
-
 	for i=1, #cases do -- We figure out what we can run.
 		local case = cases[i]
 		local op1 = case[1]
@@ -474,17 +465,11 @@ registerOperator("switch", "", "", function(self, args)
 			local stmts = cases[i][2]
 			local ok, msg = pcall(stmts[1], self, stmts)
 			if not ok then
-				if msg == "break" then
-					break
-				elseif msg ~= "continue" then
-					self:PopScope()
-					error(msg, 0)
-				end
+				if msg == "break" then break end
+				if msg ~= "continue" then error(msg, 0) end
 			end
 		end
 	end
-
-	self:PopScope()
 end)
 
 registerOperator("include", "", "", function(self, args)
@@ -495,11 +480,9 @@ registerOperator("include", "", "", function(self, args)
 
 		local OldScopes = self:SaveScopes()
 		self:InitScope() -- Create a new Scope Enviroment
-		self:PushScope()
 
 		Script[1](self, Script)
 
-		self:PopScope()
 		self:LoadScopes(OldScopes)
 	end
 end)

--- a/lua/entities/gmod_wire_expression2/core/custom/effects.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/effects.lua
@@ -48,15 +48,6 @@ registerType("effect", "xef", nil,
 
 __e2setcost(1)
 
-registerOperator("ass", "xef", "xef", function(self, args)
-	local lhs, op2, scope = args[2], args[3], args[4]
-	local rhs = op2[1](self, op2)
-
-	self.Scopes[scope][lhs] = rhs
-	self.Scopes[scope].vclk[lhs] = true
-	return rhs
-end)
-
 e2function effect effect()
 	return EffectData()
 end

--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -50,19 +50,6 @@ local function checkOwner(self)
 end
 
 /******************************************************************************/
-// Functions using operators
-
-__e2setcost(5) -- temporary
-
-registerOperator("ass", "e", "e", function(self, args)
-	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
-	self.Scopes[scope][op1] = rv2
-	self.Scopes[scope].vclk[op1] = true
-	return rv2
-end)
-
-/******************************************************************************/
 
 e2function number operator_is(entity ent)
 	if IsValid(ent) then return 1 else return 0 end

--- a/lua/entities/gmod_wire_expression2/core/extpp.lua
+++ b/lua/entities/gmod_wire_expression2/core/extpp.lua
@@ -37,7 +37,6 @@ local optable = {
 	["operator||"] = "or",
 	["operator[]"] = "idx", -- typeless op[]
 	["operator[T]"] = { "idx", OPTYPE_APPEND_RET }, -- typed op[]
-	["operator$"] = { "dlt", OPTYPE_DONT_FETCH_FIRST }, -- mostly superfluous now
 
 	["operator_is"] = "is",
 	["operator_neg"] = "neg",

--- a/lua/entities/gmod_wire_expression2/core/functions.lua
+++ b/lua/entities/gmod_wire_expression2/core/functions.lua
@@ -17,12 +17,11 @@ registerOperator("function", "", "", function(self, args)
 		for K,Data in pairs (Args) do
 			local Name, Type, OP = Data[1], Data[2], args[K + 1]
 			local RV = OP[1](self, OP)
-			Variables[#Variables + 1] = {Name,RV}
+			Variables[#Variables + 1] = {assert(Data.Id),RV}
 		end
 
 		local OldScopes = self:SaveScopes()
 		self:InitScope() -- Create a new Scope Enviroment
-		self:PushScope()
 
 		for I = 1, #Variables do
 			local Var = Variables[I]
@@ -32,7 +31,6 @@ registerOperator("function", "", "", function(self, args)
 		self.func_rv = nil
 		local ok, msg = pcall(Stmt[1],self,Stmt)
 
-		self:PopScope()
 		self:LoadScopes(OldScopes)
 
 		if not ok and msg:find( "C stack overflow" ) then error( "tick quota exceeded", -1 ) end -- a "C stack overflow" error will probably just confuse E2 users more than a "tick quota" error.

--- a/lua/entities/gmod_wire_expression2/core/functions.lua
+++ b/lua/entities/gmod_wire_expression2/core/functions.lua
@@ -27,7 +27,6 @@ registerOperator("function", "", "", function(self, args)
 		for I = 1, #Variables do
 			local Var = Variables[I]
 			self.Scope[Var[1]] = Var[2]
-			self.Scope["$" .. Var[1]] = Var[2]
 			self.Scope.vclk[Var[1]] = true
 		end
 

--- a/lua/entities/gmod_wire_expression2/core/functions.lua
+++ b/lua/entities/gmod_wire_expression2/core/functions.lua
@@ -20,8 +20,8 @@ registerOperator("function", "", "", function(self, args)
 			Variables[#Variables + 1] = {assert(Data.Id),RV}
 		end
 
-		local OldScopes = self:SaveScopes()
-		self:InitScope() -- Create a new Scope Enviroment
+		local oldScope = self.Scope
+		self:SetScope({})
 
 		for I = 1, #Variables do
 			local Var = Variables[I]
@@ -31,7 +31,7 @@ registerOperator("function", "", "", function(self, args)
 		self.func_rv = nil
 		local ok, msg = pcall(Stmt[1],self,Stmt)
 
-		self:LoadScopes(OldScopes)
+		self:SetScope(oldScope)
 
 		if not ok and msg:find( "C stack overflow" ) then error( "tick quota exceeded", -1 ) end -- a "C stack overflow" error will probably just confuse E2 users more than a "tick quota" error.
 

--- a/lua/entities/gmod_wire_expression2/core/functions.lua
+++ b/lua/entities/gmod_wire_expression2/core/functions.lua
@@ -27,7 +27,6 @@ registerOperator("function", "", "", function(self, args)
 		for I = 1, #Variables do
 			local Var = Variables[I]
 			self.Scope[Var[1]] = Var[2]
-			self.Scope.vclk[Var[1]] = true
 		end
 
 		self.func_rv = nil

--- a/lua/entities/gmod_wire_expression2/core/globalvars.lua
+++ b/lua/entities/gmod_wire_expression2/core/globalvars.lua
@@ -217,8 +217,6 @@ registerCallback("postinit",function()
 
 				for key, value in pairs(tbl) do
 					if key:sub(1, len) == v[1] then
-						self:PushScope()
-
 						self.prf = self.prf + 3
 
 						self.Scope[keyname] = key:sub(len + 1)
@@ -227,11 +225,9 @@ registerCallback("postinit",function()
 						local ok, msg = pcall(statement[1], self, statement)
 
 						if not ok then
-							if msg == "break" then	self:PopScope() break
-							elseif msg ~= "continue" then self:PopScope() error(msg, 0) end
+							if msg == "break" then break end
+							if msg ~= "continue" then error(msg, 0) end
 						end
-
-						self:PopScope()
 					end
 				end
 			end)

--- a/lua/entities/gmod_wire_expression2/core/globalvars.lua
+++ b/lua/entities/gmod_wire_expression2/core/globalvars.lua
@@ -26,31 +26,6 @@ registerType( "gtable", "xgt", {},
 
 __e2setcost(1)
 
-registerOperator("ass", "xgt", "xgt", function(self, args)
-	local lhs, op2, scope = args[2], args[3], args[4]
-	local      rhs = op2[1](self, op2)
-
-	local Scope = self.Scopes[scope]
-	if !Scope.lookup then Scope.lookup = {} end
-	local lookup = Scope.lookup
-
-	-- remove old lookup entry
-	if lookup[rhs] then lookup[rhs][lhs] = nil end
-
-	-- add new lookup entry
-	local lookup_entry = lookup[rhs]
-	if not lookup_entry then
-		lookup_entry = {}
-		lookup[rhs] = lookup_entry
-	end
-	lookup_entry[lhs] = true
-
-	--Scope.vars[lhs] = rhs
-	Scope[lhs] = rhs
-	Scope.vclk[lhs] = true
-	return rhs
-end)
-
 e2function number operator_is( gtable tbl )
 	return istable(tbl) and 1 or 0
 end

--- a/lua/entities/gmod_wire_expression2/core/globalvars.lua
+++ b/lua/entities/gmod_wire_expression2/core/globalvars.lua
@@ -221,9 +221,6 @@ registerCallback("postinit",function()
 
 						self.prf = self.prf + 3
 
-						self.Scope.vclk[keyname] = true
-						self.Scope.vclk[valname] = true
-
 						self.Scope[keyname] = key:sub(len + 1)
 						self.Scope[valname] = value
 

--- a/lua/entities/gmod_wire_expression2/core/init.lua
+++ b/lua/entities/gmod_wire_expression2/core/init.lua
@@ -93,12 +93,51 @@ function wire_expression2_reset_extensions()
 	wire_expression2_constants = {}
 end
 
+E2Lib.MutableReferenceType = "MutableReferenceType"
+
 -- additional args: <input serializer>, <output serializer>, <type checker>
-function registerType(name, id, def, ...)
-	wire_expression_types[string.upper(name)] = { id, def, ... }
-	wire_expression_types2[id] = { string.upper(name), def, ... }
+function registerType(name, id, def, inputSerializer, outputSerializer, typeAssert, inverseTypeTest, mutability, ...)
+	wire_expression_types[string.upper(name)] = { id, def, inputSerializer, outputSerializer, typeAssert, inverseTypeTest, ... }
+	wire_expression_types2[id] = { string.upper(name), def, inputSerializer, outputSerializer, typeAssert, inverseTypeTest, ... }
 	if not WireLib.DT[string.upper(name)] then
 		WireLib.DT[string.upper(name)] = { Zero = def }
+	end
+	if mutability == E2Lib.MutableReferenceType then
+		-- Mutable reference types have a different assignment operator that does
+		-- some extra tracking. This is so that modifications to the value through
+		-- one reference will also trigger that value to be output through all other
+		-- variables that are bound to it.
+		registerOperator("ass", id, id, function(self, args)
+			local name, expr, scopeId = args[2], args[3], args[4]
+			local value = expr[1](self, expr)
+
+			local scope = self.Scopes[scopeId]
+			scope[name] = value
+
+			if scopeId == 0 then
+				if not scope.lookup then scope.lookup = {} end
+				local lookup = scope.lookup
+				if not lookup[value] then lookup[value] = {} end
+				lookup[value][name] = true
+				scope.vclk[value] = true
+			end
+
+			return value
+		end, 2)
+	else
+		registerOperator("ass", id, id, function(self, args)
+			local name, expr, scopeId = args[2], args[3], args[4]
+			local value = expr[1](self, expr)
+
+			local scope = self.Scopes[scopeId]
+			scope[name] = value
+
+			if scopeId == 0 then
+				scope.vclk[name] = true
+			end
+
+			return value
+		end, 1)
 	end
 end
 

--- a/lua/entities/gmod_wire_expression2/core/init.lua
+++ b/lua/entities/gmod_wire_expression2/core/init.lua
@@ -107,7 +107,7 @@ function registerType(name, id, def, ...)
 		local scope = self.Scopes[scopeId]
 		scope[name] = value
 
-		if scopeId == 0 then
+		if scopeId == 1 then
 			self.TriggerQueued[name] = true
 		end
 

--- a/lua/entities/gmod_wire_expression2/core/matrix.lua
+++ b/lua/entities/gmod_wire_expression2/core/matrix.lua
@@ -87,16 +87,6 @@ e2function matrix2 identity2()
 end
 
 /******************************************************************************/
-
-registerOperator("ass", "xm2", "xm2", function(self, args)
-	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
-	self.Scopes[scope][op1] = rv2
-	self.Scopes[scope].vclk[op1] = true
-	return rv2
-end)
-
-/******************************************************************************/
 // Comparison
 
 e2function number operator_is(matrix2 rv1)
@@ -463,16 +453,6 @@ e2function matrix identity()
 			 0, 1, 0,
 			 0, 0, 1 }
 end
-
-/******************************************************************************/
-
-registerOperator("ass", "m", "m", function(self, args)
-	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
-	self.Scopes[scope][op1] = rv2
-	self.Scopes[scope].vclk[op1] = true
-	return rv2
-end)
 
 /******************************************************************************/
 // Comparison
@@ -999,16 +979,6 @@ e2function matrix4 identity4()
 			 0, 0, 1, 0,
 			 0, 0, 0, 1 }
 end
-
-/******************************************************************************/
-
-registerOperator("ass", "xm4", "xm4", function(self, args)
-	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
-	self.Scopes[scope][op1] = rv2
-	self.Scopes[scope].vclk[op1] = true
-	return rv2
-end)
 
 /******************************************************************************/
 // Comparison

--- a/lua/entities/gmod_wire_expression2/core/matrix.lua
+++ b/lua/entities/gmod_wire_expression2/core/matrix.lua
@@ -126,13 +126,6 @@ end
 /******************************************************************************/
 // Basic operations
 
-registerOperator("dlt", "xm2", "xm2", function(self, args)
-	local op1, scope = args[2], args[3]
-	local rv1, rv2 = self.Scopes[scope][op1], self.Scopes[scope]["$" .. op1]
-	return { rv1[1] - rv2[1], rv1[2] - rv2[2],
-			 rv1[3] - rv2[3], rv1[4] - rv2[4] }
-end)
-
 e2function matrix2 operator_neg(matrix2 rv1)
 	return { -rv1[1], -rv1[2],
 			 -rv1[3], -rv1[4] }
@@ -525,14 +518,6 @@ end
 
 /******************************************************************************/
 // Basic operations
-
-registerOperator("dlt", "m", "m", function(self, args)
-	local op1, scope = args[2], args[3]
-	local rv1, rv2 = self.Scopes[scope][op1], self.Scopes[scope]["$" .. op1]
-	return { rv1[1] - rv2[1], rv1[2] - rv2[2], rv1[3] - rv2[3],
-			 rv1[4] - rv2[4], rv1[5] - rv2[5], rv1[6] - rv2[6],
-			 rv1[7] - rv2[7], rv1[8] - rv2[8], rv1[9] - rv2[9]	}
-end)
 
 e2function matrix operator_neg(matrix rv1)
 	return { -rv1[1], -rv1[2], -rv1[3],
@@ -1090,15 +1075,6 @@ end
 
 /******************************************************************************/
 // Basic operations
-
-registerOperator("dlt", "xm4", "xm4", function(self, args)
-	local op1, scope = args[2], args[3]
-	local rv1, rv2 = self.Scopes[scope][op1], self.Scopes[scope]["$" .. op1]
-	return { rv1[1] - rv2[1],	rv1[2] - rv2[2],	rv1[3] - rv2[3],	rv1[4] - rv2[4],
-			 rv1[5] - rv2[5],	rv1[6] - rv2[6],	rv1[7] - rv2[7],	rv1[8] - rv2[8],
-			 rv1[9] - rv2[9],	rv1[10] - rv2[10],	rv1[11] - rv2[11],	rv1[12] - rv2[12],
-			 rv1[13] - rv2[13],	rv1[14] - rv2[14],	rv1[15] - rv2[15],	rv1[16] - rv2[16] }
-end)
 
 e2function matrix4 operator_neg(matrix4 rv1)
 	return { -rv1[1],	-rv1[2],	-rv1[3],	-rv1[4],

--- a/lua/entities/gmod_wire_expression2/core/number.lua
+++ b/lua/entities/gmod_wire_expression2/core/number.lua
@@ -51,16 +51,6 @@ E2Lib.registerConstant("PHI", (1+sqrt(5))/2)
 
 --[[************************************************************************]]--
 
-__e2setcost(2)
-
-registerOperator("ass", "n", "n", function(self, args)
-	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
-	self.Scopes[scope][op1] = rv2
-	self.Scopes[scope].vclk[op1] = true
-	return rv2
-end)
-
 __e2setcost(1.5)
 
 registerOperator("inc", "n", "", function(self, args)

--- a/lua/entities/gmod_wire_expression2/core/number.lua
+++ b/lua/entities/gmod_wire_expression2/core/number.lua
@@ -56,13 +56,17 @@ __e2setcost(1.5)
 registerOperator("inc", "n", "", function(self, args)
 	local op1, scope = args[2], args[3]
 	self.Scopes[scope][op1] = self.Scopes[scope][op1] + 1
-	self.Scopes[scope].vclk[op1] = true
+	if scope == 0 then
+		self.GlobalScope.vclk[op1] = true
+	end
 end)
 
 registerOperator("dec", "n", "", function(self, args)
 	local op1, scope = args[2], args[3]
 	self.Scopes[scope][op1] = self.Scopes[scope][op1] - 1
-	self.Scopes[scope].vclk[op1] = true
+	if scope == 0 then
+		self.GlobalScope.vclk[op1] = true
+	end
 end)
 
 --[[************************************************************************]]--

--- a/lua/entities/gmod_wire_expression2/core/number.lua
+++ b/lua/entities/gmod_wire_expression2/core/number.lua
@@ -126,13 +126,6 @@ end)
 
 --[[************************************************************************]]--
 
-__e2setcost(5)
-
-registerOperator("dlt", "n", "n", function(self, args)
-	local op1, scope = args[2], args[3]
-	return self.Scopes[scope][op1] - self.Scopes[scope]["$" .. op1]
-end)
-
 __e2setcost(0.5) -- approximation
 
 registerOperator("neg", "n", "n", function(self, args)

--- a/lua/entities/gmod_wire_expression2/core/number.lua
+++ b/lua/entities/gmod_wire_expression2/core/number.lua
@@ -57,7 +57,7 @@ registerOperator("inc", "n", "", function(self, args)
 	local op1, scope = args[2], args[3]
 	self.Scopes[scope][op1] = self.Scopes[scope][op1] + 1
 	if scope == 0 then
-		self.GlobalScope.vclk[op1] = true
+		self.TriggerQueued[op1] = true
 	end
 end)
 
@@ -65,7 +65,7 @@ registerOperator("dec", "n", "", function(self, args)
 	local op1, scope = args[2], args[3]
 	self.Scopes[scope][op1] = self.Scopes[scope][op1] - 1
 	if scope == 0 then
-		self.GlobalScope.vclk[op1] = true
+		self.TriggerQueued[op1] = true
 	end
 end)
 

--- a/lua/entities/gmod_wire_expression2/core/quaternion.lua
+++ b/lua/entities/gmod_wire_expression2/core/quaternion.lua
@@ -227,19 +227,6 @@ e2function quaternion qk(n)
 end
 
 /******************************************************************************/
-
-__e2setcost(2)
-
-registerOperator("ass", "q", "q", function(self, args)
-	local lhs, op2, scope = args[2], args[3], args[4]
-	local      rhs = op2[1](self, op2)
-
-	self.Scopes[scope][lhs] = rhs
-	self.Scopes[scope].vclk[lhs] = true
-	return rhs
-end)
-
-/******************************************************************************/
 // TODO: define division as multiplication with (1/x), or is it not useful?
 
 __e2setcost(4)

--- a/lua/entities/gmod_wire_expression2/core/ranger.lua
+++ b/lua/entities/gmod_wire_expression2/core/ranger.lua
@@ -151,16 +151,6 @@ end
 
 __e2setcost(1) -- temporary
 
---- RD = RD
-registerOperator("ass", "xrd", "xrd", function(self, args)
-	local lhs, op2, scope = args[2], args[3], args[4]
-	local      rhs = op2[1](self, op2)
-
-	self.Scopes[scope][lhs] = rhs
-	self.Scopes[scope].vclk[lhs] = true
-	return rhs
-end)
-
 e2function number operator_is(ranger walker)
 	if walker then return 1 else return 0 end
 end

--- a/lua/entities/gmod_wire_expression2/core/selfaware.lua
+++ b/lua/entities/gmod_wire_expression2/core/selfaware.lua
@@ -54,7 +54,7 @@ local function setOutput( self, args, Type )
 	local rv1, rv2 = op1[1](self,op1), op2[1](self,op2)
 	if (self.entity.Outputs[rv1] and self.entity.Outputs[rv1].Type == Type) then
 		self.GlobalScope[rv1] = rv2
-		self.GlobalScope.vclk[rv1] = true
+		self.TriggerQueued[rv1] = true
 	end
 end
 

--- a/lua/entities/gmod_wire_expression2/core/strfunc.lua
+++ b/lua/entities/gmod_wire_expression2/core/strfunc.lua
@@ -78,7 +78,7 @@ end
 
 __e2setcost(20)
 
-registerOperator( "sfun", "", "", function(self, args)
+registerOperator( "scall", "", "", function(self, args)
 	local op1, funcargs, typeids, typeids_str, returntype = args[2], args[3], args[4], args[5], args[6]
 	local funcname = op1[1](self,op1)
 

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -24,18 +24,6 @@ registerType("string", "s", "",
 
 /******************************************************************************/
 
-__e2setcost(3) -- temporary
-
-registerOperator("ass", "s", "s", function(self, args)
-	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
-	self.Scopes[scope][op1] = rv2
-	self.Scopes[scope].vclk[op1] = true
-	return rv2
-end)
-
-/******************************************************************************/
-
 registerOperator("is", "s", "n", function(self, args)
 	local op1 = args[2]
 	local rv1 = op1[1](self, op1)

--- a/lua/entities/gmod_wire_expression2/core/table.lua
+++ b/lua/entities/gmod_wire_expression2/core/table.lua
@@ -1113,8 +1113,6 @@ registerCallback( "postinit", function()
 
 			for key, value in pairs(tbl.s) do
 				if tbl.stypes[key] == id then
-					self:PushScope()
-
 					self.prf = self.prf + 3
 
 					self.Scope[keyname] = key
@@ -1123,11 +1121,9 @@ registerCallback( "postinit", function()
 					local ok, msg = pcall(statement[1], self, statement)
 
 					if not ok then
-						if msg == "break" then	self:PopScope() break
-						elseif msg ~= "continue" then self:PopScope() error(msg, 0) end
+						if msg == "break" then break end
+						if msg ~= "continue" then error(msg, 0) end
 					end
-
-					self:PopScope()
 				end
 			end
 		end)
@@ -1142,8 +1138,6 @@ registerCallback( "postinit", function()
 
 			for key, value in pairs(tbl.n) do
 				if tbl.ntypes[key] == id then
-					self:PushScope()
-
 					self.prf = self.prf + 3
 
 					self.Scope[keyname] = key
@@ -1152,11 +1146,9 @@ registerCallback( "postinit", function()
 					local ok, msg = pcall(statement[1], self, statement)
 
 					if not ok then
-						if msg == "break" then	self:PopScope() break
-						elseif msg ~= "continue" then self:PopScope() error(msg, 0) end
+						if msg == "break" then break end
+						if msg ~= "continue" then error(msg, 0) end
 					end
-
-					self:PopScope()
 				end
 			end
 		end)

--- a/lua/entities/gmod_wire_expression2/core/table.lua
+++ b/lua/entities/gmod_wire_expression2/core/table.lua
@@ -48,7 +48,8 @@ registerType("table", "t", table.Copy(DEFAULT),
 	end,
 	function(v)
 		return not istable(v)
-	end
+	end,
+	E2Lib.MutableReferenceType
 )
 
 local formatPort = WireLib.Debugger.formatPort
@@ -253,25 +254,6 @@ end
 --------------------------------------------------------------------------------
 -- Operators
 --------------------------------------------------------------------------------
-
-__e2setcost(5)
-
-registerOperator("ass", "t", "t", function(self, args)
-	local lhs, op2, scope = args[2], args[3], args[4]
-	local      rhs = op2[1](self, op2)
-
-	local Scope = self.Scopes[scope]
-	if !Scope.lookup then Scope.lookup = {} end
-
-	local lookup = Scope.lookup
-	if (lookup[rhs]) then lookup[rhs][lhs] = nil end
-	if (!lookup[rhs]) then lookup[rhs] = {} end
-	lookup[rhs][lhs] = true
-
-	Scope[lhs] = rhs
-	Scope.vclk[lhs] = true
-	return rhs
-end)
 
 __e2setcost(1)
 

--- a/lua/entities/gmod_wire_expression2/core/table.lua
+++ b/lua/entities/gmod_wire_expression2/core/table.lua
@@ -1118,9 +1118,6 @@ registerCallback( "postinit", function()
 
 					self.prf = self.prf + 3
 
-					self.Scope.vclk[keyname] = true
-					self.Scope.vclk[valname] = true
-
 					self.Scope[keyname] = key
 					self.Scope[valname] = value
 
@@ -1149,9 +1146,6 @@ registerCallback( "postinit", function()
 					self:PushScope()
 
 					self.prf = self.prf + 3
-
-					self.Scope.vclk[keyname] = true
-					self.Scope.vclk[valname] = true
 
 					self.Scope[keyname] = key
 					self.Scope[valname] = value

--- a/lua/entities/gmod_wire_expression2/core/vector.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector.lua
@@ -104,12 +104,6 @@ end
 
 --------------------------------------------------------------------------------
 
-registerOperator("dlt", "v", "v", function(self, args)
-	local op1, scope = args[2], args[3]
-	local rv1, rv2 = self.Scopes[scope][op1], self.Scopes[scope]["$" .. op1]
-	return { rv1[1] - rv2[1], rv1[2] - rv2[2], rv1[3] - rv2[3] }
-end)
-
 e2function vector vector:operator_neg()
 	return { -this[1], -this[2], -this[3] }
 end

--- a/lua/entities/gmod_wire_expression2/core/vector.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector.lua
@@ -71,16 +71,6 @@ end
 
 --------------------------------------------------------------------------------
 
-registerOperator("ass", "v", "v", function(self, args)
-	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
-	self.Scopes[scope][op1] = rv2
-	self.Scopes[scope].vclk[op1] = true
-	return rv2
-end)
-
---------------------------------------------------------------------------------
-
 e2function number vector:operator_is()
 	if this[1] > delta or -this[1] > delta or
 	   this[2] > delta or -this[2] > delta or

--- a/lua/entities/gmod_wire_expression2/core/vector2.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector2.lua
@@ -59,16 +59,6 @@ end)
 
 /******************************************************************************/
 
-registerOperator("ass", "xv2", "xv2", function(self, args)
-	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
-	self.Scopes[scope][op1] = rv2
-	self.Scopes[scope].vclk[op1] = true
-	return rv2
-end)
-
-/******************************************************************************/
-
 registerOperator("is", "xv2", "n", function(self, args)
 	local op1 = args[2]
 	local rv1 = op1[1](self, op1)
@@ -587,16 +577,6 @@ registerFunction("vec4", "vn", "xv4", function(self, args)
 	local op1, op2 = args[2], args[3]
 	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
 	return { rv1[1], rv1[2], rv1[3], rv2 }
-end)
-
-/******************************************************************************/
-
-registerOperator("ass", "xv4", "xv4", function(self, args)
-	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
-	self.Scopes[scope][op1] = rv2
-	self.Scopes[scope].vclk[op1] = true
-	return rv2
 end)
 
 /******************************************************************************/

--- a/lua/entities/gmod_wire_expression2/core/vector2.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector2.lua
@@ -95,12 +95,6 @@ end)
 
 /******************************************************************************/
 
-registerOperator("dlt", "xv2", "xv2", function(self, args)
-	local op1, scope = args[2], args[3]
-	local rv1, rv2 = self.Scopes[scope][op1], self.Scopes[scope]["$" .. op1]
-	return { rv1[1] - rv2[1], rv1[2] - rv2[2] }
-end)
-
 registerOperator("neg", "xv2", "xv2", function(self, args)
 	local op1 = args[2]
 	local rv1 = op1[1](self, op1)
@@ -638,12 +632,6 @@ registerOperator("neq", "xv4xv4", "n", function(self, args)
 end)
 
 /******************************************************************************/
-
-registerOperator("dlt", "xv4", "xv4", function(self, args)
-	local op1, scope = args[2], args[3]
-	local rv1, rv2 = self.Scopes[scope][op1], self.Scopes[scope]["$" .. op1]
-	return { rv1[1] - rv2[1], rv1[2] - rv2[2], rv1[3] - rv2[3], rv1[4] - rv2[4] }
-end)
 
 registerOperator("neg", "xv4", "xv4", function(self, args)
 	local op1 = args[2]

--- a/lua/entities/gmod_wire_expression2/core/wirelink.lua
+++ b/lua/entities/gmod_wire_expression2/core/wirelink.lua
@@ -135,18 +135,6 @@ registerType("wirelink", "xwl", nil,
 
 /******************************************************************************/
 
-__e2setcost(2) -- temporary
-
-registerOperator("ass", "xwl", "xwl", function(self, args)
-	local lhs, op2, scope = args[2], args[3], args[4]
-	local      rhs = op2[1](self, op2)
-	self.Scopes[scope][lhs] = rhs
-	self.Scopes[scope].vclk[lhs] = true
-	return rhs
-end)
-
-/******************************************************************************/
-
 e2function number operator_is(wirelink value)
 	if not validWirelink(self, value) then return 0 end
 	return 1

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -42,24 +42,6 @@ local function copytype(var)
 	return istable(var) and table.Copy(var) or var
 end
 
-
-local ScopeManager = {}
-ScopeManager.__index = ScopeManager
-
-function ScopeManager:InitScope()
-	self:LoadScopes({ self.GlobalScope or {}, {} })
-end
-
-function ScopeManager:SaveScopes()
-	return self.Scopes
-end
-
-function ScopeManager:LoadScopes(Scopes)
-	self.Scopes = Scopes
-	self.GlobalScope = Scopes[1]
-	self.Scope = Scopes[2]
-end
-
 function ENT:UpdateOverlay(clear)
 	if clear then
 		self:SetOverlayData( {
@@ -314,16 +296,21 @@ function ENT:ResetContext()
 		timebench = 0,
 		includes = self.includes,
 
+		GlobalScope = {}, -- The values of all global variables.
+
 		-- A set of variable names that need a TriggerOutput
 		TriggerQueued = {},
 		-- Values which, if a global variable has this value, then that variable needs a TriggerOutput
 		IndirectTriggerQueued = {},
+
+		SetScope = function(self, scope)
+			self.Scope = scope
+			self.Scopes[2] = scope
+		end
 	}
-
-	setmetatable(context, ScopeManager)
-	context:InitScope()
-
+	context.Scopes = { context.GlobalScope, nil }
 	self.context = context
+	self.context:SetScope({})
 	self.GlobalScope = context.GlobalScope
 	self._vars = self.GlobalScope -- Dupevars
 

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -119,10 +119,6 @@ function ENT:Execute()
 	if self.error then return end
 	if self.context.resetting then return end
 
-	for k, v in pairs(self.tvars) do
-		self.GlobalScope[k] = copytype(wire_expression_types2[v][2])
-	end
-
 	self:PCallHook('preexecute')
 
 	self.context:PushScope()
@@ -265,7 +261,6 @@ function ENT:CompileCode(buffer, files, filepath)
 
 	self.script = script
 	self.dvars = inst.dvars
-	self.tvars = inst.tvars
 	self.funcs = inst.funcs
 	self.funcs_ret = inst.funcs_ret
 	self.globvars = inst.GlobalScope

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -257,6 +257,9 @@ function ENT:CompileCode(buffer, files, filepath)
 	status,tree = E2Lib.Optimizer.Execute(tree)
 	if not status then self:Error(tree) return end
 
+	status, tree = E2Lib.Analyzer.Execute(tree, self.includes)
+	if not status then self:Error(tree) return end
+
 	local status, script, inst = E2Lib.Compiler.Execute(tree, self.inports[3], self.outports[3], self.persists[3], dvars, self.includes)
 	if not status then self:Error(script) return end
 

--- a/lua/entities/gmod_wire_expression2/shared.lua
+++ b/lua/entities/gmod_wire_expression2/shared.lua
@@ -17,6 +17,7 @@ include("core/e2lib.lua")
 include("base/preprocessor.lua")
 include("base/tokenizer.lua")
 include("base/parser.lua")
+include("base/analyzer.lua")
 if SERVER then
 	include("base/optimizer.lua")
 end


### PR DESCRIPTION
This pull request shouldn't change anything as far as E2 users are concerned. Under the hood, things should be simpler and faster.

The headline change is that instead of maintaining a stack of scopes in order to implement local variables, we now give each local variable a unique ID and just store them in a flat table. That means that instructions which implicitly introduce a new scope - such as `if`, `whl`, `fea`, and others - no longer need to do any work to achieve that at runtime. The only place runtime scope management still happens is on user-defined function calls and `#include`.