### PR TITLE
Remove deprecated property AdminSpawnable

### DIFF
--- a/lua/entities/gmod_wire_consolescreen/shared.lua
+++ b/lua/entities/gmod_wire_consolescreen/shared.lua
@@ -8,6 +8,5 @@ ENT.Purpose         = ""
 ENT.Instructions    = ""
 
 ENT.Spawnable       = false
-ENT.AdminSpawnable  = false
 
 ENT.RenderGroup     = RENDERGROUP_BOTH

--- a/lua/entities/gmod_wire_digitalscreen/shared.lua
+++ b/lua/entities/gmod_wire_digitalscreen/shared.lua
@@ -8,6 +8,5 @@ ENT.Purpose         = ""
 ENT.Instructions    = ""
 
 ENT.Spawnable       = false
-ENT.AdminSpawnable  = false
 
 ENT.RenderGroup     = RENDERGROUP_BOTH

--- a/lua/entities/gmod_wire_egp/shared.lua
+++ b/lua/entities/gmod_wire_egp/shared.lua
@@ -8,7 +8,6 @@ ENT.Purpose        = "Bring Graphic Processing to E2"
 ENT.Instructions   = "Wirelink To E2"
 
 ENT.Spawnable      = false
-ENT.AdminSpawnable = false
 
 ENT.RenderGroup     = RENDERGROUP_BOTH
 

--- a/lua/entities/gmod_wire_egp_hud/shared.lua
+++ b/lua/entities/gmod_wire_egp_hud/shared.lua
@@ -8,4 +8,3 @@ ENT.Purpose        = "EGP Hud"
 ENT.Instructions   = "WireLink To E2"
 
 ENT.Spawnable      = false
-ENT.AdminSpawnable = false

--- a/lua/entities/gmod_wire_gpu/shared.lua
+++ b/lua/entities/gmod_wire_gpu/shared.lua
@@ -8,6 +8,5 @@ ENT.Purpose         = ""
 ENT.Instructions    = ""
 
 ENT.Spawnable       = false
-ENT.AdminSpawnable  = false
 
 ENT.RenderGroup     = RENDERGROUP_BOTH

--- a/lua/entities/gmod_wire_hudindicator/shared.lua
+++ b/lua/entities/gmod_wire_hudindicator/shared.lua
@@ -8,4 +8,3 @@ ENT.Purpose         = ""
 ENT.Instructions    = ""
 
 ENT.Spawnable       = false
-ENT.AdminSpawnable  = false

--- a/lua/entities/gmod_wire_keyboard/shared.lua
+++ b/lua/entities/gmod_wire_keyboard/shared.lua
@@ -8,4 +8,3 @@ ENT.Purpose         = "Send key input to the server."
 ENT.Instructions    = "Click Use on it to activate it."
 
 ENT.Spawnable       = false
-ENT.AdminSpawnable  = false

--- a/lua/entities/gmod_wire_spu/shared.lua
+++ b/lua/entities/gmod_wire_spu/shared.lua
@@ -8,4 +8,3 @@ ENT.Purpose         = ""
 ENT.Instructions    = ""
 
 ENT.Spawnable       = false
-ENT.AdminSpawnable  = false


### PR DESCRIPTION
'AdminSpawnable' has been renamed to 'AdminOnly' since GMod 13, the default value is 'false', it should simply be fine to remove those lines too.
Old docs say:
"If false, admins can't spawn that weapon (you can set to false for base weapons)."
See also:
https://wiki.garrysmod.com/page/Structures/ENT