### PR TITLE
Add Visual Studio cache directory to the gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .svn/
 luac.out
-/.vs
+.vs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .svn/
 luac.out
+
+# Cache/Options directory for Visual Studio 2015 and higher
 .vs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .svn/
 luac.out
+/.vs


### PR DESCRIPTION
Since VS2015 and Visual Studio Code, they create this folder which store cache/options stuff, when opening a repository folder.
Removing the folder is not really possible, because file inside is being used by editor.
It becomes annoying to use stashing all the time while contributing.