### PR TITLE
Fix clamp e2 ranger range

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/ranger.lua
+++ b/lua/entities/gmod_wire_expression2/core/ranger.lua
@@ -36,7 +36,6 @@ end
 local function ranger(self, rangertype, range, p1, p2, hulltype, mins, maxs, traceEntity )
 	local data = self.data
 	local chip = self.entity
-	local range = math.Clamp(range, -57000, 57000)
 
 	local defaultzero = data.rangerdefaultzero
 	local ignoreworld = data.rangerignoreworld
@@ -78,8 +77,8 @@ local function ranger(self, rangertype, range, p1, p2, hulltype, mins, maxs, tra
 		tracedata.start = Vector( p1[1], p1[2], p1[3] )
 		tracedata.endpos = Vector( p2[1], p2[2], p2[3] )
 	elseif rangertype == 3 then
-		tracedata.start = Vector( p1[1], p1[2], p1[3] )
-		tracedata.endpos = tracedata.start + WireLib.clampPos( Vector( p2[1], p2[2], p2[3] ) ):GetNormalized()*range
+		tracedata.start = WireLib.clampPos( Vector( p1[1], p1[2], p1[3] ) )
+		tracedata.endpos = WireLib.clampPos( tracedata.start + Vector( p2[1], p2[2], p2[3] ):GetNormalized() * range )
 	else
 		tracedata.start = chip:GetPos()
 

--- a/lua/entities/gmod_wire_expression2/core/ranger.lua
+++ b/lua/entities/gmod_wire_expression2/core/ranger.lua
@@ -33,6 +33,13 @@ local function ResetRanger(self)
 	data.rangerfilter_lookup = table.MakeNonIterable{ [self.entity] = true }
 end
 
+local function infPos(pos)
+	if pos.x ~= pos.x or pos.x == math.huge or pos.x == -math.huge then return true end
+	if pos.y ~= pos.y or pos.y == math.huge or pos.y == -math.huge then return true end
+	if pos.z ~= pos.z or pos.z == math.huge or pos.z == -math.huge then return true end
+	return false
+end
+
 local function ranger(self, rangertype, range, p1, p2, hulltype, mins, maxs, traceEntity )
 	local data = self.data
 	local chip = self.entity
@@ -77,8 +84,8 @@ local function ranger(self, rangertype, range, p1, p2, hulltype, mins, maxs, tra
 		tracedata.start = Vector( p1[1], p1[2], p1[3] )
 		tracedata.endpos = Vector( p2[1], p2[2], p2[3] )
 	elseif rangertype == 3 then
-		tracedata.start = WireLib.clampPos( Vector( p1[1], p1[2], p1[3] ) )
-		tracedata.endpos = WireLib.clampPos( tracedata.start + Vector( p2[1], p2[2], p2[3] ):GetNormalized() * range )
+		tracedata.start = Vector( p1[1], p1[2], p1[3] )
+		tracedata.endpos = tracedata.start + Vector( p2[1], p2[2], p2[3] ):GetNormalized()*range
 	else
 		tracedata.start = chip:GetPos()
 
@@ -98,11 +105,7 @@ local function ranger(self, rangertype, range, p1, p2, hulltype, mins, maxs, tra
 		end
 	end
 
-	-- clamp positions
-	tracedata.start = WireLib.clampPos( tracedata.start )
-	if tracedata.start:Distance( tracedata.endpos ) > 57000 then -- 57000 is slightly larger than the diagonal distance (min corner to max corner) of the source max map size
-		tracedata.endpos = tracedata.start + (tracedata.endpos - tracedata.start):GetNormal() * 57000
-	end
+	if infPos(tracedata.start) or infPos(tracedata.endpos) then return end
 
 	---------------------------------------------------------------------------------------
 	local trace

--- a/lua/entities/gmod_wire_expression2/core/ranger.lua
+++ b/lua/entities/gmod_wire_expression2/core/ranger.lua
@@ -130,6 +130,7 @@ local function ranger(self, rangertype, range, p1, p2, hulltype, mins, maxs, tra
 			self.prf = self.prf + tracedata.mins:Distance(tracedata.maxs) * 0.5
 		end
 
+		if infPos(tracedata.mins) or infPos(tracedata.maxs) then return end
 		-- If max is less than min it'll cause a hang
 		OrderVectors(tracedata.mins, tracedata.maxs)
 

--- a/lua/entities/gmod_wire_expression2/core/ranger.lua
+++ b/lua/entities/gmod_wire_expression2/core/ranger.lua
@@ -36,6 +36,7 @@ end
 local function ranger(self, rangertype, range, p1, p2, hulltype, mins, maxs, traceEntity )
 	local data = self.data
 	local chip = self.entity
+	local range = math.Clamp(range, -64000, 64000)
 
 	local defaultzero = data.rangerdefaultzero
 	local ignoreworld = data.rangerignoreworld

--- a/lua/entities/gmod_wire_expression2/core/ranger.lua
+++ b/lua/entities/gmod_wire_expression2/core/ranger.lua
@@ -36,7 +36,7 @@ end
 local function ranger(self, rangertype, range, p1, p2, hulltype, mins, maxs, traceEntity )
 	local data = self.data
 	local chip = self.entity
-	local range = math.Clamp(range, -64000, 64000)
+	local range = math.Clamp(range, -57000, 57000)
 
 	local defaultzero = data.rangerdefaultzero
 	local ignoreworld = data.rangerignoreworld

--- a/lua/entities/gmod_wire_expression2/core/ranger.lua
+++ b/lua/entities/gmod_wire_expression2/core/ranger.lua
@@ -33,7 +33,7 @@ local function ResetRanger(self)
 	data.rangerfilter_lookup = table.MakeNonIterable{ [self.entity] = true }
 end
 
-local function infPos(pos)
+local function IsErrorVector(pos)
 	if pos.x ~= pos.x or pos.x == math.huge or pos.x == -math.huge then return true end
 	if pos.y ~= pos.y or pos.y == math.huge or pos.y == -math.huge then return true end
 	if pos.z ~= pos.z or pos.z == math.huge or pos.z == -math.huge then return true end
@@ -105,7 +105,7 @@ local function ranger(self, rangertype, range, p1, p2, hulltype, mins, maxs, tra
 		end
 	end
 
-	if infPos(tracedata.start) or infPos(tracedata.endpos) then return end
+	if IsErrorVector(tracedata.start) or IsErrorVector(tracedata.endpos) then return end
 
 	---------------------------------------------------------------------------------------
 	local trace
@@ -130,7 +130,7 @@ local function ranger(self, rangertype, range, p1, p2, hulltype, mins, maxs, tra
 			self.prf = self.prf + tracedata.mins:Distance(tracedata.maxs) * 0.5
 		end
 
-		if infPos(tracedata.mins) or infPos(tracedata.maxs) then return end
+		if IsErrorVector(tracedata.mins) or IsErrorVector(tracedata.maxs) then return end
 		-- If max is less than min it'll cause a hang
 		OrderVectors(tracedata.mins, tracedata.maxs)
 

--- a/lua/entities/gmod_wire_expression2/core/ranger.lua
+++ b/lua/entities/gmod_wire_expression2/core/ranger.lua
@@ -79,7 +79,7 @@ local function ranger(self, rangertype, range, p1, p2, hulltype, mins, maxs, tra
 		tracedata.endpos = Vector( p2[1], p2[2], p2[3] )
 	elseif rangertype == 3 then
 		tracedata.start = Vector( p1[1], p1[2], p1[3] )
-		tracedata.endpos = tracedata.start + Vector( p2[1], p2[2], p2[3] ):GetNormalized()*range
+		tracedata.endpos = tracedata.start + WireLib.clampPos( Vector( p2[1], p2[2], p2[3] ) ):GetNormalized()*range
 	else
 		tracedata.start = chip:GetPos()
 


### PR DESCRIPTION
This fixes an exploit with E2's ranger functions.

Tested on my development server and it seems to work well.

(excluding a bit, message me on steam if you want more info)
```
RD = rangerOffset(inf(), entity():pos(), vec(inf(),inf(),inf()))
```

This code was previously causing issues on servers, due to two pieces:
- The first parameter of `rangerOffset(distance, vector from, vector direction)` wasn't limited its size
- The third parameter of `rangerOffset(distance, vector from, vector direction)` wasn't limiting the size of the `x,y,z`

I've addressed both of these problems as best as I understand them, but someone else who worked on this should take a closer look to see if this problem could be exploited elsewhere in the `ranger` function.

Thanks!