### PR TITLE
Remove timed property from setMass and setColor

### DIFF
--- a/lua/wire/gates/entity.lua
+++ b/lua/wire/gates/entity.lua
@@ -739,7 +739,6 @@ GateActions["entity_setmass"] = {
 	name = "Set Mass",
 	inputs = { "Ent" , "Val" },
 	inputtypes = { "ENTITY" , "NORMAL" },
-	timed = true,
 	output = function(gate, Ent, Val )
 		if !Ent:IsValid() then return end
 		if !Ent:GetPhysicsObject():IsValid() then return end
@@ -781,7 +780,6 @@ GateActions["entity_setcol"] = {
 	name = "Set Color",
 	inputs = { "Ent" , "Col" },
 	inputtypes = { "ENTITY" , "VECTOR" },
-	timed = true,
 	output = function(gate, Ent, Col )
 		if !Ent:IsValid() then return end
 		if not gamemode.Call("CanTool", WireLib.GetOwner(gate), WireLib.dummytrace(Ent), "color") then return end


### PR DESCRIPTION
Apparently some addons use the "CanTool" hook to log tool usage (instead of actually *using* the tool), so having a setColor/setMass gate would spam that log many times per second.  
The setter gates have no point in being timed, *unless* you have something else changing the color.

This leaves the example case when a color gates sets the color to red, but the player uses the color tool to change it to green. I see two possible options:
* Color stays green (this PR in current form)
* Color changes back to red immediately (current behavior)

Current behavior could be retained by not removing timed, but instead checking if the current color/mass of the entity matches the target color/mass before actually calling CanTool and applying the color/mass.