### PR TITLE
Made wire constraint so wired entities don't need other constraints for duplicator to track them.

### DIFF
--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -458,7 +458,7 @@ local function WireConstraint(Ent1, Ent2)
 		Ent2 = Ent2,
 		Type = "Wire"
 	}
-	duplicator.AddConstraintTableNoDelete(Ent1, Constraint Ent2)
+	constraint.AddConstraintTableNoDelete(Ent1, Constraint, Ent2)
 	return Constraint
 end
 duplicator.RegisterConstraint("Wire", WireConstraint, "Ent1", "Ent2")

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -455,6 +455,7 @@ local function WireConstraint(Ent1, Ent2)
 		IsValid = function(self) return self.Ent1:IsValid() and self.Ent2:IsValid() end,
 		GetTable = function(self) return self end,
 		GetCreationID = function() return "Wire"..UniqueWireID end,
+		Remove = function() end,
 		Ent1 = Ent1,
 		Ent2 = Ent2,
 		Type = "Wire"

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -448,9 +448,10 @@ end
 
 local UniqueWireID = 0
 local function WireConstraint(Ent1, Ent2)
-	if constraint.Find(Ent1, Ent2, "Wire") then return end
+	local Constraint = constraint.Find(Ent1, Ent2, "Wire")
+	if Constraint then return Constraint end
 	UniqueWireID = UniqueWireID + 1
-	local Constraint = {
+	Constraint = {
 		IsValid = function(self) return self.Ent1:IsValid() and self.Ent2:IsValid() end,
 		GetTable = function(self) return self end,
 		GetCreationID = function() return "Wire"..UniqueWireID end,

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -458,7 +458,7 @@ local function WireConstraint(Ent1, Ent2)
 		Ent2 = Ent2,
 		Type = "Wire"
 	}
-	duplicator.AddConstraintTable(Ent1, Constraint Ent2)
+	duplicator.AddConstraintTableNoDelete(Ent1, Constraint Ent2)
 	return Constraint
 end
 duplicator.RegisterConstraint("Wire", WireConstraint, "Ent1", "Ent2")


### PR DESCRIPTION
Fixes #339

Untested still, but putting here for review.