### PR TITLE
Fix errors when spawning highspeed gates

### DIFF
--- a/lua/entities/gmod_wire_gate.lua
+++ b/lua/entities/gmod_wire_gate.lua
@@ -110,13 +110,13 @@ end
 function ENT:CalcOutput(iter)
 	if (self.Action) and (self.Action.output) then
 		if (self.Action.outputs) then
-			local result = { self.Action.output(self, unpack(self:GetActionInputs())) }
+			local result = { self.Action.output(self, unpack(self:GetActionInputs(), 1, #self.Action.inputs)) }
 
 			for k,v in ipairs(self.Action.outputs) do
 				Wire_TriggerOutput(self, v, result[k] or WireLib.DT[ self.Outputs[v].Type ].Zero, iter)
 			end
 		else
-			local value = self.Action.output(self, unpack(self:GetActionInputs())) or WireLib.DT[ self.Outputs.Out.Type ].Zero
+			local value = self.Action.output(self, unpack(self:GetActionInputs(), 1, #self.Action.inputs)) or WireLib.DT[ self.Outputs.Out.Type ].Zero
 
 			Wire_TriggerOutput(self, "Out", value, iter)
 		end
@@ -129,7 +129,7 @@ function ENT:ShowOutput()
 	if (self.Action) then
 		txt = (self.Action.name or "No Name")
 		if (self.Action.label) then
-			txt = txt.."\n"..self.Action.label(self:GetActionOutputs(), unpack(self:GetActionInputs(Wire_EnableGateInputValues:GetBool())))
+			txt = txt.."\n"..self.Action.label(self:GetActionOutputs(), unpack(self:GetActionInputs(Wire_EnableGateInputValues:GetBool()), 1, #self.Action.inputs))
 		end
 	else
 		txt = "Invalid gate!"

--- a/lua/wire/gates/highspeed.lua
+++ b/lua/wire/gates/highspeed.lua
@@ -15,7 +15,7 @@ GateActions["highspeed_write"] = {
 		return Memory:WriteCell(Address, Data) and 1 or 0
 	end,
 	label = function(Out, Clk, Memory, Address, Data)
-		return "Clock:"..Clk.." Memory:"..Memory.." Address:"..Address.." Data:"..Data.." = "..Out
+		return string.format("Clock:%s Memory:%s Address:%s Data:%s = %s", Clk, Memory, Address, Data, Out)
 	end
 }
 
@@ -34,7 +34,7 @@ GateActions["highspeed_read"] = {
 		return Memory:ReadCell(Address) or 0
 	end,
 	label = function(Out, Clk, Memory, Address)
-		return "Clock:"..Clk.." Memory:"..Memory.." Address:"..Address.." = "..Out
+		return string.format("Clock:%s Memory:%s Address:%s = %s", Clk, Memory, Address, Out)
 	end
 }
 


### PR DESCRIPTION
Currently, spawning a `highspeed_read` or `highspeed_write` gate causes an error (unless you have the convar `Wire_EnableGateInputValues` set to 1), and both can fail with a `"bad argument #1 to 'floor' (number expected, got nil)"` error if any input is changed while the Memory input is `nil` (the default wirelink value).