### PR TITLE
Simplify the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,2 @@
-# First of all, make sure those pesky SVN folders don't end up on git
-.svn
-
-# Next, ignore all untracked files...
-/*
-
-# ...except the following folders and files in them
-!/data
-!/lua
-!/materials
-!/models
-!/settings
-!/sound
-
-# If you need more folders at the root level, don't hesitate to add them
-# If you need a new file at the root level, just use "git add -f <filename>"
+.svn/
+luac.out


### PR DESCRIPTION
Currently there are many files which are ignored by .gitignore but also
tracked - such as every file in the root of the repository. This was
done to make it harder for developers to accidentally commit files that
shouldn't be in the repository, but it also upsets many tools and
editors. (For example, Atom won't navigate to any file ignored by
.gitignore, even if it's also in the Git index.)

Given this, and given that this isn't something I've seen any other
projects do and I've never seen it recommended anywhere, I'm replacing
the .gitignore with a much simpler one. All it ignores is a .svn
directory (as the old one did), and any file generated by luac (as `luac
filename.lua` can be used to quickly check that a file is syntactically
valid Lua).