### PR TITLE
Add missing DEFINE_BASECLASS to files

### DIFF
--- a/lua/entities/gmod_wire_egp_hud/init.lua
+++ b/lua/entities/gmod_wire_egp_hud/init.lua
@@ -4,6 +4,8 @@ include("shared.lua")
 AddCSLuaFile("huddraw.lua")
 include("huddraw.lua")
 
+DEFINE_BASECLASS("base_wire_entity")
+
 ENT.WireDebugName = "E2 Graphics Processor HUD"
 
 function ENT:Initialize()

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -2,6 +2,8 @@ AddCSLuaFile('cl_init.lua')
 AddCSLuaFile('shared.lua')
 include('shared.lua')
 
+DEFINE_BASECLASS("base_wire_entity")
+
 -- This makes E2s not save using garry's workshop save
 -- Until someone can find the cause of the crashes, leave this in here
 local old = gmsave.ShouldSaveEntity

--- a/lua/entities/gmod_wire_gpu/init.lua
+++ b/lua/entities/gmod_wire_gpu/init.lua
@@ -4,6 +4,8 @@ AddCSLuaFile("cl_gpuvm.lua")
 AddCSLuaFile("shared.lua")
 include("shared.lua")
 
+DEFINE_BASECLASS("base_wire_entity")
+
 ENT.WireDebugName = "ZGPU"
 
 

--- a/lua/entities/gmod_wire_hudindicator/init.lua
+++ b/lua/entities/gmod_wire_hudindicator/init.lua
@@ -4,6 +4,8 @@ AddCSLuaFile( "shared.lua" )
 
 include('shared.lua')
 
+DEFINE_BASECLASS("base_wire_entity")
+
 ENT.WireDebugName = "HUD Indicator"
 
 function ENT:Initialize()

--- a/lua/entities/gmod_wire_keyboard/init.lua
+++ b/lua/entities/gmod_wire_keyboard/init.lua
@@ -5,6 +5,8 @@ AddCSLuaFile("remap.lua")
 include('shared.lua')
 include('remap.lua')
 
+DEFINE_BASECLASS("base_wire_entity")
+
 ENT.WireDebugName = "Wired Keyboard"
 
 local All_Enums = {} -- table containing key -> key enum conversion

--- a/lua/entities/gmod_wire_spu/init.lua
+++ b/lua/entities/gmod_wire_spu/init.lua
@@ -4,6 +4,8 @@ AddCSLuaFile("cl_spuvm.lua")
 AddCSLuaFile("shared.lua")
 include("shared.lua")
 
+DEFINE_BASECLASS("base_wire_entity")
+
 ENT.WireDebugName = "ZSPU"
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Fix bugs caused by #1632 

Considering the magic behind `DEFINE_BASECLASS` it'll only define the `BaseClass` variable in the file that called it. This adds `DEFINE_BASECLASS` to each file that requires it, calling it multiple times shouldn't cause any adverse effects.

I looked through each file changed in #1632 and I believe this fixes all the missing variables errors.

Edit: @AbigailBuccaneer 