### PR TITLE
Changes the antispam for print-statements in E2:

### DIFF
--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -835,6 +835,7 @@ E2Helper.Descriptions["selfDestruct()"] = "Removes the expression"
 E2Helper.Descriptions["selfDestructAll()"] = "Removes the expression and all constrained props"
 
 -- Debug
+E2Helper.Descriptions["playerCanPrint()"] = "Returns whether or not the next print-message will be printed or omitted by antispam"
 E2Helper.Descriptions["printDriver(e:s)"] = "Posts a string to the chat of Es driver. Returns 1 if the text was printed, 0 if not"
 E2Helper.Descriptions["hintDriver(e:sn)"] = "Displays a hint popup to the driver of vehicle E, with message S for N seconds (N being clamped between 0.7 and 7). Same return value as printDriver"
 E2Helper.Descriptions["printDriver(e:ns)"] = "Same as EE:printDriver(S), but can make the text show up in different places. N can be one of the following: _HUD_PRINTCENTER, _HUD_PRINTCONSOLE, _HUD_PRINTNOTIFY, _HUD_PRINTTALK"


### PR DESCRIPTION
> 
>  Every player has a number of "charges"
>  These are set with the convar "wire_expression2_print_max". After a given delay a new charge is added to >the player's account. This delay is taken from the convar "wire_expression2_print_delay"
>
>This new system remvoes the hook on "Think" and checks only when required how many charges are left

I am new to wire and lua and hope I haven't missed anything that could go terribly wrong...?

Anyway to test the new system you can use the following E2 script:
```golo
@name PrintTest

@persist [StartTime]:number
@outputs [Num]

if(first())
{
    StartTime = realtime()
    for(I = 1, 5, 1)
    {
        print("Initial")
    }

    timer("print", 8000)
}

if(clk("print"))
{
    StartTime = realtime()
    print("TimerStart")

    interval(1050)
}

if(clk())
{
    if(playerCanPrint())
    {
        Num = 1
        print((realtime() - StartTime) + " seconds passed")
    }
    else
    {
        Num = 0
    }
    interval(1050)
}
```

Setting the variables "wire_expression2_print_max" to 3 and "wire_expression2_print_delay" to 5 should produce the following output:

> Initial                      -- t = 0
> Initial                      -- t = 0
> Initial                      -- t = 0
> TimerStart              -- t = 8'000 [ms]
> 2 seconds passed  -- t = 10'000 [ms]
> 7 seconds passed  -- t = 15'000 [ms]
> ...

Using the old implementation the following output should be produced:
> Initial                        -- t = 0
> Initial                        -- t = 0
> Initial                        -- t = 0
> TimerStart                -- t = 8'000 [ms]
> 5 seconds passed    -- t = 13'000 [ms]
> 10 seconds passed  -- t = 18'000 [ms]
> ...
