### PR TITLE
Remove void signature from changed

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/selfaware.lua
+++ b/lua/entities/gmod_wire_expression2/core/selfaware.lua
@@ -203,6 +203,7 @@ local excluded_types = {
 	n = true,
 	v = true,
 	a = true,
+	[""] = true,
 
 	r = true,
 	t = true,


### PR DESCRIPTION
Currently `changed` can be called without an argument because `wire_expression_types2` contains void, this of course causes an error when called. 