### PR TITLE
Add "Range" input for Wire Data Transferer

### DIFF
--- a/lua/entities/gmod_wire_cd_ray.lua
+++ b/lua/entities/gmod_wire_cd_ray.lua
@@ -14,7 +14,7 @@ function ENT:Initialize()
 	self:PhysicsInit( SOLID_VPHYSICS )
 	self:SetMoveType( MOVETYPE_VPHYSICS )
 	self:SetSolid( SOLID_VPHYSICS )
-	self.Inputs = Wire_CreateInputs(self, {"Write","Read","Value"})
+	self.Inputs = Wire_CreateInputs(self, {"Write","Read","Value","Range"})
 	self.Outputs = Wire_CreateOutputs(self, {"Data","Sector","LocalSector","Track","Stack","Address"})
 
 	self.Command = {}
@@ -47,6 +47,7 @@ function ENT:Initialize()
 	self.Command[29] = 0 //[R] Bytes per block
 	self.Command[30] = 0 //[R] Disk size (per stack)
 	self.Command[31] = 0 //[R] Disk volume (bytes total)
+	self.Command[32] = 0 //[R] Disk entity id
 
 	self.WriteBuffer = {}
 	self.PrevDiskEnt = nil
@@ -109,6 +110,8 @@ function ENT:TriggerInput(iname, value)
 		self.Command[8] = 1
 		self.Command[9] = 1
 		self.WriteBuffer[0] = value
+	elseif(iname == "Range")then
+		self:SetBeamLength(math.Clamp(value,0,32000))
 	end
 end
 
@@ -186,6 +189,7 @@ function ENT:Think()
 			self.Command[29] = disk.BytesPerBlock
 			self.Command[30] = disk.DiskSize
 			self.Command[31] = disk.DiskVolume
+			self.Command[32] = disk.Entity:EntIndex()
 		end
 
 		if ((track >= disk.FirstTrack) and (stack >= 0) and (sector >= 0) and
@@ -247,6 +251,7 @@ function ENT:Think()
 		self.Command[29] = 0
 		self.Command[30] = 0
 		self.Command[31] = 0
+		self.Command[32] = 0
 	end
 
 	//Update output

--- a/lua/entities/gmod_wire_data_transferer.lua
+++ b/lua/entities/gmod_wire_data_transferer.lua
@@ -14,7 +14,7 @@ function ENT:Initialize()
 	self:PhysicsInit( SOLID_VPHYSICS )
 	self:SetMoveType( MOVETYPE_VPHYSICS )
 	self:SetSolid( SOLID_VPHYSICS )
-	self.Inputs = Wire_CreateInputs(self, {"Send","A","B","C","D","E","F","G","H"})
+	self.Inputs = Wire_CreateInputs(self, {"Send","Range","A","B","C","D","E","F","G","H"})
 	self.Outputs = Wire_CreateOutputs(self, {"A","B","C","D","E","F","G","H"})
 	self.Sending = false
 	self.Activated = false
@@ -43,6 +43,8 @@ end
 function ENT:TriggerInput(iname, value)
 	if(iname == "Send")then
 		self.Sending = value > 0
+	elseif(iname == "Range")then
+		self:SetBeamLength(math.Clamp(value,0,32000))
 	else
 		self.Values[iname] = value
 	end


### PR DESCRIPTION
This change will allow to dynamically change range of beam via wiremod and also you can "disable beam" by setting range to zero (when you want for example disable beam when your device is off or so).