### PR TITLE
Update DHDD Size when loading a dupe

### DIFF
--- a/lua/entities/gmod_wire_dhdd.lua
+++ b/lua/entities/gmod_wire_dhdd.lua
@@ -123,6 +123,13 @@ end
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
 	if (info.DHDD) then
 		ent.Memory = (info.DHDD.Memory or {})
+
+		local size = #ent.Memory
+		if size ~= 0 or ent.Memory[0] ~= nil then
+			size = size + 1
+		end
+		self.Size = size
+
 		if info.DHDD.AllowWrite ~= nil then
 			ent.AllowWrite = info.DHDD.AllowWrite
 		end

--- a/lua/entities/gmod_wire_dhdd.lua
+++ b/lua/entities/gmod_wire_dhdd.lua
@@ -124,7 +124,7 @@ function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
 	if (info.DHDD) then
 		ent.Memory = (info.DHDD.Memory or {})
 
-		local size = #ent.Memory
+		local size = table.maxn(ent.Memory)
 		if size ~= 0 or ent.Memory[0] ~= nil then
 			size = size + 1
 		end

--- a/lua/entities/gmod_wire_dhdd.lua
+++ b/lua/entities/gmod_wire_dhdd.lua
@@ -87,7 +87,7 @@ function ENT:TriggerInput( name, value )
 		--     {} ⇒ 0
 		--     { 0 = 0 } ⇒ 1
 		--     { 1 = 1 }, { 0 = 0, 1 = 1 } ⇒ 2
-		local size = #value
+		local size = table.maxn(value)
 		if size ~= 0 or value[0] ~= nil then
 			size = size + 1
 		end


### PR DESCRIPTION
Previously it would still load the data *itself* correctly, but not update the `Size` variable (which is responsible for the Size output and the tooltip).
The code is just a copy of the code from the `TriggerInput` function.

Looks like this was forgotten when [rewriting the size to be deterministic](https://github.com/wiremod/wire/commit/3f37ae3af9fe8822dd70b9737cf300924943df6f#diff-ceb36a5071fc2279f9f851f86e8aefa1).