### PR TITLE
Clear E2's strfunc cache when defining a function

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/functions.lua
+++ b/lua/entities/gmod_wire_expression2/core/functions.lua
@@ -9,6 +9,7 @@ __e2setcost(1)
 registerOperator("function", "", "", function(self, args)
 	local sig, body = args[2], args[3]
 	self.funcs[sig] = body
+	self.strfunc_cache = {}
 end)
 
 __e2setcost(2)


### PR DESCRIPTION
Previously the following code:

    function string f() { print("A") }
    "f"()
    function string f() { print("B") }
    "f"()

...would print "A" twice, because the previous entry for "f()" was still
present in the cache.

Fixes #1612.