### PR TITLE
Fix type highlighting when using default type

### DIFF
--- a/lua/wire/client/text_editor/modes/e2.lua
+++ b/lua/wire/client/text_editor/modes/e2.lua
@@ -368,8 +368,6 @@ function EDITOR:SyntaxColorLine(row)
       else -- aww
       addToken( "notfound", self.tokendata )
       end
-    else
-      break
     end
 
     local spaces = self:SkipPattern( " *" )


### PR DESCRIPTION
Fixes #1714 

Remove break that was causing types specified after a non specified type to be miscolored.