### PR TITLE
Added "Range" input for Wire CD Ray and new command

### DIFF
--- a/lua/entities/gmod_wire_cd_ray.lua
+++ b/lua/entities/gmod_wire_cd_ray.lua
@@ -14,7 +14,7 @@ function ENT:Initialize()
 	self:PhysicsInit( SOLID_VPHYSICS )
 	self:SetMoveType( MOVETYPE_VPHYSICS )
 	self:SetSolid( SOLID_VPHYSICS )
-	self.Inputs = Wire_CreateInputs(self, {"Write","Read","Value"})
+	self.Inputs = Wire_CreateInputs(self, {"Write","Read","Value","Range"})
 	self.Outputs = Wire_CreateOutputs(self, {"Data","Sector","LocalSector","Track","Stack","Address"})
 
 	self.Command = {}
@@ -47,6 +47,7 @@ function ENT:Initialize()
 	self.Command[29] = 0 //[R] Bytes per block
 	self.Command[30] = 0 //[R] Disk size (per stack)
 	self.Command[31] = 0 //[R] Disk volume (bytes total)
+	self.Command[32] = 0 //[R] Disk entity id
 
 	self.WriteBuffer = {}
 	self.PrevDiskEnt = nil
@@ -109,6 +110,8 @@ function ENT:TriggerInput(iname, value)
 		self.Command[8] = 1
 		self.Command[9] = 1
 		self.WriteBuffer[0] = value
+	elseif(iname == "Range")then
+		self:SetBeamLength(math.Clamp(value,0,32000))
 	end
 end
 
@@ -186,6 +189,7 @@ function ENT:Think()
 			self.Command[29] = disk.BytesPerBlock
 			self.Command[30] = disk.DiskSize
 			self.Command[31] = disk.DiskVolume
+			self.Command[32] = disk.Entity:EntIndex()
 		end
 
 		if ((track >= disk.FirstTrack) and (stack >= 0) and (sector >= 0) and
@@ -247,6 +251,7 @@ function ENT:Think()
 		self.Command[29] = 0
 		self.Command[30] = 0
 		self.Command[31] = 0
+		self.Command[32] = 0
 	end
 
 	//Update output


### PR DESCRIPTION
- Added "Range" input for Wire CD Ray
- Added new read command (32 index) what return disk entity id

Basically this will also allow you to turn off beam or change range dynamically. As for new command - it also makes some additional ability to make some checks or so in your scripts without using rangeOffset or other things.