### PR TITLE
Clamp wire width for tool and e2 extension

### DIFF
--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -596,7 +596,7 @@ function WireLib.Link_Start(idx, ent, pos, iname, material, color, width)
 	input.StartPos = pos
 	input.Material = material
 	input.Color = color
-	input.Width = width
+	input.Width = math.Clamp(width, 0, 5)
 
 	return true
 end


### PR DESCRIPTION
having wires with the width of 500 is a bit annoying and unneeded, I chose to cap it at 5 because that is the max that can be set in the tool settings.