### PR TITLE
Egp fonts now use the actual font name and no ids

### DIFF
--- a/lua/entities/gmod_wire_egp/lib/egplib/materials.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/materials.lua
@@ -5,37 +5,7 @@ local EGP = EGP
 
 -- Valid fonts table
 EGP.ValidFonts_Lookup = {}
-EGP.ValidFonts = {}
-EGP.ValidFonts[1] = "WireGPU_ConsoleFont"
-EGP.ValidFonts[2] = "Coolvetica"
-EGP.ValidFonts[3] = "Arial"
-EGP.ValidFonts[4] = "Lucida Console"
-EGP.ValidFonts[5] = "Trebuchet"
-EGP.ValidFonts[6] = "Courier New"
-EGP.ValidFonts[7] = "Times New Roman"
-EGP.ValidFonts[8] = "ChatFont"
-EGP.ValidFonts[9] = "Marlett"
-EGP.ValidFonts[10] = "Roboto"
 if (CLIENT) then
-	local new = {}
-	for k,v in ipairs( EGP.ValidFonts ) do
-		local font = "WireEGP_18_"..k
-		local fontTable =
-		{
-			font=v,
-			size = 18,
-			weight = 800,
-			antialias = true,
-			additive = false
-		}
-		surface.CreateFont( font, fontTable )
-
-		EGP.ValidFonts_Lookup[font] = true
-		table.insert( new, font )
-	end
-	for k,v in ipairs( new ) do
-		table.insert( EGP.ValidFonts, v )
-	end
 
 	local type = type
 	local SetMaterial = surface.SetMaterial

--- a/lua/entities/gmod_wire_egp/lib/egplib/objectcontrol.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/objectcontrol.lua
@@ -245,7 +245,7 @@ if CLIENT then mat = Material else mat = function( str ) return str end end
 -- Create table
 local tbl = {
 	{ ID = EGP.Objects.Names["Box"], Settings = { x = 256, y = 256, h = 356, w = 356, material = mat("expression 2/cog"), r = 150, g = 34, b = 34, a = 255 } },
-	{ ID = EGP.Objects.Names["Text"], Settings = {x = 256, y = 256, text = "EGP 3", fontid = 1, valign = 1, halign = 1, size = 50, r = 135, g = 135, b = 135, a = 255 } }
+	{ ID = EGP.Objects.Names["Text"], Settings = {x = 256, y = 256, text = "EGP 3", font = "WireGPU_ConsoleFont", valign = 1, halign = 1, size = 50, r = 135, g = 135, b = 135, a = 255 } }
 }
 
 --[[ Old homescreen (EGP v2 home screen design contest winner)

--- a/lua/entities/gmod_wire_egp/lib/objects/text.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/text.lua
@@ -3,7 +3,7 @@ local Obj = EGP:NewObject( "Text" )
 Obj.h = nil
 Obj.w = nil
 Obj.text = ""
-Obj.fontid = 1
+Obj.font = "WireGPU_ConsoleFont"
 Obj.size = 18
 Obj.valign = 0
 Obj.halign = 0
@@ -44,19 +44,17 @@ Obj.Draw = function( self )
 	if (self.text and #self.text>0) then
 		surface_SetTextColor( self.r, self.g, self.b, self.a )
 
-		if (!EGP.ValidFonts[self.fontid]) then self.fontid = 1 end
-		local font = "WireEGP_" .. self.size .. "_" .. self.fontid
+		local font = "WireEGP_" .. self.size .. "_" .. self.font
 		if (!EGP.ValidFonts_Lookup[font]) then
 			local fontTable =
 			{
-				font=EGP.ValidFonts[self.fontid],
+				font=self.font,
 				size = self.size,
 				weight = 800,
 				antialias = true,
 				additive = false
 			}
 			surface_CreateFont( font, fontTable )
-			EGP.ValidFonts[#EGP.ValidFonts+1]= font
 			EGP.ValidFonts_Lookup[font] = true
 		end
 		surface_SetFont( font )
@@ -105,7 +103,7 @@ Obj.Transmit = function( self, Ent, ply )
 	net.WriteInt( self.x, 16 )
 	net.WriteInt( self.y, 16 )
 	EGP:InsertQueue( Ent, ply, EGP._SetText, "SetText", self.index, self.text )
-	net.WriteUInt(self.fontid, 8)
+	net.WriteString(self.font)
 	net.WriteUInt(math.Clamp(self.size,0,256), 8)
 	net.WriteUInt(math.Clamp(self.valign,0,2), 2)
 	net.WriteUInt(math.Clamp(self.halign,0,2), 2)
@@ -117,7 +115,7 @@ Obj.Receive = function( self )
 	local tbl = {}
 	tbl.x = net.ReadInt(16)
 	tbl.y = net.ReadInt(16)
-	tbl.fontid = net.ReadUInt(8)
+	tbl.font = net.ReadString()
 	tbl.size = net.ReadUInt(8)
 	tbl.valign = net.ReadUInt(2)
 	tbl.halign = net.ReadUInt(2)
@@ -127,5 +125,5 @@ Obj.Receive = function( self )
 	return tbl
 end
 Obj.DataStreamInfo = function( self )
-	return { x = self.x, y = self.y, valign = self.valign, halign = self.halign, size = self.size, r = self.r, g = self.g, b = self.b, a = self.a, text = self.text, fontid = self.fontid, parent = self.parent, angle = self.angle }
+	return { x = self.x,	y = self.y,	valign = self.valign, halign = self.halign, size = self.size, r = self.r, g = self.g, b = self.b, a = self.a, text = self.text, font = self.font, parent = self.parent, angle = self.angle }
 end

--- a/lua/entities/gmod_wire_egp/lib/objects/text.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/text.lua
@@ -125,5 +125,5 @@ Obj.Receive = function( self )
 	return tbl
 end
 Obj.DataStreamInfo = function( self )
-	return { x = self.x,	y = self.y,	valign = self.valign, halign = self.halign, size = self.size, r = self.r, g = self.g, b = self.b, a = self.a, text = self.text, font = self.font, parent = self.parent, angle = self.angle }
+	return { x = self.x, y = self.y, valign = self.valign, halign = self.halign, size = self.size, r = self.r, g = self.g, b = self.b, a = self.a, text = self.text, font = self.font, parent = self.parent, angle = self.angle }
 end

--- a/lua/entities/gmod_wire_egp/lib/objects/textlayout.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/textlayout.lua
@@ -3,7 +3,7 @@ local Obj = EGP:NewObject( "TextLayout" )
 Obj.h = 512
 Obj.w = 512
 Obj.text = ""
-Obj.fontid = 1
+Obj.font = "WireGPU_ConsoleFont"
 Obj.size = 18
 Obj.valign = 0
 Obj.halign = 0
@@ -23,19 +23,17 @@ Obj.Draw = function( self )
 	if (self.text and #self.text>0) then
 		surface.SetTextColor( self.r, self.g, self.b, self.a )
 
-		if (!EGP.ValidFonts[self.fontid]) then self.fontid = 1 end
-		local font = "WireEGP_" .. self.size .. "_" .. self.fontid
+		local font = "WireEGP_" .. self.size .. "_" .. self.font
 		if (!EGP.ValidFonts_Lookup[font]) then
 			local fontTable =
 			{
-				font=EGP.ValidFonts[self.fontid],
+				font=self.font,
 				size = self.size,
 				weight = 800,
 				antialias = true,
 				additive = false
 			}
 			surface.CreateFont( font, fontTable )
-			table.insert( EGP.ValidFonts, font )
 			EGP.ValidFonts_Lookup[font] = true
 		end
 		surface.SetFont( font )
@@ -93,7 +91,7 @@ end
 Obj.Transmit = function( self, Ent, ply )
 	EGP:SendPosSize( self )
 	EGP:InsertQueue( Ent, ply, EGP._SetText, "SetText", self.index, self.text )
-	net.WriteUInt(self.fontid, 8)
+	net.WriteString(self.font)
 	net.WriteUInt(math.Clamp(self.size,0,256), 8)
 	net.WriteUInt(math.Clamp(self.valign,0,2), 2)
 	net.WriteUInt(math.Clamp(self.halign,0,2), 2)
@@ -104,7 +102,7 @@ end
 Obj.Receive = function( self )
 	local tbl = {}
 	EGP:ReceivePosSize( tbl )
-	tbl.fontid = net.ReadUInt(8)
+	tbl.font = net.ReadString(8)
 	tbl.size = net.ReadUInt(8)
 	tbl.valign = net.ReadUInt(2)
 	tbl.halign = net.ReadUInt(2)
@@ -114,5 +112,5 @@ Obj.Receive = function( self )
 	return tbl
 end
 Obj.DataStreamInfo = function( self )
-	return { x = self.x, y = self.y, w = self.w, h = self.h, valign = self.valign, halign = self.halign, size = self.size, r = self.r, g = self.g, b = self.b, a = self.a, text = self.text, fontid = self.fontid, parent = self.parent, angle = self.angle }
+	return { x = self.x, y = self.y, w = self.w, h = self.h, valign = self.valign, halign = self.halign, size = self.size, r = self.r, g = self.g, b = self.b, a = self.a, text = self.text, font = self.font, parent = self.parent, angle = self.angle }
 end

--- a/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
@@ -247,14 +247,7 @@ e2function void wirelink:egpFont( number index, string font )
 	if (!EGP:IsAllowed( self, this )) then return end
 	local bool, k, v = EGP:HasObject( this, index )
 	if (bool) then
-		local fontid = 0
-		for k,v in ipairs( EGP.ValidFonts ) do
-			if (v:lower() == font:lower()) then
-				fontid = k
-				break
-			end
-		end
-		if (EGP:EditObject( v, { fontid = fontid } )) then EGP:DoAction( this, self, "SendObject", v ) Update(self,this) end
+		if (EGP:EditObject( v, { font = font } )) then EGP:DoAction( this, self, "SendObject", v ) Update(self,this) end
 	end
 end
 
@@ -262,14 +255,14 @@ e2function void wirelink:egpFont( number index, string font, number size )
 	if (!EGP:IsAllowed( self, this )) then return end
 	local bool, k, v = EGP:HasObject( this, index )
 	if (bool) then
-		local fontid = 0
+		local selected_font = "WireGPU_ConsoleFont"
 		for k,v in ipairs( EGP.ValidFonts ) do
 			if (v:lower() == font:lower()) then
-				fontid = k
+				selected_font = k
 				break
 			end
 		end
-		if (EGP:EditObject( v, { fontid = fontid, size = size } )) then EGP:DoAction( this, self, "SendObject", v ) Update(self,this) end
+		if (EGP:EditObject( v, { font = selected_font, size = size } )) then EGP:DoAction( this, self, "SendObject", v ) Update(self,this) end
 	end
 end
 

--- a/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
@@ -255,14 +255,7 @@ e2function void wirelink:egpFont( number index, string font, number size )
 	if (!EGP:IsAllowed( self, this )) then return end
 	local bool, k, v = EGP:HasObject( this, index )
 	if (bool) then
-		local selected_font = "WireGPU_ConsoleFont"
-		for k,v in ipairs( EGP.ValidFonts ) do
-			if (v:lower() == font:lower()) then
-				selected_font = k
-				break
-			end
-		end
-		if (EGP:EditObject( v, { font = selected_font, size = size } )) then EGP:DoAction( this, self, "SendObject", v ) Update(self,this) end
+		if (EGP:EditObject( v, { font = font, size = size } )) then EGP:DoAction( this, self, "SendObject", v ) Update(self,this) end
 	end
 end
 


### PR DESCRIPTION
I tried to remove the id system for fonts for Egp text elements so that you could use any font.
I'm not that familiar with the Egp code and how it works so I might have messed something up.

