### PR TITLE
Fix matching around strings/comments

### DIFF
--- a/lua/wire/client/text_editor/texteditor.lua
+++ b/lua/wire/client/text_editor/texteditor.lua
@@ -2258,12 +2258,17 @@ tbl.RunOnCheck = function( self )
 		return false
 	end
 
-	local caret = self:CopyPosition( self.Caret )
-	caret[2] = caret[2] - 1
-	local tokenname = self:GetTokenAtPosition( caret )
+	local caret = self:CopyPosition(self.Caret)
+	local tokenname = self:GetTokenAtPosition(caret)
+
 	if tokenname and (tokenname == "string" or tokenname == "comment") then
-		self:AC_SetVisible( false )
-		return false
+		caret[2] = caret[2] - 1
+		tokenname = self:GetTokenAtPosition(caret)
+
+		if tokenname and (tokenname == "string" or tokenname == "comment") then
+			self:AC_SetVisible(false)
+			return false
+		end
 	end
 
 	if self:IsVarLine() and not self.AC_WasVarLine then -- If the user IS editing a var line, and they WEREN'T editing a var line before this..

--- a/lua/wire/client/text_editor/texteditor.lua
+++ b/lua/wire/client/text_editor/texteditor.lua
@@ -2760,7 +2760,7 @@ function EDITOR:GetTokenAtPosition( caret )
 	local column = caret[2]
 	local line = self.PaintRows[caret[1]]
 	if line then
-		local startindex = 1
+		local startindex = 0
 		for _, data in pairs( line ) do
 			startindex = startindex+#data[1]
 			if startindex >= column then return data[3] end


### PR DESCRIPTION
Fixes #1667 

`EDITOR:GetTokenAtPosition` should probably return the token of the character to the right of said position, this makes the most sense in following behavior of the rest of the code.

AutoComplete had an issue of when there was a comment/string at the start of the word it wouldn't work correctly. Part of it not working correctly was due to `EDITOR:GetTokenAtPosition`, the other part of it was not checking both sides of the cursor.

As for the matching code it now checks the token of both sides of the cursor, so cases like `" ")` work correctly now. I also cleaned up this code because it does the same thing twice basically.