### PR TITLE
 Fix infinite recursion when extending Wiremod ents

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -3605,6 +3605,7 @@ stds.garrysmod.read_globals = {
   "WEAPON_PROFICIENCY_PERFECT",
 
   -- END_GENERATED_CODE
+  "BaseClass",
   "CLIENT",
   "DEFINE_BASECLASS",
   "GAMEMODE",

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -347,9 +347,8 @@ end)
 -- Other functions
 --------------------------------------------------------------------------------
 
-local base_gmodentity = scripted_ents.Get("base_gmodentity")
 function ENT:Initialize()
-	base_gmodentity.Initialize(self)
+	BaseClass.Initialize(self)
 	self:PhysicsInit(SOLID_VPHYSICS)
 	self:SetMoveType(MOVETYPE_VPHYSICS)
 	self:SetSolid(SOLID_VPHYSICS)

--- a/lua/entities/gmod_wire_addressbus.lua
+++ b/lua/entities/gmod_wire_addressbus.lua
@@ -41,7 +41,7 @@ function ENT:Setup(Mem1st, Mem2st, Mem3st, Mem4st, Mem1sz, Mem2sz, Mem3sz, Mem4s
 end
 
 function ENT:Think()
-	self.BaseClass.Think(self)
+	BaseClass.Think(self)
 
 	self.DataRate = self.DataBytes
 	self.DataBytes = 0

--- a/lua/entities/gmod_wire_adv_emarker.lua
+++ b/lua/entities/gmod_wire_adv_emarker.lua
@@ -107,7 +107,7 @@ end
 duplicator.RegisterEntityClass( "gmod_wire_adv_emarker", WireLib.MakeWireEnt, "Data" )
 
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 
 	if next(self.Marks) then
 		local tbl = {}
@@ -122,7 +122,7 @@ function ENT:BuildDupeInfo()
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
 	if (info.marks) then
 		self.Marks = self.Marks or {}

--- a/lua/entities/gmod_wire_adv_input.lua
+++ b/lua/entities/gmod_wire_adv_input.lua
@@ -66,7 +66,7 @@ function ENT:Switch( on, mul )
 end
 
 function ENT:Think()
-	self.BaseClass.Think(self)
+	BaseClass.Think(self)
 	local timediff = CurTime()-(self.LastThink or 0)
 	self.LastThink = (self.LastThink or 0)+timediff
 	if (self.On == true) then

--- a/lua/entities/gmod_wire_button.lua
+++ b/lua/entities/gmod_wire_button.lua
@@ -100,7 +100,7 @@ function ENT:Use(ply, caller)
 end
 
 function ENT:Think()
-	self.BaseClass.Think(self)
+	BaseClass.Think(self)
 
 	if ( self:GetOn() ) then
 		if (not self.PrevUser)

--- a/lua/entities/gmod_wire_cameracontroller.lua
+++ b/lua/entities/gmod_wire_cameracontroller.lua
@@ -302,7 +302,7 @@ end
 --------------------------------------------------
 
 function ENT:Initialize()
-	self.BaseClass.Initialize(self)
+	BaseClass.Initialize(self)
 	self.Outputs = WireLib.CreateOutputs( self, { 	"On", "HitPos [VECTOR]", "CamPos [VECTOR]", "CamDir [VECTOR]",
 													"CamAng [ANGLE]", "Trace [RANGER]" } )
 	self.Inputs = WireLib.CreateInputs( self, {	"Activated", "Direction [VECTOR]", "Angle [ANGLE]", "Position [VECTOR]",
@@ -564,7 +564,7 @@ end
 -- Think
 --------------------------------------------------
 function ENT:Think()
-	self.BaseClass.Think(self)
+	BaseClass.Think(self)
 
 	if self.NeedsSync then
 		self.NeedsSync = nil
@@ -929,7 +929,7 @@ end
 --------------------------------------------------
 
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self)
+	local info = BaseClass.BuildDupeInfo(self)
 	local veh = {}
 	for i=1,#self.Vehicles do
 		veh[i] = self.Vehicles[i]:EntIndex()
@@ -944,7 +944,7 @@ function ENT:BuildDupeInfo()
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
 	if info.cam or info.pod or info.OldDupe then -- OLD DUPE DETECTED
 		if info.cam then

--- a/lua/entities/gmod_wire_cd_disk.lua
+++ b/lua/entities/gmod_wire_cd_disk.lua
@@ -21,7 +21,7 @@ function ENT:Initialize()
 end
 
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 
 	info.Precision = self.Precision
 	info.IRadius = self.IRadius
@@ -43,7 +43,7 @@ end
 
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
 	self.Precision = info.Precision
 	self.IRadius = info.IRadius

--- a/lua/entities/gmod_wire_cd_lock.lua
+++ b/lua/entities/gmod_wire_cd_lock.lua
@@ -45,7 +45,7 @@ function ENT:TriggerInput(iname, value)
 end
 
 function ENT:Think()
-	self.BaseClass.Think(self)
+	BaseClass.Think(self)
 
 	// If we were undiskged, reset the disk and socket to accept new ones.
 	if (self.Const) and (not self.Const:IsValid()) then

--- a/lua/entities/gmod_wire_clutch.lua
+++ b/lua/entities/gmod_wire_clutch.lua
@@ -239,7 +239,7 @@ end
    Linked entities are stored and recalled by their EntIndexes
 ---------------------------------------------------------]]
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 	info.constrained_pairs = {}
 
 	for k, v in pairs( self:GetConstrainedPairs() ) do
@@ -252,7 +252,7 @@ function ENT:BuildDupeInfo()
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
 	local Ent1, Ent2
 	for _, v in pairs( info.constrained_pairs ) do

--- a/lua/entities/gmod_wire_colorer.lua
+++ b/lua/entities/gmod_wire_colorer.lua
@@ -155,7 +155,7 @@ function ENT:ShowOutput()
 end
 
 function ENT:Think()
-	self.BaseClass.Think(self)
+	BaseClass.Think(self)
 	if self.outColor then
 		local vStart = self:GetPos()
 		local vForward = self:GetUp()

--- a/lua/entities/gmod_wire_cpu.lua
+++ b/lua/entities/gmod_wire_cpu.lua
@@ -224,7 +224,7 @@ function ENT:SetCPUName(name)
 end
 
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 
 	info.SerialNo = self.VM.SerialNo
 	info.InternalRAMSize = self.VM.RAMSize
@@ -240,7 +240,7 @@ function ENT:BuildDupeInfo()
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
 	self.VM.SerialNo = info.SerialNo or CPULib.GenerateSN("UNK")
 	self.VM.RAMSize  = info.InternalRAMSize or 65536

--- a/lua/entities/gmod_wire_damage_detector.lua
+++ b/lua/entities/gmod_wire_damage_detector.lua
@@ -290,7 +290,7 @@ end
 duplicator.RegisterEntityClass("gmod_wire_damage_detector", WireLib.MakeWireEnt, "Data", "includeconstrained")
 
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 
 	if #self.linked_entities > 0 then
 		info.linked_entities = {}
@@ -308,7 +308,7 @@ function ENT:BuildDupeInfo()
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
 	if info.linked_entities then
 		if type( info.linked_entities ) == "number" then -- old dupe compatibility

--- a/lua/entities/gmod_wire_data_satellitedish.lua
+++ b/lua/entities/gmod_wire_data_satellitedish.lua
@@ -35,7 +35,7 @@ end
 duplicator.RegisterEntityClass("gmod_wire_data_satellitedish", WireLib.MakeWireEnt, "Data")
 
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 	if IsValid( self.Transmitter ) then
 	    info.Transmitter = self.Transmitter:EntIndex()
 	end
@@ -43,7 +43,7 @@ function ENT:BuildDupeInfo()
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
 	self.Transmitter = GetEntByID(info.Transmitter)
 	self:ShowOutput()

--- a/lua/entities/gmod_wire_dataport.lua
+++ b/lua/entities/gmod_wire_dataport.lua
@@ -24,7 +24,7 @@ function ENT:Initialize()
 end
 
 function ENT:Think()
-	self.BaseClass.Think(self)
+	BaseClass.Think(self)
 
 	for i = 0,7 do
 		if self.OutPorts[i] then

--- a/lua/entities/gmod_wire_datarate.lua
+++ b/lua/entities/gmod_wire_datarate.lua
@@ -26,7 +26,7 @@ function ENT:Initialize()
 end
 
 function ENT:Think()
-	self.BaseClass.Think(self)
+	BaseClass.Think(self)
 
 	self.WDataRate = (self.WDataRate*(2-self.Smooth) + self.WDataBytes * (1/self.Interval) * (self.Smooth)) / 2
 	self.WDataBytes = 0

--- a/lua/entities/gmod_wire_datasocket.lua
+++ b/lua/entities/gmod_wire_datasocket.lua
@@ -100,9 +100,8 @@ function ENT:TriggerInput(iname, value, iter)
 end
 
 -- Override dupeinfo functions from wire plug
-local base = scripted_ents.Get("gmod_wire_socket")
 function ENT:BuildDupeInfo()
-	local info = base.BuildDupeInfo(self)
+	local info = BaseClass.BuildDupeInfo(self)
 
 	if info.Socket then info.Socket.ArrayInput = nil end -- this input is not used on this entity
 

--- a/lua/entities/gmod_wire_detonator.lua
+++ b/lua/entities/gmod_wire_detonator.lua
@@ -55,7 +55,7 @@ end
 
 -- Dupe info functions added by TheApathetic
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 
 	if self.target and self.target:IsValid() then
 		info.target = self.target:EntIndex()
@@ -65,7 +65,7 @@ function ENT:BuildDupeInfo()
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
 	self.target = GetEntByID(info.target)
 end

--- a/lua/entities/gmod_wire_dhdd.lua
+++ b/lua/entities/gmod_wire_dhdd.lua
@@ -70,7 +70,7 @@ function ENT:TriggerInput( name, value )
 end
 
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo( self ) or {}
+	local info = BaseClass.BuildDupeInfo( self ) or {}
 
 	info.DHDD = {}
 	info.ROM = self.ROM
@@ -97,7 +97,7 @@ function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
 	end
 	self.ROM = info.ROM or false
 
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 end
 
 duplicator.RegisterEntityClass( "gmod_wire_dhdd", WireLib.MakeWireEnt, "Data" )

--- a/lua/entities/gmod_wire_dynamic_button.lua
+++ b/lua/entities/gmod_wire_dynamic_button.lua
@@ -77,7 +77,7 @@ function ENT:Use(ply, caller)
 end
 
 function ENT:Think()
-	self.BaseClass.Think(self)
+	BaseClass.Think(self)
 
 	if self:GetOn() then
 		if (not self.PrevUser)

--- a/lua/entities/gmod_wire_egp_hud/init.lua
+++ b/lua/entities/gmod_wire_egp_hud/init.lua
@@ -82,7 +82,7 @@ function ENT:OnRemove()
 end
 
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 
 	local vehicles = self.LinkedVehicles
 	if vehicles then
@@ -97,7 +97,7 @@ function ENT:BuildDupeInfo()
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
 	local vehicles = info.egp_hud_vehicles
 	if vehicles then

--- a/lua/entities/gmod_wire_emarker.lua
+++ b/lua/entities/gmod_wire_emarker.lua
@@ -33,7 +33,7 @@ end
 duplicator.RegisterEntityClass( "gmod_wire_emarker", WireLib.MakeWireEnt, "Data" )
 
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 	if ( self.mark ) and ( self.mark:IsValid() ) then
 	    info.mark = self.mark:EntIndex()
 	end
@@ -41,7 +41,7 @@ function ENT:BuildDupeInfo()
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
 	self:LinkEMarker(GetEntByID(info.mark))
 end

--- a/lua/entities/gmod_wire_exit_point.lua
+++ b/lua/entities/gmod_wire_exit_point.lua
@@ -5,7 +5,7 @@ ENT.PrintName		= "Wire Vehicle Exit Point"
 if CLIENT then return end -- No more client
 
 function ENT:Initialize()
-	self.BaseClass.Initialize(self)
+	BaseClass.Initialize(self)
 
 	self.Inputs = WireLib.CreateInputs(self, {"Entity [ENTITY]", "Entities [ARRAY]", "Position [VECTOR]", "Local Position [VECTOR]", "Angle [ANGLE]", "Local Angle [ANGLE]"})
 
@@ -134,7 +134,7 @@ function ENT:ClearEntities()
 end
 
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 
 	if next(self.Entities) then
 		info.marks = {}
@@ -147,7 +147,7 @@ function ENT:BuildDupeInfo()
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
 	if info.marks then
 		for _, entindex in pairs(info.marks) do

--- a/lua/entities/gmod_wire_explosive.lua
+++ b/lua/entities/gmod_wire_explosive.lua
@@ -170,7 +170,7 @@ function ENT:Trigger()
 end
 
 function ENT:Think()
-	self.BaseClass.Think(self)
+	BaseClass.Think(self)
 
 	if (self.exploding) then
 		if (self.ExplodeTime < CurTime()) then

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -174,7 +174,7 @@ function ENT:Execute()
 end
 
 function ENT:Think()
-	self.BaseClass.Think(self)
+	BaseClass.Think(self)
 	self:NextThink(CurTime()+0.030303)
 
 	if self.context and not self.error then
@@ -510,7 +510,7 @@ function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID, GetConstByID)
 		self.duped = false
 	end
 
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID, GetConstByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID, GetConstByID)
 end
 
 -- -------------------------------- Transfer ----------------------------------

--- a/lua/entities/gmod_wire_extbus.lua
+++ b/lua/entities/gmod_wire_extbus.lua
@@ -31,7 +31,7 @@ function ENT:Initialize()
 end
 
 function ENT:Think()
-  self.BaseClass.Think(self)
+  BaseClass.Think(self)
 
   self.DataRate = self.DataBytes
   self.DataBytes = 0

--- a/lua/entities/gmod_wire_eyepod.lua
+++ b/lua/entities/gmod_wire_eyepod.lua
@@ -343,7 +343,7 @@ end)
 
 -- Advanced Duplicator Support
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 	if IsValid(self.pod) then
 		info.pod = self.pod:EntIndex()
 	end
@@ -351,7 +351,7 @@ function ENT:BuildDupeInfo()
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
 	self:PodLink(GetEntByID(info.pod))
 end

--- a/lua/entities/gmod_wire_forcer.lua
+++ b/lua/entities/gmod_wire_forcer.lua
@@ -105,7 +105,7 @@ function ENT:ShowOutput()
 end
 
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 	info.ForceMul = self.ForceMul
 	info.Reaction = self.Reaction
 	return info
@@ -115,7 +115,7 @@ end
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
 	self:Setup( info.ForceMul, info.Length, info.ShowBeam, info.Reaction )
 
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 end
 
 --Moves old "A" input to new "Force" input for older saves

--- a/lua/entities/gmod_wire_freezer.lua
+++ b/lua/entities/gmod_wire_freezer.lua
@@ -117,7 +117,7 @@ end
 duplicator.RegisterEntityClass( "gmod_wire_freezer", WireLib.MakeWireEnt, "Data" )
 
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 
 	if next(self.Marks) then
 		local tbl = {}
@@ -132,7 +132,7 @@ function ENT:BuildDupeInfo()
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
 	if info.Ent1 then
 		-- Old wire-extras dupe support

--- a/lua/entities/gmod_wire_friendslist.lua
+++ b/lua/entities/gmod_wire_friendslist.lua
@@ -6,7 +6,7 @@ ENT.WireDebugName	= "Friends List"
 if CLIENT then return end -- No more client
 
 function ENT:Initialize()
-	self.BaseClass.Initialize( self )
+	BaseClass.Initialize( self )
 
 	WireLib.CreateInputs( self, {"CheckEntity [ENTITY]", "CheckSteamID [STRING]", "CheckEntityID"} )
 	WireLib.CreateOutputs( self, {"Checked", "Friends [ARRAY]", "AmountConnected", "AmountTotal"} )

--- a/lua/entities/gmod_wire_fx_emitter.lua
+++ b/lua/entities/gmod_wire_fx_emitter.lua
@@ -48,7 +48,7 @@ if CLIENT then
 			if ( weapon_name == "gmod_camera" ) then return end
 		end
 
-		self.BaseClass.Draw( self )
+		BaseClass.Draw( self )
 	end
 
 	function ENT:Think()
@@ -125,7 +125,7 @@ function ENT:TriggerInput( inputname, value, iter )
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 	-- Old dupes stored this info here rather than as RegisterEntityClass vars
 	if info.Effect then self:SetEffect(info.Effect) end
 	if info.Delay then self:SetDelay(info.Delay) end

--- a/lua/entities/gmod_wire_gate.lua
+++ b/lua/entities/gmod_wire_gate.lua
@@ -95,7 +95,7 @@ function ENT:TriggerInput(iname, value, iter)
 end
 
 function ENT:Think()
-	self.BaseClass.Think(self)
+	BaseClass.Think(self)
 
 	if (self.Action) and (self.Action.timed) then
 		self:CalcOutput()
@@ -142,7 +142,7 @@ end
 function ENT:OnRestore()
 	self.Action = GateActions[self.action]
 
-	self.BaseClass.OnRestore(self)
+	BaseClass.OnRestore(self)
 end
 
 

--- a/lua/entities/gmod_wire_gps.lua
+++ b/lua/entities/gmod_wire_gps.lua
@@ -5,7 +5,7 @@ ENT.WireDebugName	= "GPS"
 
 if CLIENT then
 	function ENT:Think()
-		self.BaseClass.Think(self)
+		BaseClass.Think(self)
 
 		local pos = self:GetPos()
 		if (COLOSSAL_SANDBOX) then pos = pos * 6.25 end
@@ -51,7 +51,7 @@ function ENT:Setup()
 end
 
 function ENT:Think()
-	self.BaseClass.Think(self)
+	BaseClass.Think(self)
 
 	local pos = self:GetPos()
 	if (COLOSSAL_SANDBOX) then pos = pos * 6.25 end

--- a/lua/entities/gmod_wire_gpu/init.lua
+++ b/lua/entities/gmod_wire_gpu/init.lua
@@ -165,7 +165,7 @@ end
 -- Write advanced dupe
 --------------------------------------------------------------------------------
 function ENT:BuildDupeInfo()
-  local info = self.BaseClass.BuildDupeInfo(self) or {}
+  local info = BaseClass.BuildDupeInfo(self) or {}
 
   info.SerialNo = self.SerialNo
   info.RAMSize = self.RAMSize
@@ -184,7 +184,7 @@ end
 -- Read from advanced dupe
 --------------------------------------------------------------------------------
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-  self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+  BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
   self.SerialNo = info.SerialNo or 999999
   self.RAMSize  = info.RAMSize or 65536

--- a/lua/entities/gmod_wire_grabber.lua
+++ b/lua/entities/gmod_wire_grabber.lua
@@ -143,7 +143,7 @@ end
 
 --duplicator support (TAD2020)
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 
 	if self.WeldEntity and self.WeldEntity:IsValid() then
 		info.WeldEntity = self.WeldEntity:EntIndex()
@@ -157,7 +157,7 @@ function ENT:BuildDupeInfo()
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
 	self.WeldEntity = GetEntByID(info.WeldEntity)
 

--- a/lua/entities/gmod_wire_graphics_tablet.lua
+++ b/lua/entities/gmod_wire_graphics_tablet.lua
@@ -100,7 +100,7 @@ function ENT:Initialize()
 end
 
 function ENT:Think()
-	self.BaseClass.Think(self)
+	BaseClass.Think(self)
 	local onScreen = 0
 	local clickActive = 0
 
@@ -169,7 +169,7 @@ function ENT:ShowOutput(cx, cy, activeval, osval)
 end
 
 function ENT:OnRestore()
-	self.BaseClass.OnRestore(self)
+	BaseClass.OnRestore(self)
 	Wire_AdjustOutputs(self, { "X", "Y", "Use", "OnScreen" })
 end
 

--- a/lua/entities/gmod_wire_gyroscope.lua
+++ b/lua/entities/gmod_wire_gyroscope.lua
@@ -10,7 +10,7 @@ end
 if CLIENT then
 	--handle overlay text client side instead (TAD2020)
 	function ENT:Think()
-		self.BaseClass.Think(self)
+		BaseClass.Think(self)
 
 		if self:GetModel() == "models/bull/various/gyroscope.mdl" then
 
@@ -58,7 +58,7 @@ function ENT:Setup( out180 )
 end
 
 function ENT:Think()
-	self.BaseClass.Think(self)
+	BaseClass.Think(self)
 
     local ang = self:GetAngles()
 	if (ang.p < 0 && !self:GetOut180()) then ang.p = ang.p + 360 end

--- a/lua/entities/gmod_wire_holoemitter.lua
+++ b/lua/entities/gmod_wire_holoemitter.lua
@@ -100,7 +100,7 @@ if CLIENT then
 	end
 
 	function ENT:Draw()
-		self.BaseClass.Draw(self)
+		BaseClass.Draw(self)
 
 		local ent = self:GetNWEntity( "Link", false )
 		if not IsValid(ent) then ent = self end
@@ -398,7 +398,7 @@ function ENT:UpdateTransmitState()
 end
 
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 
 	local link = self:GetNWEntity("Link",false)
 	if (link) then
@@ -409,7 +409,7 @@ function ENT:BuildDupeInfo()
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
 	self:Link(GetEntByID(info.holoemitter_link))
 end

--- a/lua/entities/gmod_wire_hologrid.lua
+++ b/lua/entities/gmod_wire_hologrid.lua
@@ -53,7 +53,7 @@ duplicator.RegisterEntityClass("gmod_wire_hologrid", WireLib.MakeWireEnt, "Data"
 
 
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 
 	info.hologrid_usegps = self.usesgps and 1 or 0
 
@@ -67,7 +67,7 @@ function ENT:BuildDupeInfo()
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
 	self.reference = GetEntByID(info.reference, self)
 	self:Setup(info.hologrid_usegps ~= 0)

--- a/lua/entities/gmod_wire_hoverball.lua
+++ b/lua/entities/gmod_wire_hoverball.lua
@@ -150,7 +150,7 @@ function ENT:Disable()
 end
 
 function ENT:Think()
-	self.BaseClass.Think( self )
+	BaseClass.Think( self )
 
 	local on = self:IsOn() and "\nActivated" or "\nDeactivated"
 
@@ -216,13 +216,13 @@ function ENT:PhysicsSimulate( phys, deltatime )
 end
 
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 	info.OnState = self:IsOn() and 1 or 0 -- convert to 1/0 for simple old dupe compatibility
 	return info
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
 	if info and info.OnState and info.OnState == 1 then
 		self:Enable()
@@ -232,7 +232,7 @@ end
 function ENT:OnRestore()
 	self.ZVelocity = 0
 
-	self.BaseClass.OnRestore(self)
+	BaseClass.OnRestore(self)
 end
 
 duplicator.RegisterEntityClass("gmod_wire_hoverball", WireLib.MakeWireEnt, "Data", "speed", "resistance", "strength", "starton")

--- a/lua/entities/gmod_wire_hudindicator/init.lua
+++ b/lua/entities/gmod_wire_hudindicator/init.lua
@@ -318,7 +318,7 @@ function ENT:UnLinkVehicle()
 end
 
 function ENT:Think()
-	self.BaseClass.Think(self)
+	BaseClass.Think(self)
 
 	if IsValid(self.Pod) then
 		local ply = nil
@@ -364,7 +364,7 @@ end
 
 -- Advanced Duplicator Support
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 
 	if (self.Pod) and (self.Pod:IsValid()) then
 	    info.pod = self.Pod:EntIndex()
@@ -374,7 +374,7 @@ function ENT:BuildDupeInfo()
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
 	self.Pod = GetEntByID(info.pod)
 end

--- a/lua/entities/gmod_wire_hydraulic.lua
+++ b/lua/entities/gmod_wire_hydraulic.lua
@@ -6,7 +6,7 @@ ENT.WireDebugName 	= "Hydraulic"
 if CLIENT then return end -- No more client
 
 function ENT:Initialize()
-	self.BaseClass.Initialize(self)
+	BaseClass.Initialize(self)
 	self.Inputs = WireLib.CreateInputs( self, { "Length", "In", "Out", "Constant", "Damping" } )
 	self.Outputs = WireLib.CreateOutputs( self, { "Length", "Target Length", "Constant", "Damping" } )
 	self.TargetLength = 0
@@ -36,7 +36,7 @@ function ENT:GetDistance()
 end
 
 function ENT:Think()
-	self.BaseClass.Think( self )
+	BaseClass.Think( self )
 	if not IsValid(self.constraint) then return end
 
 	local deltaTime = CurTime() - self.last_time

--- a/lua/entities/gmod_wire_keyboard/init.lua
+++ b/lua/entities/gmod_wire_keyboard/init.lua
@@ -230,7 +230,7 @@ end
 function ENT:OnRemove()
 	self:UnlinkEnt()
 	self:PlayerDetach()
-	self.BaseClass.OnRemove(self)
+	BaseClass.OnRemove(self)
 end
 
 function ENT:LinkEnt(pod)
@@ -427,7 +427,7 @@ end
 duplicator.RegisterEntityClass("gmod_wire_keyboard", WireLib.MakeWireEnt, "Data", "AutoBuffer", "Synchronous", "EnterKeyAscii")
 
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 	if IsValid(self.Pod) then
 		info.pod = self.Pod:EntIndex()
 	end
@@ -435,7 +435,7 @@ function ENT:BuildDupeInfo()
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
 	self:LinkEnt(GetEntByID(info.pod), true)
 	if info.autobuffer then self.AutoBuffer = info.autobuffer end

--- a/lua/entities/gmod_wire_keypad.lua
+++ b/lua/entities/gmod_wire_keypad.lua
@@ -162,7 +162,7 @@ util.PrecacheSound("buttons/button14.wav")
 util.PrecacheSound("buttons/button15.wav")
 
 function ENT:Initialize()
-	self.BaseClass.Initialize(self)
+	BaseClass.Initialize(self)
 
 	self.Outputs = WireLib.CreateOutputs(self, {"Valid", "Invalid"})
 

--- a/lua/entities/gmod_wire_lamp.lua
+++ b/lua/entities/gmod_wire_lamp.lua
@@ -18,7 +18,7 @@ if CLIENT then
 
 	function ENT:DrawTranslucent()
 
-		self.BaseClass.DrawTranslucent( self )
+		BaseClass.DrawTranslucent( self )
 
 		-- No glow if we're not switched on!
 		if not self:GetOn() then return end

--- a/lua/entities/gmod_wire_latch.lua
+++ b/lua/entities/gmod_wire_latch.lua
@@ -152,7 +152,7 @@ end
 
 -- duplicator support
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 	if IsValid( self.Ent1 ) then
 		info.Ent1 = self.Ent1:EntIndex()
 		info.Bone1 = self.Bone1
@@ -170,7 +170,7 @@ function ENT:BuildDupeInfo()
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
 	self.Ent1 = GetEntByID(info.Ent1, game.GetWorld())
 	if IsValid(self.Ent1) then

--- a/lua/entities/gmod_wire_lever.lua
+++ b/lua/entities/gmod_wire_lever.lua
@@ -44,7 +44,7 @@ function ENT:Use( ply )
 end
 
 function ENT:Think()
-	self.BaseClass.Think(self)
+	BaseClass.Think(self)
 	if not IsValid(self.BaseEnt) then return end
 
 	if IsValid(self.User) then
@@ -92,7 +92,7 @@ function ENT:OnRemove( )
 end
 
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 	if IsValid(self.BaseEnt) then
 		info.baseent = self.BaseEnt:EntIndex()
 		constraint.Weld(self, self.BaseEnt, 0, 0, 0, true) -- Just in case the weld has been broken somehow, remake to ensure inclusion in dupe
@@ -102,7 +102,7 @@ function ENT:BuildDupeInfo()
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 	if info.baseent then
 		self.BaseEnt = GetEntByID(info.baseent)
 	end

--- a/lua/entities/gmod_wire_motor.lua
+++ b/lua/entities/gmod_wire_motor.lua
@@ -9,7 +9,7 @@ if CLIENT then
 end
 
 function ENT:Initialize()
-	self.BaseClass.Initialize(self)
+	BaseClass.Initialize(self)
 	self.Inputs = Wire_CreateInputs( self, { "Mul" } )
 end
 

--- a/lua/entities/gmod_wire_oscilloscope.lua
+++ b/lua/entities/gmod_wire_oscilloscope.lua
@@ -119,7 +119,7 @@ end
 
 function ENT:Think()
 	if (self.Inputs.Pause.Value == 0) then
-		self.BaseClass.Think(self)
+		BaseClass.Think(self)
 
 		local x = math.max(-1, math.min(self.Inputs.X.Value or 0, 1))
 		local y = math.max(-1, math.min(self.Inputs.Y.Value or 0, 1))

--- a/lua/entities/gmod_wire_plug.lua
+++ b/lua/entities/gmod_wire_plug.lua
@@ -5,7 +5,6 @@ ENT.Author          = "Divran"
 ENT.Purpose         = "Links with a socket"
 ENT.Instructions    = "Move a plug close to a socket to link them, and data will be transferred through the link."
 ENT.WireDebugName = "Plug"
-local base = scripted_ents.Get("base_wire_entity")
 
 function ENT:GetSocketClass()
 	return "gmod_wire_socket"
@@ -34,7 +33,7 @@ end
 if CLIENT then
 	function ENT:DrawEntityOutline()
 		if (GetConVar("wire_plug_drawoutline"):GetBool()) then
-			base.DrawEntityOutline( self )
+			BaseClass.DrawEntityOutline( self )
 		end
 	end
 	return -- No more client
@@ -139,7 +138,7 @@ function ENT:ReadCell( Address )
 end
 
 function ENT:Think()
-	base.Think( self )
+	BaseClass.Think( self )
 	self:SetNWBool( "PlayerHolding", self:IsPlayerHolding() )
 end
 
@@ -190,5 +189,5 @@ function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
 		ent:Setup( info.Plug.ArrayInput )
 	end
 
-	base.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 end

--- a/lua/entities/gmod_wire_pod.lua
+++ b/lua/entities/gmod_wire_pod.lua
@@ -514,7 +514,7 @@ end
 
 --Duplicator support to save pod link (TAD2020)
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 	if self:HasPod() and not self.RC then
 		info.pod = self.Pod:EntIndex()
 	end
@@ -522,7 +522,7 @@ function ENT:BuildDupeInfo()
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
 	local pod = GetEntByID(info.pod)
 	if IsValid(pod) then

--- a/lua/entities/gmod_wire_radio.lua
+++ b/lua/entities/gmod_wire_radio.lua
@@ -125,7 +125,7 @@ function ENT:ShowOutput()
 end
 
 function ENT:OnRestore()
-	self.BaseClass.OnRestore(self)
+	BaseClass.OnRestore(self)
 	Radio_Register(self)
 end
 

--- a/lua/entities/gmod_wire_ranger.lua
+++ b/lua/entities/gmod_wire_ranger.lua
@@ -115,7 +115,7 @@ function ENT:TriggerInput(iname, value)
 end
 
 function ENT:Think()
-	self.BaseClass.Think(self)
+	BaseClass.Think(self)
 
 	local tracedata = {}
 	tracedata.start = self:GetPos()

--- a/lua/entities/gmod_wire_sensor.lua
+++ b/lua/entities/gmod_wire_sensor.lua
@@ -68,7 +68,7 @@ function ENT:Setup(xyz_mode, outdist, outbrng, gpscord, direction_vector, direct
 end
 
 function ENT:Think()
-	self.BaseClass.Think(self)
+	BaseClass.Think(self)
 
 	if not IsValid(self.ToSense) or not self.ToSense.GetBeaconPos then return end
 	if (self.Active) then
@@ -197,7 +197,7 @@ end
 duplicator.RegisterEntityClass("gmod_wire_sensor", WireLib.MakeWireEnt, "Data", "xyz_mode", "outdist", "outbrng", "gpscord", "direction_vector", "direction_normalized", "target_velocity", "velocity_normalized")
 
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 
 	if IsValid(self.ToSense) then
 	    info.to_sense = self.ToSense:EntIndex()
@@ -207,7 +207,7 @@ function ENT:BuildDupeInfo()
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
 	self:LinkEnt(GetEntByID(info.to_sense))
 end

--- a/lua/entities/gmod_wire_socket.lua
+++ b/lua/entities/gmod_wire_socket.lua
@@ -4,7 +4,6 @@ ENT.PrintName       = "Wire Socket"
 ENT.Purpose         = "Links with a plug"
 ENT.Instructions    = "Move a plug close to a plug to link them, and data will be transferred through the link."
 ENT.WireDebugName	= "Socket"
-local base = scripted_ents.Get("base_wire_entity")
 
 local PositionOffsets = {
 	["models/wingf0x/isasocket.mdl"] = Vector(0,0,0),
@@ -75,7 +74,7 @@ end
 if CLIENT then
 	function ENT:DrawEntityOutline()
 		if (GetConVar("wire_plug_drawoutline"):GetBool()) then
-			base.DrawEntityOutline( self )
+			BaseClass.DrawEntityOutline( self )
 		end
 	end
 
@@ -231,7 +230,7 @@ end
 -- Find nearby plugs and connect to them
 ------------------------------------------------------------
 function ENT:Think()
-	base.Think(self)
+	BaseClass.Think(self)
 
 	if not (self.Plug and self.Plug:IsValid()) then -- Has not been linked or plug was deleted
 		local Pos, Ang = self:GetLinkPos()
@@ -304,7 +303,7 @@ duplicator.RegisterEntityClass( "gmod_wire_socket", WireLib.MakeWireEnt, "Data",
 -- Adv Duplicator Support
 ------------------------------------------------------------
 function ENT:BuildDupeInfo()
-	local info = base.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 
 	info.Socket = {}
 	info.Socket.ArrayInput = self.ArrayInput
@@ -347,7 +346,7 @@ function ENT:GetApplyDupeInfoParams(info)
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID, GetConstByID)
-	base.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
 	if (info.Socket) then
 		ent:Setup( self:GetApplyDupeInfoParams(info) )

--- a/lua/entities/gmod_wire_soundemitter.lua
+++ b/lua/entities/gmod_wire_soundemitter.lua
@@ -45,7 +45,7 @@ end
 function ENT:OnRemove()
 	hook.Remove("PlayerConnect", self:GetClass() .. self:EntIndex())
 	self:StopSounds()
-	self.BaseClass.OnRemove(self)
+	BaseClass.OnRemove(self)
 end
 
 --[[

--- a/lua/entities/gmod_wire_speedometer.lua
+++ b/lua/entities/gmod_wire_speedometer.lua
@@ -18,7 +18,7 @@ end
 
 if CLIENT then
 	function ENT:Think()
-		self.BaseClass.Think(self)
+		BaseClass.Think(self)
 
 		local txt
 		if (self:GetXYZMode()) then
@@ -74,7 +74,7 @@ function ENT:Setup( xyz_mode, AngVel )
 end
 
 function ENT:Think()
-	self.BaseClass.Think(self)
+	BaseClass.Think(self)
 
 	if (self.XYZMode) then
 		local vel = self:WorldToLocal(self:GetVelocity()+self:GetPos())

--- a/lua/entities/gmod_wire_spu/init.lua
+++ b/lua/entities/gmod_wire_spu/init.lua
@@ -165,7 +165,7 @@ end
 -- Write advanced dupe
 --------------------------------------------------------------------------------
 function ENT:BuildDupeInfo()
-  local info = self.BaseClass.BuildDupeInfo(self) or {}
+  local info = BaseClass.BuildDupeInfo(self) or {}
 
   info.SerialNo = self.SerialNo
   info.RAMSize = self.RAMSize
@@ -184,7 +184,7 @@ end
 -- Read from advanced dupe
 --------------------------------------------------------------------------------
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-  self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+  BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
   self.SerialNo = info.SerialNo or 999999
   self.RAMSize  = info.RAMSize or 65536

--- a/lua/entities/gmod_wire_target_finder.lua
+++ b/lua/entities/gmod_wire_target_finder.lua
@@ -229,7 +229,7 @@ function ENT:CheckTheBuddyList(friend)
 end
 
 function ENT:Think()
-	self.BaseClass.Think(self)
+	BaseClass.Think(self)
 
 	if not (self.Inputs.Hold and self.Inputs.Hold.Value > 0) then
 		-- Find targets that meet requirements
@@ -345,7 +345,7 @@ end
 
 
 function ENT:OnRemove()
-	self.BaseClass.OnRemove(self)
+	BaseClass.OnRemove(self)
 
 	--unpaint all our targets
 	if (self.PaintTarget) then
@@ -356,7 +356,7 @@ function ENT:OnRemove()
 end
 
 function ENT:OnRestore()
-	self.BaseClass.OnRestore(self)
+	BaseClass.OnRestore(self)
 
 	self.MaxTargets = self.MaxTargets or 1
 end

--- a/lua/entities/gmod_wire_thruster.lua
+++ b/lua/entities/gmod_wire_thruster.lua
@@ -48,7 +48,7 @@ if CLIENT then
 	end
 
 	function ENT:Think()
-		self.BaseClass.Think(self)
+		BaseClass.Think(self)
 
 		self.ShouldDraw = GetConVarNumber("cl_drawthrusterseffects")
 
@@ -102,7 +102,7 @@ function ENT:Initialize()
 end
 
 function ENT:OnRemove()
-	self.BaseClass.OnRemove(self)
+	BaseClass.OnRemove(self)
 
 	if (self.soundname and self.soundname != "") then
 		self:StopSound(self.soundname)
@@ -304,7 +304,7 @@ function ENT:OnRestore()
 	self:SetOffset( self.ThrustOffset )
 	self:StartMotionController()
 
-	self.BaseClass.OnRestore(self)
+	BaseClass.OnRestore(self)
 end
 
 duplicator.RegisterEntityClass("gmod_wire_thruster", WireLib.MakeWireEnt, "Data", "force", "force_min", "force_max", "oweffect", "uweffect", "owater", "uwater", "bidir", "soundname")

--- a/lua/entities/gmod_wire_turret.lua
+++ b/lua/entities/gmod_wire_turret.lua
@@ -69,7 +69,7 @@ function ENT:OnTakeDamage( dmginfo )
 end
 
 function ENT:Think()
-	self.BaseClass.Think(self)
+	BaseClass.Think(self)
 
 	if( self.Firing ) then
 		self:FireShot()

--- a/lua/entities/gmod_wire_twoway_radio.lua
+++ b/lua/entities/gmod_wire_twoway_radio.lua
@@ -38,7 +38,7 @@ function ENT:TriggerInput(iname, value)
 end
 
 function ENT:Think()
-	self.BaseClass.Think(self)
+	BaseClass.Think(self)
 
 	if (not self.Other) or (not self.Other:IsValid()) then
 		self.Other = nil
@@ -138,7 +138,7 @@ function ENT:ShowOutput(iname, value)
 end
 
 function ENT:OnRestore()
-	self.BaseClass.OnRestore(self)
+	BaseClass.OnRestore(self)
 
 	Wire_AdjustInputs(self, { "A", "B", "C", "D" })
 	Wire_AdjustOutputs(self, { "A", "B", "C", "D" })
@@ -146,7 +146,7 @@ end
 
 // Dupe info functions added by TheApathetic
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 
 	if (self.Other) && (self.Other:IsValid()) then
 		info.Other = self.Other:EntIndex()
@@ -156,7 +156,7 @@ function ENT:BuildDupeInfo()
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
 	local other = GetEntByID(info.Other)
 	if IsValid(other) then

--- a/lua/entities/gmod_wire_vectorthruster.lua
+++ b/lua/entities/gmod_wire_vectorthruster.lua
@@ -63,7 +63,7 @@ if CLIENT then
 	end
 
 	function ENT:Think()
-		self.BaseClass.Think(self)
+		BaseClass.Think(self)
 
 		self.ShouldDraw = GetConVarNumber("cl_drawthrusterseffects")
 
@@ -138,7 +138,7 @@ function ENT:Initialize()
 end
 
 function ENT:OnRemove()
-	self.BaseClass.OnRemove(self)
+	BaseClass.OnRemove(self)
 
 	if (self.soundname) then
 		self:StopSound(self.soundname)
@@ -376,5 +376,5 @@ function ENT:OnRestore()
 		self:Switch(false)
 	end
 
-	self.BaseClass.OnRestore(self)
+	BaseClass.OnRestore(self)
 end

--- a/lua/entities/gmod_wire_vehicle.lua
+++ b/lua/entities/gmod_wire_vehicle.lua
@@ -54,7 +54,7 @@ function ENT:Think()
 end
 
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 
 	if (self.Vehicle) and (self.Vehicle:IsValid()) then
 	    info.Vehicle = self.Vehicle:EntIndex()
@@ -64,7 +64,7 @@ function ENT:BuildDupeInfo()
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
 	self.Vehicle = GetEntByID(info.Vehicle)
 end

--- a/lua/entities/gmod_wire_watersensor.lua
+++ b/lua/entities/gmod_wire_watersensor.lua
@@ -17,7 +17,7 @@ function ENT:ShowOutput()
 end
 
 function ENT:Think()
-	self.BaseClass.Think(self)
+	BaseClass.Think(self)
 	if(self:WaterLevel()>0)then
 		Wire_TriggerOutput(self,"Out",1)
 	else

--- a/lua/entities/gmod_wire_waypoint.lua
+++ b/lua/entities/gmod_wire_waypoint.lua
@@ -10,7 +10,7 @@ end
 if CLIENT then
 	local physBeamMat = Material("cable/physbeam")
 	function ENT:Draw()
-		self.BaseClass.Draw(self)
+		BaseClass.Draw(self)
 
 		local nextWP = self:GetNextWaypoint()
 		if IsValid(nextWP) and (LocalPlayer():GetEyeTrace().Entity == self) and (EyePos():Distance(self:GetPos()) < 4096) then

--- a/lua/entities/gmod_wire_weight.lua
+++ b/lua/entities/gmod_wire_weight.lua
@@ -31,7 +31,7 @@ function ENT:TriggerInput(iname,value)
 end
 
 function ENT:Think()
-	self.BaseClass.Think(self)
+	BaseClass.Think(self)
 end
 
 function ENT:Setup()

--- a/lua/entities/gmod_wire_wheel.lua
+++ b/lua/entities/gmod_wire_wheel.lua
@@ -183,7 +183,7 @@ function ENT:SetWheelBase(Base)
 end
 
 function ENT:BuildDupeInfo()
-	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	local info = BaseClass.BuildDupeInfo(self) or {}
 	if IsValid(self.Base) then
 		info.Base = self.Base:EntIndex()
 	end
@@ -191,7 +191,7 @@ function ENT:BuildDupeInfo()
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
-	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+	BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
 	local Base = GetEntByID(info.Base)
 	if IsValid(Base) then


### PR DESCRIPTION
In our entities, we do:

    DEFINE_BASECLASS("base_wire_entity")

...which is replaced by Garry's Mod by:

    local BaseClass = baseclass.Get("base_wire_entity")

It also indirectly ends up setting `self.BaseClass` on the entity to its
parent. Throughout our code we ignore the mysterious `local BaseClass`
and instead use `self.BaseClass`. This works okay, until somebody uses
one of *our* classes as a base: imagine, for example, somebody extended
`gmod_wire_colorer`, which contains:

    function ENT:Think()
        self.BaseClass.Think(self)
	-- ...
    end

In the extended entity, `self.BaseClass` points to `gmod_wire_colorer`,
not to `base_wire_entity`, so this will be an infinite recursion.

The solution is just to use the file-local `BaseClass` variable that's
magically created for us.

In cases where this would've affected us, the existing code uses something like:

    local base = scripted_ents.Get("base_wire_entity")
    base.Think(self)

and this pull request also removes all of those instances and just uses `BaseClass` everywhere.