### PR TITLE
Fix nil arguments given to UDFs causing arg count to be incorrect

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -766,7 +766,7 @@ function Compiler:InstrFUNCTION(args)
 		-- runtimeArgs = { body, parameterExpression1, ..., parameterExpressionN, parameterTypes }
 		-- we need to evaluate the arguments before switching to the new scope
 		local parameterValues = {}
-		for parameterIndex = 2, #runtimeArgs - 1 do
+		for parameterIndex = 2, #Args + 1 do
 			local parameterExpression = runtimeArgs[parameterIndex]
 			local parameterValue = parameterExpression[1](self, parameterExpression)
 			parameterValues[parameterIndex - 1] = parameterValue
@@ -776,7 +776,7 @@ function Compiler:InstrFUNCTION(args)
 		self:InitScope()
 		self:PushScope()
 
-		for parameterIndex = 1, #parameterValues do
+		for parameterIndex = 1, #Args do
 			local parameterName = Args[parameterIndex][1]
 			local parameterValue = parameterValues[parameterIndex]
 			self.Scope[parameterName] = parameterValue


### PR DESCRIPTION
Considering `nil` values could be given as values to functions we can't use the length operator to reliable count the amount of arguments. Could've just used `#runtimeArgs - 2` but using `#Args` here feels a bit cleaner. The first change wasn't necessary but might as well be consistent.