### PR TITLE
Improve E2 AST walking

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/ast.lua
+++ b/lua/entities/gmod_wire_expression2/base/ast.lua
@@ -74,3 +74,31 @@ function E2Lib.AST.visitChildren(node, action)
     local visitor = childVisitors[node[1]] or genericChildVisitor
     return visitor(node, action)
 end
+
+--- Return a string representation of the tree.
+function E2Lib.AST.dump(tree, indentation)
+    indentation = indentation or ""
+    local str = indentation .. tree[1]
+
+    local summary = {}
+    for i = 3, #tree do
+        local v = tree[i]
+        if isstring(v) then
+            table.insert(summary, string.format("%q", v))
+        elseif isnumber(v) then
+            table.insert(summary, tostring(v))
+        end
+    end
+    if next(summary) then
+        str = str .. " [" .. table.concat(summary, ", ") .. "]"
+    end
+
+    str = str .. " (" .. tree[2][1] .. ":" .. tree[2][2] .. ")"
+    local childIndentation = indentation .. "|    "
+
+    E2Lib.AST.visitChildren(tree, function(child)
+        str = str .. "\n" .. E2Lib.AST.dump(child, childIndentation)
+    end)
+
+    return str
+end

--- a/lua/entities/gmod_wire_expression2/base/ast.lua
+++ b/lua/entities/gmod_wire_expression2/base/ast.lua
@@ -1,0 +1,76 @@
+-- The E2 source code is parsed into a tree structure, known as an 'abstract
+-- syntax tree' or AST. This file provides utilities for operating on nodes of
+-- this tree generically.
+
+AddCSLuaFile()
+
+E2Lib.AST = {}
+
+local function genericChildVisitor(node, action)
+    for i = 3, #node do
+        local child = node[i]
+        if istable(child) and child.__instruction then
+            node[i] = action(child) or child
+        end
+    end
+end
+local childVisitors = {}
+function childVisitors.call(node, action)
+    local arguments = node[4]
+    for i, argument in ipairs(arguments) do
+        arguments[i] = action(argument) or argument
+    end
+end
+function childVisitors.methodcall(node, action)
+    local this, arguments = node[4], node[5]
+    node[4] = action(this) or this
+    for i, argument in ipairs(arguments) do
+        arguments[i] = action(argument) or argument
+    end
+end
+function childVisitors.stringcall(node, action)
+    local name, arguments = node[3], node[4]
+    node[3] = action(name) or name
+    for i, argument in ipairs(arguments) do
+        arguments[i] = action(argument) or argument
+    end
+end
+function childVisitors.kvtable(node, action)
+    local entries = node[3]
+    local additions = {}
+    for key, value in pairs(entries) do
+        local newKey, newValue = action(key) or key, action(value) or value
+        if key ~= newKey then
+            entries[key] = nil
+            additions[newKey] = newValue
+        else
+            entries[key] = newValue
+        end
+    end
+    for key, value in pairs(additions) do entries[key] = value end
+end
+childVisitors.kvarray = childVisitors.kvtable
+function childVisitors.switch(node, action)
+    local expression = node[3]
+    node[3] = action(expression) or expression
+    for _, case in pairs(node[4]) do
+        local condition, result = case[1], case[2]
+        case[1] = condition and action(condition) or condition
+        case[2] = action(result) or result
+    end
+end
+
+--- Call `action` on every child of `node`.
+-- If it returns a value, then that value will replace the node.
+-- For example:
+-- E2Lib.AST.visitChildren(node, function(child)
+--     print(string.format("Node has a child of type %s", child[1]))
+--     -- replace (sub x x) → 0
+--     if child[1] == "sub" and child[3] == child[4] then
+--         return { "literal", child[2], 0, "n" }
+--     end
+-- end)
+function E2Lib.AST.visitChildren(node, action)
+    local visitor = childVisitors[node[1]] or genericChildVisitor
+    return visitor(node, action)
+end

--- a/lua/entities/gmod_wire_expression2/base/optimizer.lua
+++ b/lua/entities/gmod_wire_expression2/base/optimizer.lua
@@ -26,12 +26,8 @@ end
 Optimizer.Passes = {}
 
 function Optimizer.Process(tree)
-    for i = 3, #tree do
-        local child = tree[i]
-        if type(child) == "table" and child.__instruction then
-            tree[i] = Optimizer.Process(child)
-        end
-    end
+    E2Lib.AST.visitChildren(tree, Optimizer.Process)
+
     for _, pass in ipairs(Optimizer.Passes) do
         local action = pass[tree[1]]
         if action then

--- a/lua/entities/gmod_wire_expression2/base/optimizer.lua
+++ b/lua/entities/gmod_wire_expression2/base/optimizer.lua
@@ -18,7 +18,7 @@ local optimizerDebug = CreateConVar("wire_expression2_optimizer_debug", 0,
 function Optimizer.Execute(root)
     local ok, result = xpcall(Optimizer.Process, E2Lib.errorHandler, root)
     if ok and optimizerDebug:GetBool() then
-        print(E2Lib.Parser.DumpTree(result))
+        print(E2Lib.AST.dump(result))
     end
     return ok, result
 end

--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -94,23 +94,6 @@ function Parser.Execute(...)
 	return xpcall(Parser.Process, E2Lib.errorHandler, instance, ...)
 end
 
-function Parser.DumpTree(tree, indentation)
-	indentation = indentation or ''
-	local str = indentation .. tree[1] .. '(' .. tree[2][1] .. ':' .. tree[2][2] .. ')\n'
-	indentation = indentation .. '  '
-	for i = 3, #tree do
-		local child = tree[i]
-		if type(child) == 'table' and child.__instruction then
-			str = str .. Parser.DumpTree(child, indentation)
-		elseif type(child) == 'string' then
-			str = str .. indentation .. string.format('%q', child) .. '\n'
-		else
-			str = str .. indentation .. tostring(child) .. '\n'
-		end
-	end
-	return str
-end
-
 function Parser:Error(message, token)
 	if token then
 		error(message .. " at line " .. token[4] .. ", char " .. token[5], 0)
@@ -129,7 +112,7 @@ function Parser:Process(tokens, params)
 	self:NextToken()
 	local tree = self:Root()
 	if parserDebug:GetBool() then
-		print(Parser.DumpTree(tree))
+		print(E2Lib.AST.dump(tree))
 	end
 	return tree, self.delta, self.includes
 end

--- a/lua/entities/gmod_wire_expression2/shared.lua
+++ b/lua/entities/gmod_wire_expression2/shared.lua
@@ -14,6 +14,7 @@ CreateConVar("wire_expression2_quotahard", "100000", {FCVAR_REPLICATED})
 CreateConVar("wire_expression2_quotatick", "25000", {FCVAR_REPLICATED})
 
 include("core/e2lib.lua")
+include("base/ast.lua")
 include("base/preprocessor.lua")
 include("base/tokenizer.lua")
 include("base/parser.lua")


### PR DESCRIPTION
Previously in a couple places we walk the E2 AST like so:
```Lua
for i = 3, #node do
    if istable(node[i]) and node[i].__instruction then ... end
end
```

This works fine for most nodes, but there are a few (`call`, `stringcall`, `methodcall`, `kvarray`, `kvtable`, `switch`) for which this doesn't. This has two consequences:

* The optimizer doesn't optimize any expressions inside of these nodes
* The AST printer just shows their contents as `[table]`

This fixes both of those issues, by introducing an `E2Lib.AST.visitChildren` function that can be specialized for different node types. This will become more important later, as walking the AST to do analysis will be a necessary step in compilation.