### PR TITLE
Stop memory faults on keyboard hispeed writes

### DIFF
--- a/lua/entities/gmod_wire_keyboard/init.lua
+++ b/lua/entities/gmod_wire_keyboard/init.lua
@@ -150,7 +150,7 @@ function ENT:WriteCell(Address, value)
 		self:RemoveFromBufferByKey(value)
 	end
 
-	return false
+	return true
 end
 
 util.AddNetworkString("wire_keyboard_blockinput")


### PR DESCRIPTION
Previously the keyboard signalled an invalid memory location (by
returning false) in ENT:WriteCell(), even for locations it understands
and acts on. This made it harder to interact with from the CPU.

Fixes #1627.