### PR TITLE
Fix propcore functions returning nothing when value is expected

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -62,14 +62,14 @@ end
 
 function PropCore.CreateProp(self,model,pos,angles,freeze,isVehicle)
 
-	if not PropCore.ValidSpawn() then return nil end
+	if not PropCore.ValidSpawn() then return NULL end
 
 	if isVehicle then
-		if self.player:CheckLimit( "vehicles" ) == false then return nil end
+		if self.player:CheckLimit( "vehicles" ) == false then return NULL end
 		if model == "" then model = "models/nova/airboat_seat.mdl" end
 	end
 
-	if not util.IsValidProp( model ) or not WireLib.CanModel(self.player, model) then return nil end
+	if not util.IsValidProp( model ) or not WireLib.CanModel(self.player, model) then return NULL end
 
 	pos = WireLib.clampPos( pos )
 
@@ -100,7 +100,7 @@ function PropCore.CreateProp(self,model,pos,angles,freeze,isVehicle)
 		prop = self.data.propSpawnEffect and MakeProp( self.player, pos, angles, model, {}, {} ) or MakePropNoEffect( self.player, pos, angles, model, {}, {} )
 	end
 
-	if not IsValid( prop ) then return nil end
+	if not IsValid( prop ) then return NULL end
 
 	prop:Activate()
 
@@ -154,46 +154,46 @@ end
 
 __e2setcost(40)
 e2function entity propSpawn(string model, number frozen)
-	if not PropCore.ValidAction(self, nil, "spawn") then return nil end
+	if not PropCore.ValidAction(self, nil, "spawn") then return NULL end
 	return PropCore.CreateProp(self,model,self.entity:GetPos()+self.entity:GetUp()*25,self.entity:GetAngles(),frozen)
 end
 
 e2function entity propSpawn(entity template, number frozen)
-	if not PropCore.ValidAction(self, nil, "spawn") then return nil end
-	if not IsValid(template) then return nil end
+	if not PropCore.ValidAction(self, nil, "spawn") then return NULL end
+	if not IsValid(template) then return NULL end
 	return PropCore.CreateProp(self,template:GetModel(),self.entity:GetPos()+self.entity:GetUp()*25,self.entity:GetAngles(),frozen)
 end
 
 e2function entity propSpawn(string model, vector pos, number frozen)
-	if not PropCore.ValidAction(self, nil, "spawn") then return nil end
+	if not PropCore.ValidAction(self, nil, "spawn") then return NULL end
 	return PropCore.CreateProp(self,model,Vector(pos[1],pos[2],pos[3]),self.entity:GetAngles(),frozen)
 end
 
 e2function entity propSpawn(entity template, vector pos, number frozen)
-	if not PropCore.ValidAction(self, nil, "spawn") then return nil end
-	if not IsValid(template) then return nil end
+	if not PropCore.ValidAction(self, nil, "spawn") then return NULL end
+	if not IsValid(template) then return NULL end
 	return PropCore.CreateProp(self,template:GetModel(),Vector(pos[1],pos[2],pos[3]),self.entity:GetAngles(),frozen)
 end
 
 e2function entity propSpawn(string model, angle rot, number frozen)
-	if not PropCore.ValidAction(self, nil, "spawn") then return nil end
+	if not PropCore.ValidAction(self, nil, "spawn") then return NULL end
 	return PropCore.CreateProp(self,model,self.entity:GetPos()+self.entity:GetUp()*25,Angle(rot[1],rot[2],rot[3]),frozen)
 end
 
 e2function entity propSpawn(entity template, angle rot, number frozen)
-	if not PropCore.ValidAction(self, nil, "spawn") then return nil end
-	if not IsValid(template) then return nil end
+	if not PropCore.ValidAction(self, nil, "spawn") then return NULL end
+	if not IsValid(template) then return NULL end
 	return PropCore.CreateProp(self,template:GetModel(),self.entity:GetPos()+self.entity:GetUp()*25,Angle(rot[1],rot[2],rot[3]),frozen)
 end
 
 e2function entity propSpawn(string model, vector pos, angle rot, number frozen)
-	if not PropCore.ValidAction(self, nil, "spawn") then return nil end
+	if not PropCore.ValidAction(self, nil, "spawn") then return NULL end
 	return PropCore.CreateProp(self,model,Vector(pos[1],pos[2],pos[3]),Angle(rot[1],rot[2],rot[3]),frozen)
 end
 
 e2function entity propSpawn(entity template, vector pos, angle rot, number frozen)
-	if not PropCore.ValidAction(self, nil, "spawn") then return nil end
-	if not IsValid(template) then return nil end
+	if not PropCore.ValidAction(self, nil, "spawn") then return NULL end
+	if not IsValid(template) then return NULL end
 	return PropCore.CreateProp(self,template:GetModel(),Vector(pos[1],pos[2],pos[3]),Angle(rot[1],rot[2],rot[3]),frozen)
 end
 
@@ -201,12 +201,12 @@ end
 
 __e2setcost(60)
 e2function entity seatSpawn(string model, number frozen)
-	if not PropCore.ValidAction(self, nil, "spawn") then return nil end
+	if not PropCore.ValidAction(self, nil, "spawn") then return NULL end
 	return PropCore.CreateProp(self,model,self.entity:GetPos()+self.entity:GetUp()*25,self.entity:GetAngles(),frozen,true)
 end
 
 e2function entity seatSpawn(string model, vector pos, angle rot, number frozen)
-	if not PropCore.ValidAction(self, nil, "spawn") then return nil end
+	if not PropCore.ValidAction(self, nil, "spawn") then return NULL end
 	return PropCore.CreateProp(self,model,Vector(pos[1],pos[2],pos[3]),Angle(rot[1],rot[2],rot[3]),frozen,true)
 end
 
@@ -250,7 +250,7 @@ local function removeAllIn( self, tbl )
 end
 
 e2function number table:propDelete()
-	if not PropCore.ValidAction(self, nil, "Tdelete") then return end
+	if not PropCore.ValidAction(self, nil, "Tdelete") then return 0 end
 
 	local count = removeAllIn( self, this.s )
 	count = count + removeAllIn( self, this.n )
@@ -261,7 +261,7 @@ e2function number table:propDelete()
 end
 
 e2function number array:propDelete()
-	if not PropCore.ValidAction(self, nil, "Tdelete") then return end
+	if not PropCore.ValidAction(self, nil, "Tdelete") then return 0 end
 
 	local count = removeAllIn( self, this )
 
@@ -346,7 +346,7 @@ e2function void entity:propSetFriction(number friction)
 end
 
 e2function number entity:propGetFriction()
-	if not PropCore.ValidAction(self, this, "friction") then return end
+	if not PropCore.ValidAction(self, this, "friction") then return 0 end
 	return this:GetFriction()
 end
 
@@ -356,7 +356,7 @@ e2function void entity:propSetElasticity(number elasticity)
 end
 
 e2function number entity:propGetElasticity()
-	if not PropCore.ValidAction(self, this, "elasticity") then return end
+	if not PropCore.ValidAction(self, this, "elasticity") then return 0 end
 	return this:GetElasticity()
 end
 
@@ -373,7 +373,7 @@ e2function void entity:propPhysicalMaterial(string physprop)
 end
 
 e2function string entity:propPhysicalMaterial()
-	if not PropCore.ValidAction(self, this, "physprop") then return end
+	if not PropCore.ValidAction(self, this, "physprop") then return "" end
 	local phys = this:GetPhysicsObject()
 	if IsValid(phys) then return phys:GetMaterial() or "" end
 	return ""


### PR DESCRIPTION
Fixes #1648 

This also fixes the return of `nil` when `NULL` is expected.