### PR TITLE
Fix swapping from/to RC circumventing driver check

### DIFF
--- a/lua/weapons/remotecontroller.lua
+++ b/lua/weapons/remotecontroller.lua
@@ -94,7 +94,7 @@ function SWEP:Off()
 	self.OldMoveType = nil
 	ply:DrawViewModel(true)
 
-	if IsValid(self.Linked) then
+	if IsValid(self.Linked) and self.Linked:GetPly() == ply then
 		self.Linked:PlayerExited(ply)
 	end
 end


### PR DESCRIPTION
Changes the Remote Controller to require that you are the current driver in order to call `PlayerExited` so that swapping from and then back to the Remote Controller properly fails the occupancy-check in `SWEP:On`.

As is swapping from Remote Controller will call `PlayerExited` whether you're the current driver or not, resulting in the Pod being set inactive and allowing it to be hijacked when you swap back to the Remote Controller.