### PR TITLE
Pod Controller "Hide HUD" to allow EGP HUDs, and an option to hide the chat too

### DIFF
--- a/lua/entities/gmod_wire_pod.lua
+++ b/lua/entities/gmod_wire_pod.lua
@@ -12,55 +12,55 @@ if CLIENT then
 	local toolgunHUDFunc = nil
 	local function blank() end
 
-	hook.Add( "HUDShouldDraw", "Wire pod HUDShouldDraw", function( name )
-		if hideHUD > 0 then
-			if LocalPlayer():InVehicle() then
-				if firstTime then
-					LocalPlayer():ChatPrint( "The owner of this vehicle has hidden your hud using a pod controller. If it gets stuck this way, use the console command 'wire_pod_hud_show' to forcibly enable it again." )
-					firstTime = false
-				end
-				if savedHooks == nil then
-					local weapon = LocalPlayer():GetActiveWeapon()
-					if IsValid(weapon) and weapon:GetClass() == "gmod_tool" then
-						toolgunTable = weapon:GetTable()
-						toolgunHUDFunc = toolgunTable.DrawHUD
-						toolgunTable.DrawHUD = blank
-					end
-					local hooks = hook.GetTable()["HUDPaint"]
-					savedHooks = table.Copy(hooks)
-					for k in pairs(hooks) do
-						if k ~= "EGP_HUDPaint" then hooks[k] = blank end
-					end
-				end
-				if name ~= "CHudCrosshair" and name ~= "CHudGMod" and (hideHUD > 1 and name == "CHudChat" or name ~= "CHudChat")  then return false end -- Don't return false on crosshairs. Those are toggled using the other input.
-			elseif not LocalPlayer():InVehicle() then
-				hideHUD = 0
-			end
-		elseif savedHooks then
-			if toolgunTable then
-				toolgunTable.DrawHUD = toolgunHUDFunc
-				toolgunTable = nil
-			end
-			local hooks = hook.GetTable()["HUDPaint"]
-			for k,v in pairs(hooks) do
-				if v == blank then hooks[k] = savedHooks[k] end
-			end
-			savedHooks = nil
-		end
-	end)
-
-	hook.Add( "DrawDeathNotice", "Wire pod DrawDeathNotice", function()
-		if hideHUD > 0 then return false end
-	end)
-
-	hook.Add( "HUDDrawTargetID", "Wire pod HUDDrawTargetID", function()
-		if hideHUD > 0 then return false end
-	end)
-
 	usermessage.Hook( "wire pod hud", function( um )
 		local vehicle = um:ReadEntity()
 		if LocalPlayer():InVehicle() and LocalPlayer():GetVehicle() == vehicle then
 			hideHUD = um:ReadShort()
+			if hideHUD > 0 then
+				hook.Add( "HUDShouldDraw", "Wire pod HUDShouldDraw", function( name )
+					if hideHUD > 0 then
+						if LocalPlayer():InVehicle() then
+							if firstTime then
+								LocalPlayer():ChatPrint( "The owner of this vehicle has hidden your hud using a pod controller. If it gets stuck this way, use the console command 'wire_pod_hud_show' to forcibly enable it again." )
+								firstTime = false
+							end
+							if savedHooks == nil then
+								local weapon = LocalPlayer():GetActiveWeapon()
+								if IsValid(weapon) and weapon:GetClass() == "gmod_tool" then
+									toolgunTable = weapon:GetTable()
+									toolgunHUDFunc = toolgunTable.DrawHUD
+									toolgunTable.DrawHUD = blank
+								end
+								local hooks = hook.GetTable()["HUDPaint"]
+								savedHooks = table.Copy(hooks)
+								for k in pairs(hooks) do
+									if k ~= "EGP_HUDPaint" then hooks[k] = blank end
+								end
+								hook.Add( "DrawDeathNotice", "Wire pod DrawDeathNotice", function() end)
+								hook.Add( "HUDDrawTargetID", "Wire pod HUDDrawTargetID", function() end)
+							end
+							if name ~= "CHudCrosshair" and name ~= "CHudGMod" and (hideHUD > 1 and name == "CHudChat" or name ~= "CHudChat")  then return false end -- Don't return false on crosshairs. Those are toggled using the other input.
+						else
+							hideHUD = 0
+						end
+					else
+						if toolgunTable then
+							toolgunTable.DrawHUD = toolgunHUDFunc
+							toolgunTable = nil
+						end
+						if savedHooks then
+							local hooks = hook.GetTable()["HUDPaint"]
+							for k,v in pairs(hooks) do
+								if v == blank then hooks[k] = savedHooks[k] end
+							end
+							savedHooks = nil
+						end
+						hook.Remove( "HUDShouldDraw", "Wire pod HUDShouldDraw")
+						hook.Remove( "DrawDeathNotice", "Wire pod DrawDeathNotice")
+						hook.Remove( "HUDDrawTargetID", "Wire pod HUDDrawTargetID")
+					end
+				end)
+			end
 		else
 			hideHUD = 0
 		end

--- a/lua/entities/gmod_wire_pod.lua
+++ b/lua/entities/gmod_wire_pod.lua
@@ -28,7 +28,7 @@ if CLIENT then
 					end
 					local hooks = hook.GetTable()["HUDPaint"]
 					savedHooks = table.Copy(hooks)
-					for k,v in pairs(hooks) do
+					for k in pairs(hooks) do
 						if k ~= "EGP_HUDPaint" then hooks[k] = blank end
 					end
 				end

--- a/lua/entities/gmod_wire_pod.lua
+++ b/lua/entities/gmod_wire_pod.lua
@@ -49,11 +49,11 @@ if CLIENT then
 		end
 	end)
 
-	hook.Add( "DrawDeathNotice", "Wire pod DrawDeathNotice", function( name )
+	hook.Add( "DrawDeathNotice", "Wire pod DrawDeathNotice", function()
 		if hideHUD > 0 then return false end
 	end)
 
-	hook.Add( "HUDDrawTargetID", "Wire pod HUDDrawTargetID", function( name )
+	hook.Add( "HUDDrawTargetID", "Wire pod HUDDrawTargetID", function()
 		if hideHUD > 0 then return false end
 	end)
 

--- a/lua/entities/gmod_wire_pod.lua
+++ b/lua/entities/gmod_wire_pod.lua
@@ -472,10 +472,12 @@ function ENT:PlayerEntered( ply, RC )
 	end
 
 	if self.HideHUD > 0 and self:HasPod() then
-		umsg.Start( "wire pod hud", ply )
-			umsg.Entity( self:GetPod() )
-			umsg.Short( self.HideHUD )
-		umsg.End()
+		timer.Simple(0.1,function()
+			umsg.Start( "wire pod hud", ply )
+				umsg.Entity( self:GetPod() )
+				umsg.Short( self.HideHUD )
+			umsg.End()
+		end)
 	end
 
 	if (self.HidePlayerVal) then

--- a/lua/entities/gmod_wire_pod.lua
+++ b/lua/entities/gmod_wire_pod.lua
@@ -11,7 +11,7 @@ if CLIENT then
 	local toolgunTable = nil
 	local toolgunHUDFunc = nil
 	local function blank() end
-	
+
 	hook.Add( "HUDShouldDraw", "Wire pod HUDShouldDraw", function( name )
 		if hideHUD > 0 then
 			if LocalPlayer():InVehicle() then
@@ -37,9 +37,9 @@ if CLIENT then
 				hideHUD = 0
 			end
 		elseif savedHooks then
-			if toolgunTable then 
+			if toolgunTable then
 				toolgunTable.DrawHUD = toolgunHUDFunc
-				toolgunTable = nil 
+				toolgunTable = nil
 			end
 			local hooks = hook.GetTable()["HUDPaint"]
 			for k,v in pairs(hooks) do
@@ -48,15 +48,15 @@ if CLIENT then
 			savedHooks = nil
 		end
 	end)
-	
+
 	hook.Add( "DrawDeathNotice", "Wire pod DrawDeathNotice", function( name )
 		if hideHUD > 0 then return false end
 	end)
-	
+
 	hook.Add( "HUDDrawTargetID", "Wire pod HUDDrawTargetID", function( name )
 		if hideHUD > 0 then return false end
 	end)
-	
+
 	usermessage.Hook( "wire pod hud", function( um )
 		local vehicle = um:ReadEntity()
 		if LocalPlayer():InVehicle() and LocalPlayer():GetVehicle() == vehicle then


### PR DESCRIPTION
Hey guys, first time GitHub user and wiremod contributor here so apologies if I didn't do something correctly...

I've made it so that the 'Hide HUD' option of Pod Controllers no longer blocks EGP HUDs, fixing issue #1371 

I also made it so that you can hide the chat by setting the 'Hide HUD' input to a value higher than 1.

Also fixed an issue where the HUD wouldn't hide upon entering the vehicle.