### PR TITLE
Fix rotating text on egp emitter

### DIFF
--- a/lua/entities/gmod_wire_egp/lib/objects/text.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/text.lua
@@ -40,7 +40,7 @@ if CLIENT then
 	matTrans = Vector(0, 0, 0)
 end
 
-Obj.Draw = function( self )
+Obj.Draw = function( self, ent )
 	if (self.text and #self.text>0) then
 		surface_SetTextColor( self.r, self.g, self.b, self.a )
 
@@ -87,13 +87,26 @@ Obj.Draw = function( self )
 				y = (h * ((self.valign%10)/2))
 			end
 
-			-- Thanks to Wizard for the base to this rotateable text code. I edited it a bit to properly support alignment
+			mat:Identity()
+
+			-- cam.PushModelMatrix replaces the model matrix pushed onto the stack by cam.Start3D2D
+			-- We have to recreate the cam.Start3D2D model matrix
+			if ent:GetClass() == "gmod_wire_egp_emitter" then
+				-- This corresponds to the pos and ang offsets specified in the egp emitter file
+				-- We add 180 to the roll because this is how cam.Start3D2D works
+				local pos = ent:LocalToWorld(Vector(-64, 0, 135))
+				local ang = ent:LocalToWorldAngles(Angle(0, 0, 90 + 180))
+
+				mat:SetTranslation(pos)
+				mat:SetAngles(ang)
+				mat:SetScale(Vector(0.25, 0.25, 0.25))
+			end
+
 			matAng.y = -self.angle
-			mat:SetAngles(matAng)
-			matTrans.x = x
-			matTrans.y = y
-			matTrans:Rotate(matAng)
-			mat:SetTranslation(Vector(self.x,self.y,0)-matTrans)
+
+			mat:Translate(Vector(self.x, self.y, 0))
+			mat:Rotate(matAng)
+
 			surface_SetTextPos(0, 0)
 			cam_PushModelMatrix(mat)
 				surface_DrawText( self.text )

--- a/lua/entities/gmod_wire_egp/lib/objects/text.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/text.lua
@@ -17,10 +17,8 @@ local surface_SetFont
 local surface_GetTextSize
 local cam_PushModelMatrix
 local cam_PopModelMatrix
-local mat = Matrix()
-local matAng = Angle(0, 0, 0)
-local matTrans = Vector(0, 0, 0)
-local matScale = Vector(0, 0, 0)
+local mat
+local matAng
 
 if CLIENT then
 	surface_SetTextPos = surface.SetTextPos
@@ -35,9 +33,7 @@ if CLIENT then
 	cam_PushModelMatrix = cam.PushModelMatrix
 	cam_PopModelMatrix = cam.PopModelMatrix
 	mat = Matrix()
-	mat:Scale(Vector(1, 1, 1))
 	matAng = Angle(0, 0, 0)
-	matTrans = Vector(0, 0, 0)
 end
 
 Obj.Draw = function( self, ent )

--- a/lua/entities/gmod_wire_egp/lib/objects/textlayout.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/textlayout.lua
@@ -9,14 +9,17 @@ Obj.valign = 0
 Obj.halign = 0
 Obj.angle = 0
 
+local cam_PushModelMatrix
+local cam_PopModelMatrix
+local mat
+local matAng
+
 if CLIENT then
 	-- Thanks to Wizard for this rotateable text code
 	cam_PushModelMatrix = cam.PushModelMatrix
 	cam_PopModelMatrix = cam.PopModelMatrix
 	mat = Matrix()
-	mat:Scale(Vector(1, 1, 1))
 	matAng = Angle(0, 0, 0)
-	matTrans = Vector(0, 0, 0)
 end
 
 Obj.Draw = function( self, ent )

--- a/lua/entities/gmod_wire_egp/lib/objects/textlayout.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/textlayout.lua
@@ -19,7 +19,7 @@ if CLIENT then
 	matTrans = Vector(0, 0, 0)
 end
 
-Obj.Draw = function( self )
+Obj.Draw = function( self, ent )
 	if (self.text and #self.text>0) then
 		surface.SetTextColor( self.r, self.g, self.b, self.a )
 
@@ -50,12 +50,26 @@ Obj.Draw = function( self )
 		if self.angle == 0 then
 			self.layouter:DrawText(self.text, self.x, self.y, self.w, self.h, self.halign, self.valign)
 		else
+			mat:Identity()
+
+			-- cam.PushModelMatrix replaces the model matrix pushed onto the stack by cam.Start3D2D
+			-- We have to recreate the cam.Start3D2D model matrix
+			if ent:GetClass() == "gmod_wire_egp_emitter" then
+				-- This corresponds to the pos and ang offsets specified in the egp emitter file
+				-- We add 180 to the roll because this is how cam.Start3D2D works
+				local pos = ent:LocalToWorld(Vector(-64, 0, 135))
+				local ang = ent:LocalToWorldAngles(Angle(0, 0, 90 + 180))
+
+				mat:SetTranslation(pos)
+				mat:SetAngles(ang)
+				mat:SetScale(Vector(0.25, 0.25, 0.25))
+			end
+
 			matAng.y = -self.angle
-			mat:SetAngles(matAng)
-			matTrans.x = x
-			matTrans.y = y
-			matTrans:Rotate(matAng)
-			mat:SetTranslation(Vector(self.x,self.y,0)-matTrans)
+
+			mat:Translate(Vector(self.x, self.y, 0))
+			mat:Rotate(matAng)
+
 			cam_PushModelMatrix(mat)
 				self.layouter:DrawText(self.text, 0, 0, self.w, self.h, self.halign, self.valign)
 			cam_PopModelMatrix()


### PR DESCRIPTION
The egp emitter uses `cam.Start3D2D`, this seems to push a model matrix onto the stack, as such when we push one to rotate text it overwrites it. To fix this we recreate the model matrix pushed by `cam.Start3D2D`. If in the future something like https://github.com/Facepunch/garrysmod-requests/issues/912 was implemented this could be gotten rid of.

I can't think of a clean way to implement this so it doesn't look hacky. Also, it'd be nice if we gave egp objects inheritance at some point so to get rid of this boilerplate code.