### PR TITLE
Add string comparison functions

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/optimizer.lua
+++ b/lua/entities/gmod_wire_expression2/base/optimizer.lua
@@ -46,7 +46,7 @@ local function evaluateBinary(instruction)
     local op = wire_expression2_funcs["op:" .. instruction[1] .. "(" .. instruction[3][4] .. instruction[4][4] .. ")"]
     local x, y = instruction[3][3], instruction[4][3]
 
-    local value = op[3](nil, {nil, {function() return x end}, {function() return y end}})
+    local value = op[3]({prf = 0}, {nil, {function() return x end}, {function() return y end}})
     local type = op[2]
     return {"literal", instruction[2], value, type}
 end

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -64,9 +64,7 @@ registerOperator("geq", "ss", "n", function(self, args)
 	local op1, op2 = args[2], args[3]
 	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
 
-	if self then
-		self.prf = self.prf + math.min(#rv1, #rv2)
-	end
+	self.prf = self.prf + math.min(#rv1, #rv2) / 10
 
 	return rv1 >= rv2 and 1 or 0
 end)
@@ -75,9 +73,7 @@ registerOperator("leq", "ss", "n", function(self, args)
 	local op1, op2 = args[2], args[3]
 	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
 
-	if self then
-		self.prf = self.prf + math.min(#rv1, #rv2)
-	end
+	self.prf = self.prf + math.min(#rv1, #rv2) / 10
 
 	return rv1 <= rv2 and 1 or 0
 end)
@@ -86,9 +82,7 @@ registerOperator("gth", "ss", "n", function(self, args, ...)
 	local op1, op2 = args[2], args[3]
 	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
 
-	if self then
-		self.prf = self.prf + math.min(#rv1, #rv2)
-	end
+	self.prf = self.prf + math.min(#rv1, #rv2) / 10
 
 	return rv1 > rv2 and 1 or 0
 end)
@@ -97,9 +91,7 @@ registerOperator("lth", "ss", "n", function(self, args)
 	local op1, op2 = args[2], args[3]
 	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
 
-	if self then
-		self.prf = self.prf + math.min(#rv1, #rv2)
-	end
+	self.prf = self.prf + math.min(#rv1, #rv2) / 10
 
 	return rv1 < rv2 and 1 or 0
 end)

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -57,9 +57,6 @@ registerOperator("neq", "ss", "n", function(self, args)
 	return rv1 ~= rv2 and 1 or 0
 end)
 
--- TODO: work out the `if self` checks that are in place to fix errors during
--- compile-time const eval optimization
-
 registerOperator("geq", "ss", "n", function(self, args)
 	local op1, op2 = args[2], args[3]
 	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -75,7 +75,7 @@ registerOperator("leq", "ss", "n", function(self, args)
 	return rv1 <= rv2 and 1 or 0
 end)
 
-registerOperator("gth", "ss", "n", function(self, args, ...)
+registerOperator("gth", "ss", "n", function(self, args)
 	local op1, op2 = args[2], args[3]
 	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
 

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -39,19 +39,69 @@ end)
 registerOperator("is", "s", "n", function(self, args)
 	local op1 = args[2]
 	local rv1 = op1[1](self, op1)
-	if rv1 ~= "" then return 1 else return 0 end
+
+	return rv1 ~= "" and 1 or 0
 end)
 
 registerOperator("eq", "ss", "n", function(self, args)
 	local op1, op2 = args[2], args[3]
 	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
-	if rv1 == rv2 then return 1 else return 0 end
+
+	return rv1 == rv2 and 1 or 0
 end)
 
 registerOperator("neq", "ss", "n", function(self, args)
 	local op1, op2 = args[2], args[3]
 	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
-	if rv1 != rv2 then return 1 else return 0 end
+
+	return rv1 ~= rv2 and 1 or 0
+end)
+
+-- TODO: work out the `if self` checks that are in place to fix errors during
+-- compile-time const eval optimization
+
+registerOperator("geq", "ss", "n", function(self, args)
+	local op1, op2 = args[2], args[3]
+	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
+
+	if self then
+		self.prf = self.prf + math.min(#rv1, #rv2)
+	end
+
+	return rv1 >= rv2 and 1 or 0
+end)
+
+registerOperator("leq", "ss", "n", function(self, args)
+	local op1, op2 = args[2], args[3]
+	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
+
+	if self then
+		self.prf = self.prf + math.min(#rv1, #rv2)
+	end
+
+	return rv1 <= rv2 and 1 or 0
+end)
+
+registerOperator("gth", "ss", "n", function(self, args, ...)
+	local op1, op2 = args[2], args[3]
+	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
+
+	if self then
+		self.prf = self.prf + math.min(#rv1, #rv2)
+	end
+
+	return rv1 > rv2 and 1 or 0
+end)
+
+registerOperator("lth", "ss", "n", function(self, args)
+	local op1, op2 = args[2], args[3]
+	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
+
+	if self then
+		self.prf = self.prf + math.min(#rv1, #rv2)
+	end
+
+	return rv1 < rv2 and 1 or 0
 end)
 
 /******************************************************************************/


### PR DESCRIPTION
This PR adds comparison operators to strings, based on the same lexical comparisons that Lua uses; this allows users to, for example, sort an array of strings. During runtime, comparisons cost in operations the length of the smaller string.

This PR currently introduces a TODO and some nasty-ish `if self then` checks because of the [const-eval optimization](https://github.com/wiremod/wire/blob/master/lua/entities/gmod_wire_expression2/base/optimizer.lua#L43-L52) present in the E2 compiler--given that this is my first time contributing to Wire, I don't presently have any idea how to go about making this any prettier, so suggestions are welcome :).
