### PR TITLE
Refactor how E2 triggering outputs is handled

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/angle.lua
+++ b/lua/entities/gmod_wire_expression2/core/angle.lua
@@ -44,16 +44,6 @@ end
 
 /******************************************************************************/
 
-registerOperator("ass", "a", "a", function(self, args)
-	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
-	self.Scopes[scope][op1] = rv2
-	self.Scopes[scope].vclk[op1] = true
-	return rv2
-end)
-
-/******************************************************************************/
-
 e2function number operator_is(angle rv1)
 	if rv1[1] != 0 || rv1[2] != 0 || rv1[3] != 0
 	   then return 1 else return 0 end

--- a/lua/entities/gmod_wire_expression2/core/array.lua
+++ b/lua/entities/gmod_wire_expression2/core/array.lua
@@ -84,33 +84,6 @@ registerOperator( "kvarray", "", "r", function( self, args )
 end)
 
 --------------------------------------------------------------------------------
--- = operator
---------------------------------------------------------------------------------
-registerOperator("ass", "r", "r", function(self, args)
-	local lhs, op2, scope = args[2], args[3], args[4]
-	local      rhs = op2[1](self, op2)
-
-	local Scope = self.Scopes[scope]
-	if !Scope.lookup then Scope.lookup = {} end
-	local lookup = Scope.lookup
-
-	--remove old lookup entry
-	if (lookup[rhs]) then lookup[rhs][lhs] = nil end
-
-	--add new
-	if (!lookup[rhs]) then
-		lookup[rhs] = {}
-	end
-	lookup[rhs][lhs] = true
-
-	Scope[lhs] = rhs
-	Scope.vclk[lhs] = true
-	return rhs
-end)
-
-
-
---------------------------------------------------------------------------------
 -- IS operator
 --------------------------------------------------------------------------------
 e2function number operator_is(array arr)
@@ -143,7 +116,7 @@ registerCallback( "postinit", function()
 				local ret
 				if (doremove) then
 					ret = table_remove( array, index )
-					self.GlobalScope.vclk[array] = true
+					self.QueuedTriggerValues[array] = true
 				else
 					ret = array[floor(index)]
 				end
@@ -177,7 +150,7 @@ registerCallback( "postinit", function()
 				else
 					array[floor(index)] = value
 				end
-				self.GlobalScope.vclk[array] = true
+				self.QueuedTriggerValues[array] = true
 				return value
 			end
 
@@ -278,9 +251,6 @@ registerCallback( "postinit", function()
 
 						self.prf = self.prf + 3
 
-						self.Scope.vclk[keyname] = true
-						self.Scope.vclk[valname] = true
-
 						self.Scope[keyname] = key
 						self.Scope[valname] = value
 
@@ -307,7 +277,7 @@ end)
 __e2setcost(2)
 e2function number array:pop()
 	local result = table_remove( this ) and 1 or 0
-	self.GlobalScope.vclk[this] = true
+	self.QueuedTriggerValues[this] = true
 	return result
 end
 
@@ -318,7 +288,7 @@ end
 __e2setcost(3)
 e2function number array:shift()
 	local result = table_remove( this, 1 ) and 1 or 0
-	self.GlobalScope.vclk[this] = true
+	self.QueuedTriggerValues[this] = true
 	return result
 end
 
@@ -329,7 +299,7 @@ end
 __e2setcost(2)
 e2function number array:remove( index )
 	local result = table_remove( this, index ) and 1 or 0
-	self.GlobalScope.vclk[this] = true
+	self.QueuedTriggerValues[this] = true
 	return result
 end
 
@@ -341,7 +311,7 @@ end
 e2function number array:unset( index )
 	if this[index] == nil then return 0 end
 	this[index] = nil
-	self.GlobalScope.vclk[this] = true
+	self.QueuedTriggerValues[this] = true
 	return 1
 end
 

--- a/lua/entities/gmod_wire_expression2/core/bone.lua
+++ b/lua/entities/gmod_wire_expression2/core/bone.lua
@@ -88,15 +88,6 @@ e2function number operator_is(bone b)
 	if not isValidBone(b) then return 0 else return 1 end
 end
 
---- B = B
-registerOperator("ass", "b", "b", function(self, args)
-	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
-	self.Scopes[scope][op1] = rv2
-	self.Scopes[scope].vclk[op1] = true
-	return rv2
-end)
-
 --- B == B
 e2function number operator==(bone lhs, bone rhs)
 	if lhs == rhs then return 1 else return 0 end

--- a/lua/entities/gmod_wire_expression2/core/complex.lua
+++ b/lua/entities/gmod_wire_expression2/core/complex.lua
@@ -89,15 +89,6 @@ end
 
 __e2setcost(2)
 
-registerOperator("ass", "c", "c", function(self, args)
-	local lhs, op2, scope = args[2], args[3], args[4]
-	local      rhs = op2[1](self, op2)
-
-	self.Scopes[scope][lhs] = rhs
-	self.Scopes[scope].vclk[lhs] = true
-	return rhs
-end)
-
 e2function number operator_is(complex z)
 	if (z[1]==0) && (z[2]==0) then return 0 else return 1 end
 end

--- a/lua/entities/gmod_wire_expression2/core/core.lua
+++ b/lua/entities/gmod_wire_expression2/core/core.lua
@@ -94,7 +94,6 @@ registerOperator("for", "", "", function(self, args)
 	for I=rstart,rend+rdelta,rstep do
 		self:PushScope()
 		self.Scope[var] = I
-		self.Scope.vclk[var] = true
 
 		local ok, msg = pcall(op4[1], self, op4)
 		if not ok then

--- a/lua/entities/gmod_wire_expression2/core/custom/effects.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/effects.lua
@@ -48,15 +48,6 @@ registerType("effect", "xef", nil,
 
 __e2setcost(1)
 
-registerOperator("ass", "xef", "xef", function(self, args)
-	local lhs, op2, scope = args[2], args[3], args[4]
-	local rhs = op2[1](self, op2)
-
-	self.Scopes[scope][lhs] = rhs
-	self.Scopes[scope].vclk[lhs] = true
-	return rhs
-end)
-
 e2function effect effect()
 	return EffectData()
 end

--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -54,16 +54,6 @@ end
 
 __e2setcost(5) -- temporary
 
-registerOperator("ass", "e", "e", function(self, args)
-	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
-	self.Scopes[scope][op1] = rv2
-	self.Scopes[scope].vclk[op1] = true
-	return rv2
-end)
-
-/******************************************************************************/
-
 e2function number operator_is(entity ent)
 	if IsValid(ent) then return 1 else return 0 end
 end

--- a/lua/entities/gmod_wire_expression2/core/globalvars.lua
+++ b/lua/entities/gmod_wire_expression2/core/globalvars.lua
@@ -26,31 +26,6 @@ registerType( "gtable", "xgt", {},
 
 __e2setcost(1)
 
-registerOperator("ass", "xgt", "xgt", function(self, args)
-	local lhs, op2, scope = args[2], args[3], args[4]
-	local      rhs = op2[1](self, op2)
-
-	local Scope = self.Scopes[scope]
-	if !Scope.lookup then Scope.lookup = {} end
-	local lookup = Scope.lookup
-
-	-- remove old lookup entry
-	if lookup[rhs] then lookup[rhs][lhs] = nil end
-
-	-- add new lookup entry
-	local lookup_entry = lookup[rhs]
-	if not lookup_entry then
-		lookup_entry = {}
-		lookup[rhs] = lookup_entry
-	end
-	lookup_entry[lhs] = true
-
-	--Scope.vars[lhs] = rhs
-	Scope[lhs] = rhs
-	Scope.vclk[lhs] = true
-	return rhs
-end)
-
 e2function number operator_is( gtable tbl )
 	return istable(tbl) and 1 or 0
 end
@@ -245,9 +220,6 @@ registerCallback("postinit",function()
 						self:PushScope()
 
 						self.prf = self.prf + 3
-
-						self.Scope.vclk[keyname] = true
-						self.Scope.vclk[valname] = true
 
 						self.Scope[keyname] = key:sub(len + 1)
 						self.Scope[valname] = value

--- a/lua/entities/gmod_wire_expression2/core/init.lua
+++ b/lua/entities/gmod_wire_expression2/core/init.lua
@@ -112,6 +112,12 @@ function registerType(name, id, def, ...)
 	if not WireLib.DT[string.upper(name)] then
 		WireLib.DT[string.upper(name)] = { Zero = def }
 	end
+	registerOperator("ass", id, id, function(self, args)
+		local name, expression, scope = args[2], args[3], args[4]
+		local value = expression[1](self, expression)
+		self.Scopes[scope][name] = value
+		return value
+	end, 1)
 end
 
 function wire_expression2_CallHook(hookname, ...)

--- a/lua/entities/gmod_wire_expression2/core/matrix.lua
+++ b/lua/entities/gmod_wire_expression2/core/matrix.lua
@@ -87,16 +87,6 @@ e2function matrix2 identity2()
 end
 
 /******************************************************************************/
-
-registerOperator("ass", "xm2", "xm2", function(self, args)
-	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
-	self.Scopes[scope][op1] = rv2
-	self.Scopes[scope].vclk[op1] = true
-	return rv2
-end)
-
-/******************************************************************************/
 // Comparison
 
 e2function number operator_is(matrix2 rv1)
@@ -463,16 +453,6 @@ e2function matrix identity()
 			 0, 1, 0,
 			 0, 0, 1 }
 end
-
-/******************************************************************************/
-
-registerOperator("ass", "m", "m", function(self, args)
-	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
-	self.Scopes[scope][op1] = rv2
-	self.Scopes[scope].vclk[op1] = true
-	return rv2
-end)
 
 /******************************************************************************/
 // Comparison
@@ -999,16 +979,6 @@ e2function matrix4 identity4()
 			 0, 0, 1, 0,
 			 0, 0, 0, 1 }
 end
-
-/******************************************************************************/
-
-registerOperator("ass", "xm4", "xm4", function(self, args)
-	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
-	self.Scopes[scope][op1] = rv2
-	self.Scopes[scope].vclk[op1] = true
-	return rv2
-end)
 
 /******************************************************************************/
 // Comparison

--- a/lua/entities/gmod_wire_expression2/core/number.lua
+++ b/lua/entities/gmod_wire_expression2/core/number.lua
@@ -51,28 +51,16 @@ E2Lib.registerConstant("PHI", (1+sqrt(5))/2)
 
 --[[************************************************************************]]--
 
-__e2setcost(2)
-
-registerOperator("ass", "n", "n", function(self, args)
-	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
-	self.Scopes[scope][op1] = rv2
-	self.Scopes[scope].vclk[op1] = true
-	return rv2
-end)
-
 __e2setcost(1.5)
 
 registerOperator("inc", "n", "", function(self, args)
 	local op1, scope = args[2], args[3]
 	self.Scopes[scope][op1] = self.Scopes[scope][op1] + 1
-	self.Scopes[scope].vclk[op1] = true
 end)
 
 registerOperator("dec", "n", "", function(self, args)
 	local op1, scope = args[2], args[3]
 	self.Scopes[scope][op1] = self.Scopes[scope][op1] - 1
-	self.Scopes[scope].vclk[op1] = true
 end)
 
 --[[************************************************************************]]--

--- a/lua/entities/gmod_wire_expression2/core/quaternion.lua
+++ b/lua/entities/gmod_wire_expression2/core/quaternion.lua
@@ -227,19 +227,6 @@ e2function quaternion qk(n)
 end
 
 /******************************************************************************/
-
-__e2setcost(2)
-
-registerOperator("ass", "q", "q", function(self, args)
-	local lhs, op2, scope = args[2], args[3], args[4]
-	local      rhs = op2[1](self, op2)
-
-	self.Scopes[scope][lhs] = rhs
-	self.Scopes[scope].vclk[lhs] = true
-	return rhs
-end)
-
-/******************************************************************************/
 // TODO: define division as multiplication with (1/x), or is it not useful?
 
 __e2setcost(4)

--- a/lua/entities/gmod_wire_expression2/core/ranger.lua
+++ b/lua/entities/gmod_wire_expression2/core/ranger.lua
@@ -153,16 +153,6 @@ end
 
 __e2setcost(1) -- temporary
 
---- RD = RD
-registerOperator("ass", "xrd", "xrd", function(self, args)
-	local lhs, op2, scope = args[2], args[3], args[4]
-	local      rhs = op2[1](self, op2)
-
-	self.Scopes[scope][lhs] = rhs
-	self.Scopes[scope].vclk[lhs] = true
-	return rhs
-end)
-
 e2function number operator_is(ranger walker)
 	if walker then return 1 else return 0 end
 end

--- a/lua/entities/gmod_wire_expression2/core/selfaware.lua
+++ b/lua/entities/gmod_wire_expression2/core/selfaware.lua
@@ -54,7 +54,7 @@ local function setOutput( self, args, Type )
 	local rv1, rv2 = op1[1](self,op1), op2[1](self,op2)
 	if (self.entity.Outputs[rv1] and self.entity.Outputs[rv1].Type == Type) then
 		self.GlobalScope[rv1] = rv2
-		self.GlobalScope.vclk[rv1] = true
+		self.QueuedTriggerNames[rv1] = true
 	end
 end
 

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -26,16 +26,6 @@ registerType("string", "s", "",
 
 __e2setcost(3) -- temporary
 
-registerOperator("ass", "s", "s", function(self, args)
-	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
-	self.Scopes[scope][op1] = rv2
-	self.Scopes[scope].vclk[op1] = true
-	return rv2
-end)
-
-/******************************************************************************/
-
 registerOperator("is", "s", "n", function(self, args)
 	local op1 = args[2]
 	local rv1 = op1[1](self, op1)

--- a/lua/entities/gmod_wire_expression2/core/vector.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector.lua
@@ -71,16 +71,6 @@ end
 
 --------------------------------------------------------------------------------
 
-registerOperator("ass", "v", "v", function(self, args)
-	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
-	self.Scopes[scope][op1] = rv2
-	self.Scopes[scope].vclk[op1] = true
-	return rv2
-end)
-
---------------------------------------------------------------------------------
-
 e2function number vector:operator_is()
 	if this[1] > delta or -this[1] > delta or
 	   this[2] > delta or -this[2] > delta or

--- a/lua/entities/gmod_wire_expression2/core/vector2.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector2.lua
@@ -59,16 +59,6 @@ end)
 
 /******************************************************************************/
 
-registerOperator("ass", "xv2", "xv2", function(self, args)
-	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
-	self.Scopes[scope][op1] = rv2
-	self.Scopes[scope].vclk[op1] = true
-	return rv2
-end)
-
-/******************************************************************************/
-
 registerOperator("is", "xv2", "n", function(self, args)
 	local op1 = args[2]
 	local rv1 = op1[1](self, op1)
@@ -587,16 +577,6 @@ registerFunction("vec4", "vn", "xv4", function(self, args)
 	local op1, op2 = args[2], args[3]
 	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
 	return { rv1[1], rv1[2], rv1[3], rv2 }
-end)
-
-/******************************************************************************/
-
-registerOperator("ass", "xv4", "xv4", function(self, args)
-	local op1, op2, scope = args[2], args[3], args[4]
-	local      rv2 = op2[1](self, op2)
-	self.Scopes[scope][op1] = rv2
-	self.Scopes[scope].vclk[op1] = true
-	return rv2
 end)
 
 /******************************************************************************/

--- a/lua/entities/gmod_wire_expression2/core/wirelink.lua
+++ b/lua/entities/gmod_wire_expression2/core/wirelink.lua
@@ -135,18 +135,6 @@ registerType("wirelink", "xwl", nil,
 
 /******************************************************************************/
 
-__e2setcost(2) -- temporary
-
-registerOperator("ass", "xwl", "xwl", function(self, args)
-	local lhs, op2, scope = args[2], args[3], args[4]
-	local      rhs = op2[1](self, op2)
-	self.Scopes[scope][lhs] = rhs
-	self.Scopes[scope].vclk[lhs] = true
-	return rhs
-end)
-
-/******************************************************************************/
-
 e2function number operator_is(wirelink value)
 	if not validWirelink(self, value) then return 0 end
 	return 1


### PR DESCRIPTION
Before, every assignment operator would set
`self.Scopes[ScopeID].vclk[name] = true`, and then we'd trigger every
output in `self.Scopes[0].vclk`. Tables and arrays (because they're
mutable) had special handling in table.lua with a postexecute hook, and
more complex assignment operators.

Now, the assignment operator no longer sets `vclk` - instead, whenever
we assign/increment/decrement global variables, we generate a
`queueTriggerName` instruction whose only job is to add that output name
to a list of outputs to be triggered. This improves assignment
performance for most assignments, and opens the door to future
optimizations (for example, multiple writes to the same output could be
coalesced into a single `queueTriggerName`).

This pull request also uses the exact same assignment operator for each
type, which saves a lot of duplicated code.