### PR TITLE
E2: Add wirelink:egpObjectType(n) & wirelink:egpObjectTypes() functions (fixes #1864)

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
@@ -937,6 +937,22 @@ end
 --------------------------------------------------------
 -- Object Type
 --------------------------------------------------------
+__e2setcost(15)
+
+e2function array wirelink:egpObjectTypes()
+	if not EGP:ValidEGP(this) then return {} end
+	local objs = {}
+	for i = 1, EGP.ConVars.MaxObjects:GetInt() do
+		local bool, _, v = EGP:HasObject(this, i)
+		if bool then
+			objs[i] = EGP.Objects.Names_Inverted[v.ID] or ""
+		end
+	end
+	return objs
+end
+
+__e2setcost(10)
+
 e2function string wirelink:egpType(number index)
 	local bool, _, v = EGP:HasObject(this, index)
 	if bool then

--- a/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
@@ -949,7 +949,8 @@ e2function string wirelink:egpTypeCS(number index)
     local bool, _, v = EGP:HasObject(this, index)
     if bool then
 		-- "egp" prefix to allow direct use with callable string (CS) feature.
-        return ("egp" .. EGP.Objects.Names_Inverted[v.ID]) or ""
+		local name = EGP.Objects.Names_Inverted[v.ID]
+		return name and ("egp" .. name) or ""
     end
     return ""
 end

--- a/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
@@ -935,6 +935,17 @@ e2function array wirelink:egpVertices( number index )
 end
 
 --------------------------------------------------------
+-- Object Type
+--------------------------------------------------------
+e2function string wirelink:egpType(number index)
+	local bool, _, v = EGP:HasObject(this, index)
+	if bool then
+		return EGP.Objects.Names_Inverted[v.ID] or ""
+	end
+	return ""
+end
+
+--------------------------------------------------------
 -- Additional Functions
 --------------------------------------------------------
 

--- a/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
@@ -951,6 +951,20 @@ e2function array wirelink:egpObjectTypes()
 	return objs
 end
 
+e2function array wirelink:egpObjectTypesCS()
+	if not EGP:ValidEGP(this) then return {} end
+	local objs = {}
+	for i = 1, EGP.ConVars.MaxObjects:GetInt() do
+		local bool, _, v = EGP:HasObject(this, i)
+		if bool then
+			-- "egp" prefix to allow direct use with callable string (CS) feature.
+			local name = EGP.Objects.Names_Inverted[v.ID]
+			objs[i] = name and ("egp" .. name) or ""
+		end
+	end
+	return objs
+end
+
 __e2setcost(10)
 
 e2function string wirelink:egpType(number index)

--- a/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
@@ -945,6 +945,15 @@ e2function string wirelink:egpType(number index)
 	return ""
 end
 
+e2function string wirelink:egpTypeCS(number index)
+    local bool, _, v = EGP:HasObject(this, index)
+    if bool then
+		-- "egp" prefix to allow direct use with callable string (CS) feature.
+        return ("egp" .. EGP.Objects.Names_Inverted[v.ID]) or ""
+    end
+    return ""
+end
+
 --------------------------------------------------------
 -- Additional Functions
 --------------------------------------------------------

--- a/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
@@ -937,52 +937,27 @@ end
 --------------------------------------------------------
 -- Object Type
 --------------------------------------------------------
-__e2setcost(15)
+__e2setcost(1)
 
 e2function array wirelink:egpObjectTypes()
 	if not EGP:ValidEGP(this) then return {} end
+	if not this.RenderTable or #this.RenderTable == 0 then return {} end
 	local objs = {}
-	for i = 1, EGP.ConVars.MaxObjects:GetInt() do
-		local bool, _, v = EGP:HasObject(this, i)
-		if bool then
-			objs[i] = EGP.Objects.Names_Inverted[v.ID] or ""
-		end
+	for _, v in pairs(this.RenderTable) do
+		objs[v.index] = EGP.Objects.Names_Inverted[v.ID] or ""
 	end
-	return objs
-end
-
-e2function array wirelink:egpObjectTypesCS()
-	if not EGP:ValidEGP(this) then return {} end
-	local objs = {}
-	for i = 1, EGP.ConVars.MaxObjects:GetInt() do
-		local bool, _, v = EGP:HasObject(this, i)
-		if bool then
-			-- "egp" prefix to allow direct use with callable string (CS) feature.
-			local name = EGP.Objects.Names_Inverted[v.ID]
-			objs[i] = name and ("egp" .. name) or ""
-		end
-	end
+	self.prf = self.prf + #this.RenderTable/3
 	return objs
 end
 
 __e2setcost(10)
 
-e2function string wirelink:egpType(number index)
+e2function string wirelink:egpObjectType(number index)
 	local bool, _, v = EGP:HasObject(this, index)
 	if bool then
 		return EGP.Objects.Names_Inverted[v.ID] or ""
 	end
 	return ""
-end
-
-e2function string wirelink:egpTypeCS(number index)
-    local bool, _, v = EGP:HasObject(this, index)
-    if bool then
-		-- "egp" prefix to allow direct use with callable string (CS) feature.
-		local name = EGP.Objects.Names_Inverted[v.ID]
-		return name and ("egp" .. name) or ""
-    end
-    return ""
 end
 
 --------------------------------------------------------

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -1405,6 +1405,7 @@ E2Helper.Descriptions["egpNumObjects(xwl:)"] = "Returns the number of objects on
 E2Helper.Descriptions["egpRunOnQueue(xwl:n)"] = "Set to 1 if you want your E2 to be triggered once the queue has finished sending all items in the queue for the screen"
 E2Helper.Descriptions["egpVertices(xwl:n)"] = "Returns an array of the vertices of the object"
 E2Helper.Descriptions["egpType(xwl:n)"] = "Returns the type of the object"
+E2Helper.Descriptions["egpTypeCS(xwl:n)"] = "Returns the type of the object (for direct use with callable string feature due convenience). The returned string has 'egp' prefix."
 
 E2Helper.Descriptions["egp3DTracker(xwl:nv)"] = "Creates a 3D tracker object at specified world position"
 E2Helper.Descriptions["egpBox(xwl:nxv2xv2)"] = "Creates a box. First 2D vector is the position, second is size"

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -1407,6 +1407,7 @@ E2Helper.Descriptions["egpVertices(xwl:n)"] = "Returns an array of the vertices 
 E2Helper.Descriptions["egpType(xwl:n)"] = "Returns the type of the object"
 E2Helper.Descriptions["egpTypeCS(xwl:n)"] = "Returns the type of the object (for direct use with callable string feature due convenience). The returned string has 'egp' prefix."
 E2Helper.Descriptions["egpObjectTypes(xwl:)"] = "Returns an array whose keys are bound to object index, and value being the type of particular object"
+E2Helper.Descriptions["egpObjectTypesCS(xwl:)"] = "Returns an array whose keys are bound to object index, and value being the type of particular object (for direct use with callable string feature due convenience)."
 
 E2Helper.Descriptions["egp3DTracker(xwl:nv)"] = "Creates a 3D tracker object at specified world position"
 E2Helper.Descriptions["egpBox(xwl:nxv2xv2)"] = "Creates a box. First 2D vector is the position, second is size"

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -1406,6 +1406,7 @@ E2Helper.Descriptions["egpRunOnQueue(xwl:n)"] = "Set to 1 if you want your E2 to
 E2Helper.Descriptions["egpVertices(xwl:n)"] = "Returns an array of the vertices of the object"
 E2Helper.Descriptions["egpType(xwl:n)"] = "Returns the type of the object"
 E2Helper.Descriptions["egpTypeCS(xwl:n)"] = "Returns the type of the object (for direct use with callable string feature due convenience). The returned string has 'egp' prefix."
+E2Helper.Descriptions["egpObjectTypes(xwl:)"] = "Returns an array whose keys are bound to object index, and value being the type of particular object"
 
 E2Helper.Descriptions["egp3DTracker(xwl:nv)"] = "Creates a 3D tracker object at specified world position"
 E2Helper.Descriptions["egpBox(xwl:nxv2xv2)"] = "Creates a box. First 2D vector is the position, second is size"

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -1404,6 +1404,7 @@ E2Helper.Descriptions["egpMaxUmsgPerSecond()"] = "Returns the maximum number of 
 E2Helper.Descriptions["egpNumObjects(xwl:)"] = "Returns the number of objects on the screen"
 E2Helper.Descriptions["egpRunOnQueue(xwl:n)"] = "Set to 1 if you want your E2 to be triggered once the queue has finished sending all items in the queue for the screen"
 E2Helper.Descriptions["egpVertices(xwl:n)"] = "Returns an array of the vertices of the object"
+E2Helper.Descriptions["egpType(xwl:n)"] = "Returns the type of the object"
 
 E2Helper.Descriptions["egp3DTracker(xwl:nv)"] = "Creates a 3D tracker object at specified world position"
 E2Helper.Descriptions["egpBox(xwl:nxv2xv2)"] = "Creates a box. First 2D vector is the position, second is size"

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -1404,10 +1404,8 @@ E2Helper.Descriptions["egpMaxUmsgPerSecond()"] = "Returns the maximum number of 
 E2Helper.Descriptions["egpNumObjects(xwl:)"] = "Returns the number of objects on the screen"
 E2Helper.Descriptions["egpRunOnQueue(xwl:n)"] = "Set to 1 if you want your E2 to be triggered once the queue has finished sending all items in the queue for the screen"
 E2Helper.Descriptions["egpVertices(xwl:n)"] = "Returns an array of the vertices of the object"
-E2Helper.Descriptions["egpType(xwl:n)"] = "Returns the type of the object"
-E2Helper.Descriptions["egpTypeCS(xwl:n)"] = "Returns the type of the object (for direct use with callable string feature due convenience). The returned string has 'egp' prefix."
+E2Helper.Descriptions["egpObjectType(xwl:n)"] = "Returns the type of the object with specified index"
 E2Helper.Descriptions["egpObjectTypes(xwl:)"] = "Returns an array whose keys are bound to object index, and value being the type of particular object"
-E2Helper.Descriptions["egpObjectTypesCS(xwl:)"] = "Returns an array whose keys are bound to object index, and value being the type of particular object (for direct use with callable string feature due convenience)."
 
 E2Helper.Descriptions["egp3DTracker(xwl:nv)"] = "Creates a 3D tracker object at specified world position"
 E2Helper.Descriptions["egpBox(xwl:nxv2xv2)"] = "Creates a box. First 2D vector is the position, second is size"


### PR DESCRIPTION
Fixes #1864.

![add](https://user-images.githubusercontent.com/9789070/55777469-4925ec00-5aa0-11e9-98e5-bfce7815d5c8.png) E2: `string=wirelink:egpObjectType(number)` function, version with string. (Cost 10)

![add](https://user-images.githubusercontent.com/9789070/55777469-4925ec00-5aa0-11e9-98e5-bfce7815d5c8.png) E2: `array=wirelink:egpObjectTypes()` function. (Cost is being dynamically added up.)