### PR TITLE
Match E2 file size limit on the client to 300 KiB

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/cl_files.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_files.lua
@@ -3,7 +3,7 @@
 	By: Dan (McLovin)
 ]]--
 
-local cv_max_transfer_size = CreateConVar( "wire_expression2_file_max_size", "100", { FCVAR_REPLICATED, FCVAR_ARCHIVE } ) //in kb
+local cv_max_transfer_size = CreateConVar( "wire_expression2_file_max_size", "300", { FCVAR_REPLICATED, FCVAR_ARCHIVE } ) //in kib
 
 local upload_buffer = {}
 local download_buffer = {}

--- a/lua/entities/gmod_wire_expression2/core/files.lua
+++ b/lua/entities/gmod_wire_expression2/core/files.lua
@@ -4,7 +4,7 @@
 ]]--
 
 local cv_transfer_delay    = CreateConVar( "wire_expression2_file_delay", "5", { FCVAR_ARCHIVE } )
-local cv_max_transfer_size = CreateConVar( "wire_expression2_file_max_size", "300", { FCVAR_REPLICATED, FCVAR_ARCHIVE } ) -- in kb
+local cv_max_transfer_size = CreateConVar( "wire_expression2_file_max_size", "300", { FCVAR_REPLICATED, FCVAR_ARCHIVE } ) -- in kib
 
 local download_chunk_size = 20000 -- Our overhead is pretty small so lets send it in moderate sized pieces, no need to max out the buffer
 


### PR DESCRIPTION
The default size change has not been reflected on the client, which does its own check. For some reason the value is not synced to the client, but the convar is marked as replicated, leaving the client unable to change the limit himself. This fixes the problem by setting the current server default as default on the client.

An alternative solution would be to have seperate client and server limits and a file must be smaller than *both* values to be allowed thus allowing players to set levels appropriate to their connection or disabling file access from E2completely.