### PR TITLE
Add model selector for wire cd disks

### DIFF
--- a/lua/wire/stools/cd_disk.lua
+++ b/lua/wire/stools/cd_disk.lua
@@ -6,6 +6,10 @@ if (CLIENT) then
 	language.Add("Tool.wire_cd_disk.desc", "Spawns a CD Disk.")
 	language.Add("WireDataTransfererTool_cd_disk", "CD Disk:")
 
+	list.Set( "Wire_Laser_Disk_Models", "models/venompapa/wirecd_small.mdl", true )
+	list.Set( "Wire_Laser_Disk_Models", "models/venompapa/wirecd_medium.mdl", true )
+	list.Set( "Wire_Laser_Disk_Models", "models/venompapa/wirecd_huge.mdl", true )
+	
 	TOOL.Information = {
 		{ name = "left", text = "Create/Update " .. TOOL.Name },
 		{ name = "right", text = "Change model" },
@@ -41,6 +45,7 @@ function TOOL:RightClick(trace)
 end
 
 function TOOL.BuildCPanel(panel)
+	WireDermaExts.ModelSelect(panel, "wire_cd_disk_Model", list.Get( "Wire_Laser_Disk_Models" ), 1)
 	panel:NumSlider("Disk density (inches per block, ipb)","wire_cd_disk_precision",1,16,0)
 	panel:NumSlider("Inner radius (disk hole radius)","wire_cd_disk_iradius",1,48,0)
 	panel:NumSlider("Disk skin (0..8, standard disks only)","wire_cd_disk_skin",0,8,0)

--- a/lua/wire/stools/cd_disk.lua
+++ b/lua/wire/stools/cd_disk.lua
@@ -9,7 +9,7 @@ if (CLIENT) then
 	list.Set( "Wire_Laser_Disk_Models", "models/venompapa/wirecd_small.mdl", true )
 	list.Set( "Wire_Laser_Disk_Models", "models/venompapa/wirecd_medium.mdl", true )
 	list.Set( "Wire_Laser_Disk_Models", "models/venompapa/wirecd_huge.mdl", true )
-	
+
 	TOOL.Information = {
 		{ name = "left", text = "Create/Update " .. TOOL.Name },
 		{ name = "right", text = "Change model" },


### PR DESCRIPTION
This makes choosing default models for cd disks much easier (without using console).