### PR TITLE
Add "Range" input for Wire Data Transferer

### DIFF
--- a/lua/entities/gmod_wire_data_transferer.lua
+++ b/lua/entities/gmod_wire_data_transferer.lua
@@ -14,7 +14,7 @@ function ENT:Initialize()
 	self:PhysicsInit( SOLID_VPHYSICS )
 	self:SetMoveType( MOVETYPE_VPHYSICS )
 	self:SetSolid( SOLID_VPHYSICS )
-	self.Inputs = Wire_CreateInputs(self, {"Send","A","B","C","D","E","F","G","H"})
+	self.Inputs = Wire_CreateInputs(self, {"Send","Range","A","B","C","D","E","F","G","H"})
 	self.Outputs = Wire_CreateOutputs(self, {"A","B","C","D","E","F","G","H"})
 	self.Sending = false
 	self.Activated = false
@@ -43,6 +43,8 @@ end
 function ENT:TriggerInput(iname, value)
 	if(iname == "Send")then
 		self.Sending = value > 0
+	elseif(iname == "Range")then
+		self:SetBeamLength(math.Clamp(value,0,32000))
 	else
 		self.Values[iname] = value
 	end


### PR DESCRIPTION
This change will allow to dynamically change range of beam via wiremod and also you can "disable beam" by setting range to zero (when you want for example disable beam when your device is off or so).