### PR TITLE
fix e2 editor crashing when unexpected values are put in function definition

### DIFF
--- a/lua/wire/client/text_editor/modes/e2.lua
+++ b/lua/wire/client/text_editor/modes/e2.lua
@@ -333,7 +333,7 @@ function EDITOR:SyntaxColorLine(row)
     local spaces = self:SkipPattern( " *" )
     if spaces then addToken( "comment", spaces ) end
 
-    local invalidInput = self:SkipPattern( "^[^A-Z:]" )
+    local invalidInput = self:SkipPattern( "^[^A-Z:%[]" )
     if invalidInput then addToken( "notfound", invalidInput ) end
 
     if self:NextPattern( "%[" ) then -- Found a [

--- a/lua/wire/client/text_editor/modes/e2.lua
+++ b/lua/wire/client/text_editor/modes/e2.lua
@@ -333,7 +333,7 @@ function EDITOR:SyntaxColorLine(row)
     local spaces = self:SkipPattern( " *" )
     if spaces then addToken( "comment", spaces ) end
 
-    local invalidInput = self:SkipPattern( "^[^A-Z:%[]" )
+    local invalidInput = self:SkipPattern( "[^A-Z:%[]*" )
     if invalidInput then addToken( "notfound", invalidInput ) end
 
     if self:NextPattern( "%[" ) then -- Found a [

--- a/lua/wire/client/text_editor/modes/e2.lua
+++ b/lua/wire/client/text_editor/modes/e2.lua
@@ -333,6 +333,9 @@ function EDITOR:SyntaxColorLine(row)
     local spaces = self:SkipPattern( " *" )
     if spaces then addToken( "comment", spaces ) end
 
+    local invalidInput = self:SkipPattern( "^[^A-Z:]" )
+    if invalidInput then addToken( "notfound", invalidInput ) end
+
     if self:NextPattern( "%[" ) then -- Found a [
     -- Color the bracket
     addToken( "operator", self.tokendata )


### PR DESCRIPTION
A players game would crash if they put an invalid value into a function definition such as `function name(1)` or `function name("`.