### PR TITLE
Fix return void giving type mismatch

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -802,6 +802,8 @@ function Compiler:InstrRETURN(args)
 	local value, actualType
 	if args[3] then
 		value, actualType = self:Evaluate(args, 1)
+	else
+		actualType = ""
 	end
 
 	if actualType ~= expectedType then


### PR DESCRIPTION
Fixes #1616 

```
function test()
{
    return
}
```
`return type mismatch: void expected, got void`


When testing #1587 I completely forgot to test returning early/void.