### PR TITLE
E2: Allow nested function definitions

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -36,6 +36,7 @@ function Compiler:Process(root, inputs, outputs, persist, delta, includes) -- To
 	self.funcs = {}
 	self.dvars = {}
 	self.funcs_ret = {}
+	self.EnclosingFunctions = { --[[ { ReturnType: string } ]] }
 
 	for name, v in pairs(inputs) do
 		self:SetGlobalVariableType(name, wire_expression_types[v][1], { nil, { 0, 0 } })
@@ -726,11 +727,11 @@ function Compiler:InstrFUNCTION(args)
 
 	self.funcs_ret[Sig] = Return
 
-	self.func_ret = Return
+	table.insert(self.EnclosingFunctions, { ReturnType = Return })
 
 	local Stmt = self:EvaluateStatement(args, 5) -- Offset of -2
 
-	self.func_ret = nil
+	table.remove(self.EnclosingFunctions)
 
 	self:PopScope()
 	self:LoadScopes(OldScopes) -- Reload the old enviroment
@@ -741,23 +742,22 @@ function Compiler:InstrFUNCTION(args)
 end
 
 function Compiler:InstrRETURN(args)
-	local Value, Type = self:Evaluate(args, 1)
-
-	if not self.func_ret or self.func_ret == "" then
-		self:Error("Return type mismatch: void expected, got " .. tps_pretty(Type), args)
-	elseif self.func_ret ~= Type then
-		self:Error("Return type mismatch: " .. tps_pretty(self.func_ret) .. " expected, got " .. tps_pretty(Type), args)
+	local enclosingFunction = self.EnclosingFunctions[#self.EnclosingFunctions]
+	if enclosingFunction == nil then
+		self:Error("Return may not exist outside of a function", args)
 	end
 
-	return { self:GetOperator(args, "return", {})[1], Value, Type }
-end
-
-function Compiler:InstrRETURNVOID(args)
-	if self.func_ret and self.func_ret ~= "" then
-		self:Error("Return type mismatch: " .. tps_pretty(self.func_ret) .. " expected got, void", args)
+	local expectedType = assert(enclosingFunction.ReturnType)
+	local value, actualType
+	if args[3] then
+		value, actualType = self:Evaluate(args, 1)
 	end
 
-	return { self:GetOperator(args, "return", {})[1], nil, nil }
+	if actualType ~= expectedType then
+		self:Error("Return type mismatch: " .. tps_pretty(expectedType) .. " expected, got " .. tps_pretty(actualType), args)
+	end
+
+	return { self:GetOperator(args, "return", {})[1], value, actualType }
 end
 
 function Compiler:InstrKVTABLE(args)

--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -582,9 +582,6 @@ function Parser:Stmt10()
 		local Trace = self:GetTokenTrace()
 
 
-		if self.in_func then self:Error("Functions can not be created from inside other functions") end
-
-
 		local Name, Return, Type
 		local NameToken, ReturnToken, TypeToken
 		local Args, Temp = {}, {}
@@ -683,11 +680,7 @@ function Parser:Stmt10()
 
 		if wire_expression2_funcs[Sig] then self:Error("Function '" .. Sig .. "' already exists") end
 
-		self.in_func = true
-
 		local Inst = self:Instruction(Trace, "function", Sig, Return, Type, Args, self:Block("function decleration"))
-
-		self.in_func = false
 
 		return Inst
 
@@ -696,18 +689,11 @@ function Parser:Stmt10()
 
 		local Trace = self:GetTokenTrace()
 
-		if self.in_func then
-
-			if self:AcceptRoamingToken("void") or (self.readtoken[1] and self.readtoken[1] == "rcb") then
-				return self:Instruction(Trace, "returnvoid")
-			end
-
-			return self:Instruction(Trace, "return", self:Expr1())
-
-		else
-			self:Error("Return may not exist outside of a function")
+		if self:AcceptRoamingToken("void") or (self.readtoken[1] and self.readtoken[1] == "rcb") then
+			return self:Instruction(Trace, "return")
 		end
 
+		return self:Instruction(Trace, "return", self:Expr1())
 
 		-- Void Missplacement
 	elseif self:AcceptRoamingToken("void") then


### PR DESCRIPTION
Now the following code is valid:

```Javascript
function f() {
    A = 1
    function g() {
        A += 1
    }
}
f(), g()
if (A != 2) { error("") }

function number h() {
    function number h() {
        return 2
    }
    return 1
}
if (h() != 1) { error("") }
if (h() != 2) { error("") }
```

Enjoy your newfound power.

Fixes #1421