### PR TITLE
Better outlines/line strips and vertices caching

### DIFF
--- a/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
@@ -317,34 +317,34 @@ function EGP:DrawPath( vertices, size, closed )
 					local dir = {x=(x2-x1)/len, y=(y2-y1)/len}
 					if x1 ~= x2 or y1 ~= y2 then -- cannot get direction between identical points, just skip it
 						if not closed and i==1 then -- very first segment, just start perpendicular (TODO: maybe move before the loop)
-							corners[#corners+1] = { r={x=x1-dir.y*size, y=y1+dir.x*size}, l={x=x1+dir.y*size, y=y1-dir.x*size}}
+							corners[#corners+1] = { r={x=x1-dir.y*size, y=y1+dir.x*size}, l={x=x1+dir.y*size, y=y1-dir.x*size} }
 						else
 							local dot = dir.x*lastdir.x + dir.y*lastdir.y
 							local scaling = size*math.tan(math.acos(dot)/2) -- complicated math, could be also be `size*sqrt(1-dot)/sqrt(dot+1)` (no idea what is faster)
-							if dot == 1 then
+							if dot >= 1 then -- also account for rounding errors, somehow the dot product can be >1, which makes scaling nan
 								-- direction stays the same, no need for a corner, just skip this point, unless it is the last segment of a closed path (last segment of a open path is handled explicitly above)
 								if i == num+1 then
-									corners[#corners+1] = { r={x=x1-dir.y*size, y=y1+dir.x*size}, l={x=x1+dir.y*size, y=y1-dir.x*size}}
+									corners[#corners+1] = { r={x=x1-dir.y*size, y=y1+dir.x*size}, l={x=x1+dir.y*size, y=y1-dir.x*size} }
 								end
-							elseif dot == -1 then -- new direction is inverse, just add perpendicular nodes
-								corners[#corners+1] = { r={x=x1-dir.y*size, y=y1+dir.x*size}, l={x=x1+dir.y*size, y=y1-dir.x*size}}
+							elseif dot <= -1 then -- new direction is inverse, just add perpendicular nodes
+								corners[#corners+1] = { r={x=x1-dir.y*size, y=y1+dir.x*size}, l={x=x1+dir.y*size, y=y1-dir.x*size} }
 							elseif dir.x*-lastdir.y + dir.y*lastdir.x > 0 then -- right bend, checked by getting the dot product between dir and lastDir:rotate(90)
 								local offsetx = -lastdir.y*size-lastdir.x*scaling
 								local offsety = lastdir.x*size-lastdir.y*scaling
 								if dot < 0 then -- sharp corner, add two points to the outer edge to not have insanely long spikes
-									corners[#corners+1] = { r={x=x1+offsetx, y=y1+offsety}, l={x=x1+(lastdir.x+lastdir.y)*size, y=y1+(lastdir.y-lastdir.x)*size}}
-									corners[#corners+1] = { r={x=x1+offsetx, y=y1+offsety}, l={x=x1-(dir.x-dir.y)*size, y=y1-(dir.y+dir.x)*size}}
+									corners[#corners+1] = { r={x=x1+offsetx, y=y1+offsety}, l={x=x1+(lastdir.x+lastdir.y)*size, y=y1+(lastdir.y-lastdir.x)*size} }
+									corners[#corners+1] = { r={x=x1+offsetx, y=y1+offsety}, l={x=x1-(dir.x-dir.y)*size, y=y1-(dir.y+dir.x)*size} }
 								else
-									corners[#corners+1] = { r={x=x1+offsetx, y=y1+offsety}, l={x=x1-offsetx, y=y1-offsety}}
+									corners[#corners+1] = { r={x=x1+offsetx, y=y1+offsety}, l={x=x1-offsetx, y=y1-offsety} }
 								end
 							else -- left bend
 								local offsetx = lastdir.y*size-lastdir.x*scaling
 								local offsety = -lastdir.x*size-lastdir.y*scaling
 								if dot < 0 then
-									corners[#corners+1] = { l={x=x1+offsetx, y=y1+offsety}, r={x=x1+(lastdir.x-lastdir.y)*size, y=y1+(lastdir.y+lastdir.x)*size}}
-									corners[#corners+1] = { l={x=x1+offsetx, y=y1+offsety}, r={x=x1-(dir.x+dir.y)*size, y=y1-(dir.y-dir.x)*size}}
+									corners[#corners+1] = { l={x=x1+offsetx, y=y1+offsety}, r={x=x1+(lastdir.x-lastdir.y)*size, y=y1+(lastdir.y+lastdir.x)*size} }
+									corners[#corners+1] = { l={x=x1+offsetx, y=y1+offsety}, r={x=x1-(dir.x+dir.y)*size, y=y1-(dir.y-dir.x)*size} }
 								else
-									corners[#corners+1] = { l={x=x1+offsetx, y=y1+offsety}, r={x=x1-offsetx, y=y1-offsety}}
+									corners[#corners+1] = { l={x=x1+offsetx, y=y1+offsety}, r={x=x1-offsetx, y=y1-offsety} }
 								end
 							end
 						end

--- a/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
@@ -240,8 +240,8 @@ function EGP:CacheNeedsUpdate(obj, keys)
 	if not obj.vert_cache then obj.vert_cache = {} end
 	local cache = obj.vert_cache
 	local update = false
-	for i,k in pairs(keys) do
-		if cache[k] != obj[k] then
+	for _,k in pairs(keys) do
+		if cache[k] ~= obj[k] then
 			update = true
 			cache[k] = obj[k]
 		end

--- a/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
@@ -259,92 +259,6 @@ function EGP:DrawLine( x, y, x2, y2, size )
 end
 
 function EGP:DrawPath( vertices, size, closed )
-	if false then
-		EGP:DrawPathPoly(vertices, size, closed)
-		return 1
-	end
-
-	if size < 1 then size = 1 end
-	local num = #vertices
-
-	if size == 1 then
-		local last = vertices[1]
-		for i=2, num do
-			local v = vertices[i]
-			surface.DrawLine( last.x, last.y, v.x, v.y )
-			last = v
-		end
-		if closed then
-			surface.DrawLine( last.x, last.y, vertices[1].x, vertices[1].y )
-		end
-	else
-		local x1 = vertices[1].x
-		local y1 = vertices[1].y
-
-		for i=2, closed and num+1 or num do
-			local v2 = i==num+1 and vertices[1] or vertices[i]
-			local x2 = v2.x
-			local y2 = v2.y
-			local tempx = x2
-			local tempy = y2
-
-			local len = math.sqrt( (x2-x1) ^ 2 + (y2-y1) ^ 2 )
-			local dir = {x=(x2-x1)/len, y=(y2-y1)/len}
-
-			if closed and i==2 then
-				-- Offset start point to match with closing line
-				local x0 = vertices[num-1].x
-				local y0 = vertices[num-1].y
-				local len0 = math.sqrt( (x1-x0) ^ 2 + (y1-y0) ^ 2 )
-				local dir0 = {x=(x1-x0)/len0, y=(y1-y0)/len0}
-
-				local dot = dir0.x*dir.x + dir0.y*dir.y -- angle between previous line segment and this one
-				if dot>=0 then
-					local shift = size/2 * math.tan(math.acos(dot)/2)
-					x1 = x1 - shift * dir.x
-					y1 = y1 - shift * dir.y
-					len = len+shift
-				end
-			end
-
-			if closed or i<num then
-				-- Offset end point to match with next line
-				local v3 = i<num and vertices[i+1] or vertices[i+1-num]
-				local x3 = v3.x
-				local y3 = v3.y
-				local len2 = math.sqrt( (x3-x2) ^ 2 + (y3-y2) ^ 2 )
-				local dir2 = {x=(x3-x2)/len2, y=(y3-y2)/len2}
-
-				local dot = dir.x*dir2.x + dir.y*dir2.y -- angle between current line segment and the next one
-				if dot>=0 then
-					local shift = size/2 * math.tan(math.acos(dot)/2)
-					x2 = x2 + shift * dir.x
-					y2 = y2 + shift * dir.y
-					len = len+shift
-
-					tempx = tempx - shift * dir2.x
-					tempy = tempy - shift * dir2.y
-				end
-			end
-			-- Calculate position
-			local xc = (x1 + x2) / 2
-			local yc = (y1 + y2) / 2
-
-			-- Calculate angle (Thanks to Fizyk)
-			local angle = math.deg(math.atan2(y1-y2,x2-x1))
-
-			-- if the rectangle's less than a pixel wide, nothing will get drawn.
-			if len < 1 then len = 1 end
-
-			surface.DrawTexturedRectRotated( math.Round(xc), math.Round(yc), math.ceil(len), size, angle )
-
-			x1 = tempx
-			y1 = tempy
-		end
-	end
-end
-
-function EGP:DrawPathPoly( vertices, size, closed )
 	if size < 1 then size = 1 end
 	local num = #vertices
 
@@ -398,11 +312,21 @@ function EGP:DrawPathPoly( vertices, size, closed )
 						elseif dir.x*-lastdir.y+dir.y*lastdir.x>0 then -- right bend, checked by getting the dot product between dir and lastDir:rotate(90)
 							local offsetx = -lastdir.y*size-lastdir.x*scaling
 							local offsety = lastdir.x*size-lastdir.y*scaling
-							corners[#corners+1] = { r={x=x1+offsetx, y=y1+offsety}, l={x=x1-offsetx, y=y1-offsety}}
+							if dot<0 then -- sharp corner, add two points to the outer edge to not have insanely long spikes
+								corners[#corners+1] = { r={x=x1+offsetx, y=y1+offsety}, l={x=x1+(lastdir.x+lastdir.y)*size, y=y1+(lastdir.y-lastdir.x)*size}}
+								corners[#corners+1] = { r={x=x1+offsetx, y=y1+offsety}, l={x=x1-(dir.x-dir.y)*size, y=y1-(dir.y+dir.x)*size}}
+							else
+								corners[#corners+1] = { r={x=x1+offsetx, y=y1+offsety}, l={x=x1-offsetx, y=y1-offsety}}
+							end
 						else -- left bend
 							local offsetx = lastdir.y*size-lastdir.x*scaling
 							local offsety = -lastdir.x*size-lastdir.y*scaling
-							corners[#corners+1] = { l={x=x1+offsetx, y=y1+offsety}, r={x=x1-offsetx, y=y1-offsety}}
+							if dot<0 then
+								corners[#corners+1] = { l={x=x1+offsetx, y=y1+offsety}, r={x=x1+(lastdir.x-lastdir.y)*size, y=y1+(lastdir.y+lastdir.x)*size}}
+								corners[#corners+1] = { l={x=x1+offsetx, y=y1+offsety}, r={x=x1-(dir.x+dir.y)*size, y=y1-(dir.y-dir.x)*size}}
+							else
+								corners[#corners+1] = { l={x=x1+offsetx, y=y1+offsety}, r={x=x1-offsetx, y=y1-offsety}}
+							end
 						end
 					end
 					lastdir = dir

--- a/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
@@ -235,6 +235,20 @@ else
 	end)
 end
 
+-- Used to check if the cached vertices of egpCircle etc are still valid, and if not update to the current values
+function EGP:CacheNeedsUpdate(obj, keys)
+	if not obj.vert_cache then obj.vert_cache = {} end
+	local cache = obj.vert_cache
+	local update = false
+	for i,k in pairs(keys) do
+		if cache[k] != obj[k] then
+			update = true
+			cache[k] = obj[k]
+		end
+	end
+	return update
+end
+
 -- Line drawing helper function
 function EGP:DrawLine( x, y, x2, y2, size )
 	if (size < 1) then size = 1 end
@@ -275,63 +289,68 @@ function EGP:DrawPath( vertices, size, closed )
 		end
 	else
 		size = size/2 -- simplify calculations
-		local corners = {}
-		local lastdir = {x=0, y=0}
-		if closed then
-			local x1 = vertices[num].x
-			local y1 = vertices[num].y
-			local x2 = vertices[1].x
-			local y2 = vertices[1].y
-			local len = math.sqrt( (x2-x1) ^ 2 + (y2-y1) ^ 2 )
-			lastdir = {x=(x2-x1)/len, y=(y2-y1)/len} -- initialize lastdir so first segment can be drawn normally
-		end
-		for i=1, closed and num+1 or num do
-			local v1 = i==num+1 and vertices[1] or vertices[i]
-			local x1 = v1.x
-			local y1 = v1.y
-
-			if not closed and i==num then -- very last segment, just end perpendicular (TODO: maybe move after the loop)
-				corners[#corners+1] = { r={x=x1-lastdir.y*size, y=y1+lastdir.x*size}, l={x=x1+lastdir.y*size, y=y1-lastdir.x*size}}
-			else
-				local v2 = i<num and vertices[i+1] or vertices[i+1-num]
-				local x2 = v2.x
-				local y2 = v2.y
-
+		local corners = vertices.outline_cache
+		if vertices.outline_cache_size != size then -- check if the outline was cached already
+			corners = {}
+			local lastdir = {x=0, y=0}
+			if closed then
+				local x1 = vertices[num].x
+				local y1 = vertices[num].y
+				local x2 = vertices[1].x
+				local y2 = vertices[1].y
 				local len = math.sqrt( (x2-x1) ^ 2 + (y2-y1) ^ 2 )
-				local dir = {x=(x2-x1)/len, y=(y2-y1)/len}
-				if x1!=x2 or y1!=y2 then -- cannot get direction between identical points, just skip it
-					if not closed and i==1 then -- very first segment, just start perpendicular (TODO: maybe move before the loop)
-						corners[#corners+1] = { r={x=x1-dir.y*size, y=y1+dir.x*size}, l={x=x1+dir.y*size, y=y1-dir.x*size}}
-					else
-						local dot = dir.x*lastdir.x + dir.y*lastdir.y
-						local scaling = size*math.tan(math.acos(dot)/2) -- complicated math, could be also be `size*sqrt(1-dot)/sqrt(dot+1)` (no idea what is faster)
-						if dot==1 then
-							-- direction stays the same, no need for a corner, just skip this point
-						elseif dot==-1 then -- new direction is inverse, just add perpendicular nodes
+				lastdir = {x=(x2-x1)/len, y=(y2-y1)/len} -- initialize lastdir so first segment can be drawn normally
+			end
+			for i=1, (closed and num+1 or num) do
+				local v1 = i==num+1 and vertices[1] or vertices[i]
+				local x1 = v1.x
+				local y1 = v1.y
+
+				if not closed and i==num then -- very last segment, just end perpendicular (TODO: maybe move after the loop)
+					corners[#corners+1] = { r={x=x1-lastdir.y*size, y=y1+lastdir.x*size}, l={x=x1+lastdir.y*size, y=y1-lastdir.x*size}}
+				else
+					local v2 = i<num and vertices[i+1] or vertices[i+1-num]
+					local x2 = v2.x
+					local y2 = v2.y
+
+					local len = math.sqrt( (x2-x1) ^ 2 + (y2-y1) ^ 2 )
+					local dir = {x=(x2-x1)/len, y=(y2-y1)/len}
+					if x1!=x2 or y1!=y2 then -- cannot get direction between identical points, just skip it
+						if not closed and i==1 then -- very first segment, just start perpendicular (TODO: maybe move before the loop)
 							corners[#corners+1] = { r={x=x1-dir.y*size, y=y1+dir.x*size}, l={x=x1+dir.y*size, y=y1-dir.x*size}}
-						elseif dir.x*-lastdir.y+dir.y*lastdir.x>0 then -- right bend, checked by getting the dot product between dir and lastDir:rotate(90)
-							local offsetx = -lastdir.y*size-lastdir.x*scaling
-							local offsety = lastdir.x*size-lastdir.y*scaling
-							if dot<0 then -- sharp corner, add two points to the outer edge to not have insanely long spikes
-								corners[#corners+1] = { r={x=x1+offsetx, y=y1+offsety}, l={x=x1+(lastdir.x+lastdir.y)*size, y=y1+(lastdir.y-lastdir.x)*size}}
-								corners[#corners+1] = { r={x=x1+offsetx, y=y1+offsety}, l={x=x1-(dir.x-dir.y)*size, y=y1-(dir.y+dir.x)*size}}
-							else
-								corners[#corners+1] = { r={x=x1+offsetx, y=y1+offsety}, l={x=x1-offsetx, y=y1-offsety}}
-							end
-						else -- left bend
-							local offsetx = lastdir.y*size-lastdir.x*scaling
-							local offsety = -lastdir.x*size-lastdir.y*scaling
-							if dot<0 then
-								corners[#corners+1] = { l={x=x1+offsetx, y=y1+offsety}, r={x=x1+(lastdir.x-lastdir.y)*size, y=y1+(lastdir.y+lastdir.x)*size}}
-								corners[#corners+1] = { l={x=x1+offsetx, y=y1+offsety}, r={x=x1-(dir.x+dir.y)*size, y=y1-(dir.y-dir.x)*size}}
-							else
-								corners[#corners+1] = { l={x=x1+offsetx, y=y1+offsety}, r={x=x1-offsetx, y=y1-offsety}}
+						else
+							local dot = dir.x*lastdir.x + dir.y*lastdir.y
+							local scaling = size*math.tan(math.acos(dot)/2) -- complicated math, could be also be `size*sqrt(1-dot)/sqrt(dot+1)` (no idea what is faster)
+							if dot==1 then
+								-- direction stays the same, no need for a corner, just skip this point
+							elseif dot==-1 then -- new direction is inverse, just add perpendicular nodes
+								corners[#corners+1] = { r={x=x1-dir.y*size, y=y1+dir.x*size}, l={x=x1+dir.y*size, y=y1-dir.x*size}}
+							elseif dir.x*-lastdir.y+dir.y*lastdir.x>0 then -- right bend, checked by getting the dot product between dir and lastDir:rotate(90)
+								local offsetx = -lastdir.y*size-lastdir.x*scaling
+								local offsety = lastdir.x*size-lastdir.y*scaling
+								if dot<0 then -- sharp corner, add two points to the outer edge to not have insanely long spikes
+									corners[#corners+1] = { r={x=x1+offsetx, y=y1+offsety}, l={x=x1+(lastdir.x+lastdir.y)*size, y=y1+(lastdir.y-lastdir.x)*size}}
+									corners[#corners+1] = { r={x=x1+offsetx, y=y1+offsety}, l={x=x1-(dir.x-dir.y)*size, y=y1-(dir.y+dir.x)*size}}
+								else
+									corners[#corners+1] = { r={x=x1+offsetx, y=y1+offsety}, l={x=x1-offsetx, y=y1-offsety}}
+								end
+							else -- left bend
+								local offsetx = lastdir.y*size-lastdir.x*scaling
+								local offsety = -lastdir.x*size-lastdir.y*scaling
+								if dot<0 then
+									corners[#corners+1] = { l={x=x1+offsetx, y=y1+offsety}, r={x=x1+(lastdir.x-lastdir.y)*size, y=y1+(lastdir.y+lastdir.x)*size}}
+									corners[#corners+1] = { l={x=x1+offsetx, y=y1+offsety}, r={x=x1-(dir.x+dir.y)*size, y=y1-(dir.y-dir.x)*size}}
+								else
+									corners[#corners+1] = { l={x=x1+offsetx, y=y1+offsety}, r={x=x1-offsetx, y=y1-offsety}}
+								end
 							end
 						end
+						lastdir = dir
 					end
-					lastdir = dir
 				end
 			end
+			vertices.outline_cache = corners
+			vertices.outline_cache_size = size
 		end
 		for i=2, #corners, 2 do
 			local verts

--- a/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
@@ -325,6 +325,7 @@ function EGP:DrawPath( vertices, size, closed )
 								-- direction stays the same, no need for a corner, just skip this point, unless it is the last segment of a closed path (last segment of a open path is handled explicitly above)
 								if i == num+1 then
 									corners[#corners+1] = { r={x=x1-dir.y*size, y=y1+dir.x*size}, l={x=x1+dir.y*size, y=y1-dir.x*size}}
+								end
 							elseif dot == -1 then -- new direction is inverse, just add perpendicular nodes
 								corners[#corners+1] = { r={x=x1-dir.y*size, y=y1+dir.x*size}, l={x=x1+dir.y*size, y=y1-dir.x*size}}
 							elseif dir.x*-lastdir.y + dir.y*lastdir.x > 0 then -- right bend, checked by getting the dot product between dir and lastDir:rotate(90)

--- a/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
@@ -350,15 +350,14 @@ function EGP:DrawPathPoly( vertices, size, closed )
 
 
 	if size == 1 then -- size 1 => just normal lines
-		if closed then -- if closed shape, duplicate first point to end
-			vertices[num+1] = vertices[1]
-			num = num+1
-		end
 		local last = vertices[1]
 		for i=2, num do
 			local v = vertices[i]
 			surface.DrawLine( last.x, last.y, v.x, v.y )
 			last = v
+		end
+		if closed then
+			surface.DrawLine( last.x, last.y, vertices[1].x, vertices[1].y )
 		end
 	else
 		size = size/2 -- simplify calculations
@@ -371,20 +370,18 @@ function EGP:DrawPathPoly( vertices, size, closed )
 			local y2 = vertices[1].y
 			local len = math.sqrt( (x2-x1) ^ 2 + (y2-y1) ^ 2 )
 			lastdir = {x=(x2-x1)/len, y=(y2-y1)/len} -- initialize lastdir so first segment can be drawn normally
-
-			vertices[num+1] = vertices[1] -- close off shape
-			num = num+1
-			vertices[num+1] = vertices[2] -- pad so last segment can be drawn normally
 		end
-		for i=1, num do
-			local x1 = vertices[i].x
-			local y1 = vertices[i].y
+		for i=1, closed and num+1 or num do
+			local v1 = i==num+1 and vertices[1] or vertices[i]
+			local x1 = v1.x
+			local y1 = v1.y
 
 			if not closed and i==num then -- very last segment, just end perpendicular (TODO: maybe move after the loop)
 				corners[#corners+1] = { r={x=x1-lastdir.y*size, y=y1+lastdir.x*size}, l={x=x1+lastdir.y*size, y=y1-lastdir.x*size}}
 			else
-				local x2 = vertices[i+1].x
-				local y2 = vertices[i+1].y
+				local v2 = i<num and vertices[i+1] or vertices[i+1-num]
+				local x2 = v2.x
+				local y2 = v2.y
 
 				local len = math.sqrt( (x2-x1) ^ 2 + (y2-y1) ^ 2 )
 				local dir = {x=(x2-x1)/len, y=(y2-y1)/len}

--- a/lua/entities/gmod_wire_egp/lib/objects/circle.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/circle.lua
@@ -5,28 +5,29 @@ Obj.fidelity = 180
 local cos, sin, rad, floor = math.cos, math.sin, math.rad, math.floor
 Obj.Draw = function( self )
 	if (self.a>0 and self.w > 0 and self.h > 0) then
-		local vertices = {}
-		local ang = -rad(self.angle)
-		local c = cos(ang)
-		local s = sin(ang)
-		for i=0,360,floor(360/self.fidelity) do
-			local radd = rad(i)
-			local x = cos(radd)
-			local u = (x+1)/2
-			local y = sin(radd)
-			local v = (y+1)/2
+		if EGP:CacheNeedsUpdate(self, {"x", "y", "w", "h", "angle", "fidelity"}) then
+			local vertices = {}
+			local ang = -rad(self.angle)
+			local c = cos(ang)
+			local s = sin(ang)
+			for i=0,360,floor(360/self.fidelity) do
+				local radd = rad(i)
+				local x = cos(radd)
+				local u = (x+1)/2
+				local y = sin(radd)
+				local v = (y+1)/2
 
-			local tempx = x * self.w * c - y * self.h * s + self.x
-			y = x * self.w * s + y * self.h * c + self.y
-			x = tempx
+				local tempx = x * self.w * c - y * self.h * s + self.x
+				y = x * self.w * s + y * self.h * c + self.y
+				x = tempx
 
-			vertices[#vertices+1] = { x = x, y = y, u = u, v = v }
+				vertices[#vertices+1] = { x = x, y = y, u = u, v = v }
+			end
+			self.vert_cache.verts = vertices
 		end
 
 		surface.SetDrawColor( self.r, self.g, self.b, self.a )
-		if (vertices and #vertices>0) then
-			surface.DrawPoly( vertices )
-		end
+		surface.DrawPoly( self.vert_cache.verts )
 	end
 end
 Obj.Transmit = function( self )

--- a/lua/entities/gmod_wire_egp/lib/objects/circleoutline.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/circleoutline.lua
@@ -3,7 +3,7 @@ local Obj = EGP:NewObject( "CircleOutline" )
 Obj.angle = 0
 Obj.size = 1
 Obj.fidelity = 180
-local cos, sin, rad, floor = math.cos, math.sin, math.rad, math.floor
+local cos, sin, rad = math.cos, math.sin, math.rad
 Obj.Draw = function( self )
 	if (self.a>0 and self.w > 0 and self.h > 0) then
 		if EGP:CacheNeedsUpdate(self, {"x", "y", "w", "h", "angle", "fidelity"}) then
@@ -19,7 +19,7 @@ Obj.Draw = function( self )
 				y = x * self.w * s + y * self.h * c + self.y
 				x = tempx
 
-				vertices[#vertices+1] = { x = x, y = y, u = u, v = v }
+				vertices[#vertices+1] = { x = x, y = y }
 			end
 			self.vert_cache.verts = vertices
 		end

--- a/lua/entities/gmod_wire_egp/lib/objects/circleoutline.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/circleoutline.lua
@@ -10,8 +10,8 @@ Obj.Draw = function( self )
 		local ang = -rad(self.angle)
 		local c = cos(ang)
 		local s = sin(ang)
-		for i=0,360,360/self.fidelity do
-			local radd = rad(i)
+		for i=0,self.fidelity-1 do
+			local radd = rad(i*360/self.fidelity)
 			local x = cos(radd)
 			local y = sin(radd)
 
@@ -23,18 +23,7 @@ Obj.Draw = function( self )
 		end
 
 		surface.SetDrawColor( self.r, self.g, self.b, self.a )
-
-		local n = #vertices
-		for i=1, n do
-			local v = vertices[i]
-			if (i+1<=n) then
-				local x, y = v.x, v.y
-				local x2, y2 = vertices[i+1].x, vertices[i+1].y
-				EGP:DrawLine( x, y, x2, y2, self.size )
-			end
-		end
-
-		EGP:DrawLine( vertices[n].x, vertices[n].y, vertices[1].x, vertices[1].y, self.size )
+		EGP:DrawPath(vertices, self.size, true)
 	end
 end
 Obj.Transmit = function( self )

--- a/lua/entities/gmod_wire_egp/lib/objects/circleoutline.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/circleoutline.lua
@@ -23,7 +23,8 @@ Obj.Draw = function( self )
 		end
 
 		surface.SetDrawColor( self.r, self.g, self.b, self.a )
-		EGP:DrawPath(vertices, self.size, true)
+		--EGP:DrawPath(vertices, self.size, true)
+		EGP:DrawPathPoly(vertices, self.size, true)
 	end
 end
 Obj.Transmit = function( self )

--- a/lua/entities/gmod_wire_egp/lib/objects/circleoutline.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/circleoutline.lua
@@ -10,8 +10,7 @@ Obj.Draw = function( self )
 		local ang = -rad(self.angle)
 		local c = cos(ang)
 		local s = sin(ang)
-		for i=0,self.fidelity-1 do
-			local radd = rad(i*360/self.fidelity)
+		for radd=0, 2*math.pi*(1 - 0.5/self.fidelity), 2*math.pi/self.fidelity do
 			local x = cos(radd)
 			local y = sin(radd)
 
@@ -23,8 +22,7 @@ Obj.Draw = function( self )
 		end
 
 		surface.SetDrawColor( self.r, self.g, self.b, self.a )
-		--EGP:DrawPath(vertices, self.size, true)
-		EGP:DrawPathPoly(vertices, self.size, true)
+		EGP:DrawPath(vertices, self.size, true)
 	end
 end
 Obj.Transmit = function( self )

--- a/lua/entities/gmod_wire_egp/lib/objects/circleoutline.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/circleoutline.lua
@@ -6,23 +6,26 @@ Obj.fidelity = 180
 local cos, sin, rad, floor = math.cos, math.sin, math.rad, math.floor
 Obj.Draw = function( self )
 	if (self.a>0 and self.w > 0 and self.h > 0) then
-		local vertices = {}
-		local ang = -rad(self.angle)
-		local c = cos(ang)
-		local s = sin(ang)
-		for radd=0, 2*math.pi*(1 - 0.5/self.fidelity), 2*math.pi/self.fidelity do
-			local x = cos(radd)
-			local y = sin(radd)
+		if EGP:CacheNeedsUpdate(self, {"x", "y", "w", "h", "angle", "fidelity"}) then
+			local vertices = {}
+			local ang = -rad(self.angle)
+			local c = cos(ang)
+			local s = sin(ang)
+			for radd=0, 2*math.pi*(1 - 0.5/self.fidelity), 2*math.pi/self.fidelity do
+				local x = cos(radd)
+				local y = sin(radd)
 
-			local tempx = x * self.w * c - y * self.h * s + self.x
-			y = x * self.w * s + y * self.h * c + self.y
-			x = tempx
+				local tempx = x * self.w * c - y * self.h * s + self.x
+				y = x * self.w * s + y * self.h * c + self.y
+				x = tempx
 
-			vertices[#vertices+1] = { x = x, y = y, u = u, v = v }
+				vertices[#vertices+1] = { x = x, y = y, u = u, v = v }
+			end
+			self.vert_cache.verts = vertices
 		end
 
 		surface.SetDrawColor( self.r, self.g, self.b, self.a )
-		EGP:DrawPath(vertices, self.size, true)
+		EGP:DrawPath(self.vert_cache.verts, self.size, true)
 	end
 end
 Obj.Transmit = function( self )

--- a/lua/entities/gmod_wire_egp/lib/objects/linestrip.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/linestrip.lua
@@ -11,10 +11,8 @@ Obj.Draw = function( self )
 	local n = #self.vertices
 	if (self.a>0 and n>0 and self.size>0) then
 		surface.SetDrawColor( self.r, self.g, self.b, self.a )
-		for i=1,(n-1) do
-			local p1,p2 = self.vertices[i],self.vertices[1+i]
-			EGP:DrawLine( p1.x, p1.y, p2.x, p2.y, self.size )
-		end
+
+		EGP:DrawPath(self.vertices, self.size, false)
 	end
 end
 Obj.Transmit = function( self, Ent, ply )

--- a/lua/entities/gmod_wire_egp/lib/objects/linestrip.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/linestrip.lua
@@ -12,7 +12,8 @@ Obj.Draw = function( self )
 	if (self.a>0 and n>0 and self.size>0) then
 		surface.SetDrawColor( self.r, self.g, self.b, self.a )
 
-		EGP:DrawPath(self.vertices, self.size, false)
+		--EGP:DrawPath(self.vertices, self.size, false)
+		EGP:DrawPathPoly(self.vertices, self.size, false)
 	end
 end
 Obj.Transmit = function( self, Ent, ply )

--- a/lua/entities/gmod_wire_egp/lib/objects/linestrip.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/linestrip.lua
@@ -30,7 +30,7 @@ Obj.Receive = function( self )
 	local tbl = {}
 	tbl.vertices = {}
 	for i=1,net.ReadUInt(16) do
-		tbl.vertices[ #tbl.vertices+1 ] = { x = net.ReadInt(16), y = net.ReadInt(16) }
+		tbl.vertices[ i ] = { x = net.ReadInt(16), y = net.ReadInt(16) }
 	end
 	tbl.parent = net.ReadInt(16)
 	tbl.size = net.ReadInt(16)

--- a/lua/entities/gmod_wire_egp/lib/objects/linestrip.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/linestrip.lua
@@ -12,8 +12,7 @@ Obj.Draw = function( self )
 	if (self.a>0 and n>0 and self.size>0) then
 		surface.SetDrawColor( self.r, self.g, self.b, self.a )
 
-		--EGP:DrawPath(self.vertices, self.size, false)
-		EGP:DrawPathPoly(self.vertices, self.size, false)
+		EGP:DrawPath(self.vertices, self.size, false)
 	end
 end
 Obj.Transmit = function( self, Ent, ply )

--- a/lua/entities/gmod_wire_egp/lib/objects/poly.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/poly.lua
@@ -43,8 +43,8 @@ end
 Obj.Receive = function( self )
 	local tbl = {}
 	tbl.vertices = {}
-	for _ = 1, net.ReadUInt(8) do
-		tbl.vertices[ #tbl.vertices+1 ] = { x = net.ReadInt(16), y = net.ReadInt(16), u = net.ReadFloat(), v = net.ReadFloat() }
+	for i = 1, net.ReadUInt(8) do
+		tbl.vertices[ i ] = { x = net.ReadInt(16), y = net.ReadInt(16), u = net.ReadFloat(), v = net.ReadFloat() }
 	end
 	tbl.filtering = net.ReadUInt(2)
 	tbl.parent = net.ReadInt(16)

--- a/lua/entities/gmod_wire_egp/lib/objects/polyoutline.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/polyoutline.lua
@@ -29,7 +29,7 @@ Obj.Receive = function( self )
 	local tbl = {}
 	tbl.vertices = {}
 	for i=1,net.ReadUInt(16) do
-		tbl.vertices[ #tbl.vertices+1 ] = { x = net.ReadInt(16), y = net.ReadInt(16) }
+		tbl.vertices[ i ] = { x = net.ReadInt(16), y = net.ReadInt(16) }
 	end
 	tbl.parent = net.ReadInt(16)
 	tbl.size = net.ReadInt(16)

--- a/lua/entities/gmod_wire_egp/lib/objects/polyoutline.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/polyoutline.lua
@@ -11,10 +11,7 @@ Obj.Draw = function( self )
 	local n = #self.vertices
 	if (self.a>0 and n>0 and self.size>0) then
 		surface.SetDrawColor( self.r, self.g, self.b, self.a )
-		for i=1,n do
-			local p1,p2 = self.vertices[i],self.vertices[1+i%n]
-			EGP:DrawLine( p1.x, p1.y, p2.x, p2.y, self.size )
-		end
+		EGP:DrawPath(self.vertices, self.size, true)
 	end
 end
 Obj.Transmit = function( self, Ent, ply )

--- a/lua/entities/gmod_wire_egp/lib/objects/polyoutline.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/polyoutline.lua
@@ -11,8 +11,7 @@ Obj.Draw = function( self )
 	local n = #self.vertices
 	if (self.a>0 and n>0 and self.size>0) then
 		surface.SetDrawColor( self.r, self.g, self.b, self.a )
-		--EGP:DrawPath(self.vertices, self.size, true)
-		EGP:DrawPathPoly(self.vertices, self.size, true)
+		EGP:DrawPath(self.vertices, self.size, true)
 	end
 end
 Obj.Transmit = function( self, Ent, ply )

--- a/lua/entities/gmod_wire_egp/lib/objects/polyoutline.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/polyoutline.lua
@@ -11,7 +11,8 @@ Obj.Draw = function( self )
 	local n = #self.vertices
 	if (self.a>0 and n>0 and self.size>0) then
 		surface.SetDrawColor( self.r, self.g, self.b, self.a )
-		EGP:DrawPath(self.vertices, self.size, true)
+		--EGP:DrawPath(self.vertices, self.size, true)
+		EGP:DrawPathPoly(self.vertices, self.size, true)
 	end
 end
 Obj.Transmit = function( self, Ent, ply )

--- a/lua/entities/gmod_wire_egp/lib/objects/roundedbox.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/roundedbox.lua
@@ -5,30 +5,32 @@ Obj.radius = 16
 Obj.CanTopLeft = true
 Obj.fidelity = 36
 Obj.Draw = function( self )
+    if EGP:CacheNeedsUpdate(self, {"x", "y", "w", "h", "angle", "fidelity", "radius"}) then
 	local xs,ys , sx,sy = self.x,self.y , self.w, self.h
-    local polys = {}
-    local source = { {x=-1,y=-1} , {x=1,y=-1} , {x=1,y=1} , {x=-1,y=1} }
-    local radius = math.max(0,math.min((math.min(sx,sy)/2), self.radius ))
-    local div,angle = 360/self.fidelity, -self.angle
-    for x=1,4 do
-        for i=0,(self.fidelity+1)/4 do
-            local srx,sry = source[x].x,source[x].y
-            local scx,scy = srx*(sx-(radius*2))/2 , sry*(sy-(radius*2))/2
-            scx,scy = scx*math.cos(math.rad(angle)) - scy*math.sin(math.rad(angle)),
-                      scx*math.sin(math.rad(angle)) + scy*math.cos(math.rad(angle))
-            local a,r = math.rad(div*i+(x*90)), radius
-            local dir = {x=math.sin(-(a+math.rad(angle))),y=math.cos(-(a+math.rad(angle)))}
-            local dirUV = {x=math.sin(-a),y=math.cos(-a)}
-            local ru,rv = (radius/sx),(radius/sy)
-            local u,v = 0.5 + (dirUV.x*ru) + (srx/2)*(1-(ru*2)),
-                        0.5 + (dirUV.y*rv) + (sry/2)*(1-(rv*2))
-			polys[#polys+1] = {x=xs+scx+(dir.x*r),  y=ys+scy+(dir.y*r) , u=u,v=v}
-        end
+	local polys = {}
+	local source = { {x=-1,y=-1} , {x=1,y=-1} , {x=1,y=1} , {x=-1,y=1} }
+	local radius = math.max(0,math.min((math.min(sx,sy)/2), self.radius ))
+	local div,angle = 360/self.fidelity, -self.angle
+	for x=1,4 do
+	    for i=0,(self.fidelity+1)/4 do
+		local srx,sry = source[x].x,source[x].y
+		local scx,scy = srx*(sx-(radius*2))/2 , sry*(sy-(radius*2))/2
+		scx,scy = scx*math.cos(math.rad(angle)) - scy*math.sin(math.rad(angle)),
+			  scx*math.sin(math.rad(angle)) + scy*math.cos(math.rad(angle))
+		local a,r = math.rad(div*i+(x*90)), radius
+		local dir = {x=math.sin(-(a+math.rad(angle))),y=math.cos(-(a+math.rad(angle)))}
+		local dirUV = {x=math.sin(-a),y=math.cos(-a)}
+		local ru,rv = (radius/sx),(radius/sy)
+		local u,v = 0.5 + (dirUV.x*ru) + (srx/2)*(1-(ru*2)),
+			    0.5 + (dirUV.y*rv) + (sry/2)*(1-(rv*2))
+			    polys[#polys+1] = {x=xs+scx+(dir.x*r),  y=ys+scy+(dir.y*r) , u=u,v=v}
+	    end
+	end
+	self.vert_cache.verts = polys
     end
-    if polys and #polys>0 then
-        surface.SetDrawColor(self.r,self.g,self.b,self.a)
-        surface.DrawPoly(polys)
-    end
+
+    surface.SetDrawColor(self.r,self.g,self.b,self.a)
+    surface.DrawPoly(self.vert_cache.verts)
 end
 Obj.Transmit = function( self )
 	net.WriteInt((self.angle%360)*20, 16)

--- a/lua/entities/gmod_wire_egp/lib/objects/roundedboxoutline.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/roundedboxoutline.lua
@@ -25,7 +25,8 @@ Obj.Draw = function( self )
     local n = #polys
     if polys and n>0 then
 	surface.SetDrawColor(self.r,self.g,self.b,self.a)
-	EGP:DrawPath(polys, self.size, true)
+	--EGP:DrawPath(polys, self.size, true)
+	EGP:DrawPathPoly(polys, self.size, true)
     end
 end
 Obj.Transmit = function( self )

--- a/lua/entities/gmod_wire_egp/lib/objects/roundedboxoutline.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/roundedboxoutline.lua
@@ -6,27 +6,27 @@ Obj.size = 1
 Obj.CanTopLeft = true
 Obj.fidelity = 36
 Obj.Draw = function( self )
+    if EGP:CacheNeedsUpdate(self, {"x", "y", "w", "h", "angle", "fidelity", "radius"}) then
 	local xs,ys , sx,sy = self.x,self.y , self.w, self.h
-    local polys = {}
-    local source = { {x=-1,y=-1} , {x=1,y=-1} , {x=1,y=1} , {x=-1,y=1} }
-    local radius = math.max(0,math.min((math.min(sx,sy)/2), self.radius ))
-    local div,angle = 360/self.fidelity, -self.angle
-    for x=1,4 do
-        for i=0,(self.fidelity+1)/4 do
-            local srx,sry = source[x].x,source[x].y
-            local scx,scy = srx*(sx-(radius*2))/2 , sry*(sy-(radius*2))/2
-            scx,scy = scx*math.cos(math.rad(angle)) - scy*math.sin(math.rad(angle)),
-                      scx*math.sin(math.rad(angle)) + scy*math.cos(math.rad(angle))
-            local a,r = math.rad(div*i+(x*90)), radius
-            local dir = {x=math.sin(-(a+math.rad(angle))),y=math.cos(-(a+math.rad(angle)))}
-            polys[#polys+1] = {x=xs+scx+(dir.x*r),  y=ys+scy+(dir.y*r)}
-        end
+	local polys = {}
+	local source = { {x=-1,y=-1} , {x=1,y=-1} , {x=1,y=1} , {x=-1,y=1} }
+	local radius = math.max(0,math.min((math.min(sx,sy)/2), self.radius ))
+	local div,angle = 360/self.fidelity, -self.angle
+	for x=1,4 do
+	    for i=0,(self.fidelity+1)/4 do
+		local srx,sry = source[x].x,source[x].y
+		local scx,scy = srx*(sx-(radius*2))/2 , sry*(sy-(radius*2))/2
+		scx,scy = scx*math.cos(math.rad(angle)) - scy*math.sin(math.rad(angle)),
+			  scx*math.sin(math.rad(angle)) + scy*math.cos(math.rad(angle))
+		local a,r = math.rad(div*i+(x*90)), radius
+		local dir = {x=math.sin(-(a+math.rad(angle))),y=math.cos(-(a+math.rad(angle)))}
+		polys[#polys+1] = {x=xs+scx+(dir.x*r),  y=ys+scy+(dir.y*r)}
+	    end
+	end
+	self.vert_cache.verts = polys
     end
-    local n = #polys
-    if polys and n>0 then
-	surface.SetDrawColor(self.r,self.g,self.b,self.a)
-	EGP:DrawPath(polys, self.size, true)
-    end
+    surface.SetDrawColor(self.r,self.g,self.b,self.a)
+    EGP:DrawPath(self.vert_cache.verts, self.size, true)
 end
 Obj.Transmit = function( self )
 	net.WriteInt((self.angle%360)*20, 16)

--- a/lua/entities/gmod_wire_egp/lib/objects/roundedboxoutline.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/roundedboxoutline.lua
@@ -19,20 +19,13 @@ Obj.Draw = function( self )
                       scx*math.sin(math.rad(angle)) + scy*math.cos(math.rad(angle))
             local a,r = math.rad(div*i+(x*90)), radius
             local dir = {x=math.sin(-(a+math.rad(angle))),y=math.cos(-(a+math.rad(angle)))}
-            local dirUV = {x=math.sin(-a),y=math.cos(-a)}
-            local ru,rv = (radius/sx),(radius/sy)
-            local u,v = 0.5 + (dirUV.x*ru) + (srx/2)*(1-(ru*2)),
-                        0.5 + (dirUV.y*rv) + (sry/2)*(1-(rv*2))
-            polys[#polys+1] = {x=xs+scx+(dir.x*r),  y=ys+scy+(dir.y*r) , u=u,v=v}
+            polys[#polys+1] = {x=xs+scx+(dir.x*r),  y=ys+scy+(dir.y*r)}
         end
     end
-	local n = #polys
+    local n = #polys
     if polys and n>0 then
-		surface.SetDrawColor(self.r,self.g,self.b,self.a)
-		for i=1,n do
-			local p1,p2 = polys[i],polys[1+i%n]
-			EGP:DrawLine( p1.x, p1.y, p2.x, p2.y, self.size )
-		end
+	surface.SetDrawColor(self.r,self.g,self.b,self.a)
+	EGP:DrawPath(polys, self.size, true)
     end
 end
 Obj.Transmit = function( self )

--- a/lua/entities/gmod_wire_egp/lib/objects/roundedboxoutline.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/roundedboxoutline.lua
@@ -25,8 +25,7 @@ Obj.Draw = function( self )
     local n = #polys
     if polys and n>0 then
 	surface.SetDrawColor(self.r,self.g,self.b,self.a)
-	--EGP:DrawPath(polys, self.size, true)
-	EGP:DrawPathPoly(polys, self.size, true)
+	EGP:DrawPath(polys, self.size, true)
     end
 end
 Obj.Transmit = function( self )

--- a/lua/entities/gmod_wire_egp/lib/objects/wedge.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/wedge.lua
@@ -6,32 +6,32 @@ Obj.fidelity = 180
 local rad, cos, sin = math.rad, math.cos, math.sin
 Obj.Draw = function( self )
 	if self.a>0 and self.w > 0 and self.h > 0 and self.size ~= 360 then
-		local vertices = {}
+		if EGP:CacheNeedsUpdate(self, {"x", "y", "w", "h", "angle", "fidelity", "size"}) then
+			local vertices = {}
 
-		vertices[1] = { x = self.x, y = self.y, u = 0, v = 0 }
-		local ang = -rad(self.angle)
-		local c = cos(ang)
-		local s = sin(ang)
-		for ii=0,self.fidelity do
-			local i = ii*(360-self.size)/self.fidelity
-			local radd = rad(i)
-			local x = cos(radd)
-			local u = (x+1)/2
-			local y = sin(radd)
-			local v = (y+1)/2
+			vertices[1] = { x = self.x, y = self.y, u = 0, v = 0 }
+			local ang = -rad(self.angle)
+			local c = cos(ang)
+			local s = sin(ang)
+			for ii=0,self.fidelity do
+				local i = ii*(360-self.size)/self.fidelity
+				local radd = rad(i)
+				local x = cos(radd)
+				local u = (x+1)/2
+				local y = sin(radd)
+				local v = (y+1)/2
 
-			--radd = -rad(self.angle)
-			local tempx = x * self.w * c - y * self.h * s + self.x
-			y = x * self.w * s + y * self.h * c + self.y
-			x = tempx
+				--radd = -rad(self.angle)
+				local tempx = x * self.w * c - y * self.h * s + self.x
+				y = x * self.w * s + y * self.h * c + self.y
+				x = tempx
 
-			vertices[ii+2] = { x = x, y = y, u = u, v = v }
+				vertices[ii+2] = { x = x, y = y, u = u, v = v }
+			end
+			self.vert_cache.verts = vertices
 		end
-
 		surface.SetDrawColor( self.r, self.g, self.b, self.a )
-		if (vertices and #vertices>0) then
-			surface.DrawPoly( vertices )
-		end
+		surface.DrawPoly( self.vert_cache.verts )
 	end
 end
 Obj.Transmit = function( self )

--- a/lua/entities/gmod_wire_egp/lib/objects/wedgeoutline.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/wedgeoutline.lua
@@ -25,7 +25,8 @@ Obj.Draw = function( self )
 		end
 
 		surface.SetDrawColor( self.r, self.g, self.b, self.a )
-		EGP:DrawPath(vertices, 1, true)
+		--EGP:DrawPath(vertices, 1, true)
+		EGP:DrawPathPoly(vertices, 1, true)
 	end
 end
 Obj.Transmit = function( self )

--- a/lua/entities/gmod_wire_egp/lib/objects/wedgeoutline.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/wedgeoutline.lua
@@ -5,7 +5,7 @@ Obj.size = 45
 Obj.fidelity = 180
 local rad, cos, sin = math.rad, math.cos, math.sin
 Obj.Draw = function( self )
-	if (self.a>0 and self.w > 0 and self.h > 0 and self.size != 360) then
+	if (self.a>0 and self.w > 0 and self.h > 0 and self.size ~= 360) then
 		if EGP:CacheNeedsUpdate(self, {"x", "y", "w", "h", "angle", "fidelity", "size"}) then
 			local vertices = {}
 

--- a/lua/entities/gmod_wire_egp/lib/objects/wedgeoutline.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/wedgeoutline.lua
@@ -6,26 +6,29 @@ Obj.fidelity = 180
 local rad, cos, sin = math.rad, math.cos, math.sin
 Obj.Draw = function( self )
 	if (self.a>0 and self.w > 0 and self.h > 0 and self.size != 360) then
-		local vertices = {}
+		if EGP:CacheNeedsUpdate(self, {"x", "y", "w", "h", "angle", "fidelity", "size"}) then
+			local vertices = {}
 
-		vertices[1] = { x = self.x, y = self.y }
-		local ang = -rad(self.angle)
-		local c = cos(ang)
-		local s = sin(ang)
-		for ii=0,self.fidelity do
-			local i = ii*(360-self.size)/self.fidelity
-			local radd = rad(i)
-			local x = cos(radd)
-			local y = sin(radd)
-			local tempx = x * self.w * c - y * self.h * s + self.x
-			y = x * self.w * s + y * self.h * c + self.y
-			x = tempx
+			vertices[1] = { x = self.x, y = self.y }
+			local ang = -rad(self.angle)
+			local c = cos(ang)
+			local s = sin(ang)
+			for ii=0,self.fidelity do
+				local i = ii*(360-self.size)/self.fidelity
+				local radd = rad(i)
+				local x = cos(radd)
+				local y = sin(radd)
+				local tempx = x * self.w * c - y * self.h * s + self.x
+				y = x * self.w * s + y * self.h * c + self.y
+				x = tempx
 
-			vertices[ii+2] = { x = x, y = y }
+				vertices[ii+2] = { x = x, y = y }
+			end
+			self.vert_cache.verts = vertices
 		end
 
 		surface.SetDrawColor( self.r, self.g, self.b, self.a )
-		EGP:DrawPath(vertices, 1, true)
+		EGP:DrawPath(self.vert_cache.verts, 1, true)
 	end
 end
 Obj.Transmit = function( self )

--- a/lua/entities/gmod_wire_egp/lib/objects/wedgeoutline.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/wedgeoutline.lua
@@ -25,15 +25,7 @@ Obj.Draw = function( self )
 		end
 
 		surface.SetDrawColor( self.r, self.g, self.b, self.a )
-		local n = #vertices
-		for i=1,n do
-			local v = vertices[i]
-			if (i+1 > n) then break end
-			local x, y = v.x, v.y
-			local x2, y2 = vertices[i+1].x, vertices[i+1].y
-			surface.DrawLine( x, y, x2, y2 )
-		end
-		surface.DrawLine( vertices[n].x, vertices[n].y, vertices[1].x, vertices[1].y )
+		EGP:DrawPath(vertices, 1, true)
 	end
 end
 Obj.Transmit = function( self )

--- a/lua/entities/gmod_wire_egp/lib/objects/wedgeoutline.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/wedgeoutline.lua
@@ -25,8 +25,7 @@ Obj.Draw = function( self )
 		end
 
 		surface.SetDrawColor( self.r, self.g, self.b, self.a )
-		--EGP:DrawPath(vertices, 1, true)
-		EGP:DrawPathPoly(vertices, 1, true)
+		EGP:DrawPath(vertices, 1, true)
 	end
 end
 Obj.Transmit = function( self )


### PR DESCRIPTION
Offloads the drawing of a string of lines, ie used on all outlines and egpLineStrip into a dedicated function.
This function removes the gaps between line segments by drawing the line with polygons which are stretched to close the gaps.
The polygons are 6-vert and usually cover 2 line segments (except sharp corners which require trimming of the outer tip, see [this animation](https://giant.gfycat.com/BigMilkyEasternnewt.webm))
This fixes #895 

To offset the performance impact of the admittedly slow calculations, this PR not only caches the verticies for the outline itself, but also implement caching for verticies previously always generated on the fly, ie egpCircle and its derivates.

Example of think outlines working perfectly: https://i.imgur.com/J0a89FZ.jpg
(Arcs are a custom function using egpLineStrip for the filled arc and egpPolyOutline for the outlined arc, test E2 [here](https://pastebin.com/Cp6Ry0YJ))
