### PR TITLE
Replaced usages of 'Player.UniqueID' with 'Player.AccountID' function

### DIFF
--- a/lua/entities/gmod_wire_egp/init.lua
+++ b/lua/entities/gmod_wire_egp/init.lua
@@ -33,12 +33,12 @@ end
 
 function ENT:SetEGPOwner( ply )
 	self.ply = ply
-	self.plyID = IsValid(ply) and ply:UniqueID() or "World"
+	self.plyID = IsValid(ply) and ply:AccountID() or "World"
 end
 
 function ENT:GetEGPOwner()
 	if (!self.ply or !self.ply:IsValid()) then
-		local ply = player.GetByUniqueID( self.plyID )
+		local ply = player.GetByAccountID( self.plyID )
 		if (ply) then self.ply = ply end
 		return ply
 	else

--- a/lua/entities/gmod_wire_egp/init.lua
+++ b/lua/entities/gmod_wire_egp/init.lua
@@ -33,12 +33,12 @@ end
 
 function ENT:SetEGPOwner( ply )
 	self.ply = ply
-	self.plyID = IsValid(ply) and ply:AccountID() or "World"
+	self.plyID = IsValid(ply) and ply:UserID() or -1
 end
 
 function ENT:GetEGPOwner()
 	if (!self.ply or !self.ply:IsValid()) then
-		local ply = player.GetByAccountID( self.plyID )
+		local ply = Player(self.plyID)
 		if (ply) then self.ply = ply end
 		return ply
 	else

--- a/lua/entities/gmod_wire_egp_hud/init.lua
+++ b/lua/entities/gmod_wire_egp_hud/init.lua
@@ -39,12 +39,12 @@ end
 
 function ENT:SetEGPOwner( ply )
 	self.ply = ply
-	self.plyID = ply:UniqueID()
+	self.plyID = ply:AccountID()
 end
 
 function ENT:GetEGPOwner()
 	if (!self.ply or !self.ply:IsValid()) then
-		local ply = player.GetByUniqueID( self.plyID )
+		local ply = player.GetByAccountID( self.plyID )
 		if (ply) then self.ply = ply end
 		return ply
 	else

--- a/lua/entities/gmod_wire_egp_hud/init.lua
+++ b/lua/entities/gmod_wire_egp_hud/init.lua
@@ -39,12 +39,12 @@ end
 
 function ENT:SetEGPOwner( ply )
 	self.ply = ply
-	self.plyID = ply:AccountID()
+	self.plyID = IsValid(ply) and ply:UserID() or -1
 end
 
 function ENT:GetEGPOwner()
 	if (!self.ply or !self.ply:IsValid()) then
-		local ply = player.GetByAccountID( self.plyID )
+		local ply = Player(self.plyID)
 		if (ply) then self.ply = ply end
 		return ply
 	else

--- a/lua/entities/gmod_wire_expression2/core/custom/wiring.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/wiring.lua
@@ -18,8 +18,8 @@ e2function number entity:createWire(entity ent2, string inputname, string output
 
 	local trigger = self.entity.trigger
 	self.entity.trigger = { false, {} } -- So the wire creation doesn't execute the E2 immediately because an input changed
-	WireLib.Link_Start(self.player:AccountID(), this, this:WorldToLocal(this:GetPos()), inputname, "cable/rope", Vector(255,255,255), 0)
-	WireLib.Link_End(self.player:AccountID(), ent2, ent2:WorldToLocal(ent2:GetPos()), outputname, self.player)
+	WireLib.Link_Start(1, this, this:WorldToLocal(this:GetPos()), inputname, "cable/rope", Vector(255,255,255), 0) -- Divran, I'm trusting you on using 1 as index here instead
+	WireLib.Link_End(1, ent2, ent2:WorldToLocal(ent2:GetPos()), outputname, self.player)
 	self.entity.trigger = trigger
 
 	return 1
@@ -51,8 +51,8 @@ e2function number entity:createWire(entity ent2, string inputname, string output
 
 	local trigger = self.entity.trigger
 	self.entity.trigger = { false, {} } -- So the wire creation doesn't execute the E2 immediately because an input changed
-	WireLib.Link_Start(self.player:AccountID(), this, this:WorldToLocal(this:GetPos()), inputname, mat, Vector(color[1],color[2],color[3]), width or 1)
-	WireLib.Link_End(self.player:AccountID(), ent2, ent2:WorldToLocal(ent2:GetPos()), outputname, self.player)
+	WireLib.Link_Start(1, this, this:WorldToLocal(this:GetPos()), inputname, mat, Vector(color[1],color[2],color[3]), width or 1) -- Divran, I'm trusting you on using 1 as index here instead
+	WireLib.Link_End(1, ent2, ent2:WorldToLocal(ent2:GetPos()), outputname, self.player)
 	self.entity.trigger = trigger
 
 	return 1

--- a/lua/entities/gmod_wire_expression2/core/custom/wiring.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/wiring.lua
@@ -18,8 +18,8 @@ e2function number entity:createWire(entity ent2, string inputname, string output
 
 	local trigger = self.entity.trigger
 	self.entity.trigger = { false, {} } -- So the wire creation doesn't execute the E2 immediately because an input changed
-	WireLib.Link_Start(self.player:UniqueID(), this, this:WorldToLocal(this:GetPos()), inputname, "cable/rope", Vector(255,255,255), 0)
-	WireLib.Link_End(self.player:UniqueID(), ent2, ent2:WorldToLocal(ent2:GetPos()), outputname, self.player)
+	WireLib.Link_Start(self.player:AccountID(), this, this:WorldToLocal(this:GetPos()), inputname, "cable/rope", Vector(255,255,255), 0)
+	WireLib.Link_End(self.player:AccountID(), ent2, ent2:WorldToLocal(ent2:GetPos()), outputname, self.player)
 	self.entity.trigger = trigger
 
 	return 1
@@ -51,8 +51,8 @@ e2function number entity:createWire(entity ent2, string inputname, string output
 
 	local trigger = self.entity.trigger
 	self.entity.trigger = { false, {} } -- So the wire creation doesn't execute the E2 immediately because an input changed
-	WireLib.Link_Start(self.player:UniqueID(), this, this:WorldToLocal(this:GetPos()), inputname, mat, Vector(color[1],color[2],color[3]), width or 1)
-	WireLib.Link_End(self.player:UniqueID(), ent2, ent2:WorldToLocal(ent2:GetPos()), outputname, self.player)
+	WireLib.Link_Start(self.player:AccountID(), this, this:WorldToLocal(this:GetPos()), inputname, mat, Vector(color[1],color[2],color[3]), width or 1)
+	WireLib.Link_End(self.player:AccountID(), ent2, ent2:WorldToLocal(ent2:GetPos()), outputname, self.player)
 	self.entity.trigger = trigger
 
 	return 1

--- a/lua/entities/gmod_wire_expression2/core/hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/hologram.lua
@@ -1227,7 +1227,7 @@ concommand.Add( "wire_holograms_block", function( ply, com, args )
 		if BlockList[v:SteamID()] == true then
 			ConsoleMessage( ply, v:GetName() .. " is already in the holograms blocklist!" )
 		else
-			local uid = v:AccountID()
+			local uid = v:SteamID()
 			if E2HoloRepo[uid] then
 				for k2,v2 in pairs( E2HoloRepo[uid] ) do
 					if v2 and IsValid(v2.ent) then
@@ -1298,7 +1298,7 @@ concommand.Add( "wire_holograms_block_id", function( ply, com, args )
 		local uid
 		for _,v in pairs( player.GetAll() ) do
 			if v:SteamID() == steamID then
-				uid = v:AccountID()
+				uid = v:SteamID()
 				if (E2HoloRepo[uid]) then
 					for k2,v2 in pairs( E2HoloRepo[uid] ) do
 						if v2 and IsValid(v2.ent) then

--- a/lua/entities/gmod_wire_expression2/core/hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/hologram.lua
@@ -25,7 +25,7 @@ util.AddNetworkString("wire_holograms_set_player_color")
 
 
 -- context = chip.context = self
--- uid = context.uid = self.uid = chip.uid = player:UniqueID()
+-- uid = context.uid = self.uid = chip.uid = player:AccountID()
 -- Holo = { ent = prop, scale = scale, e2owner = context }
 -- E2HoloRepo[uid][-index] = Holo <-- global holos
 -- E2HoloRepo[uid][Holo] = Holo <-- local holos
@@ -1227,7 +1227,7 @@ concommand.Add( "wire_holograms_block", function( ply, com, args )
 		if BlockList[v:SteamID()] == true then
 			ConsoleMessage( ply, v:GetName() .. " is already in the holograms blocklist!" )
 		else
-			local uid = v:UniqueID()
+			local uid = v:AccountID()
 			if E2HoloRepo[uid] then
 				for k2,v2 in pairs( E2HoloRepo[uid] ) do
 					if v2 and IsValid(v2.ent) then
@@ -1298,7 +1298,7 @@ concommand.Add( "wire_holograms_block_id", function( ply, com, args )
 		local uid
 		for _,v in pairs( player.GetAll() ) do
 			if v:SteamID() == steamID then
-				uid = v:UniqueID()
+				uid = v:AccountID()
 				if (E2HoloRepo[uid]) then
 					for k2,v2 in pairs( E2HoloRepo[uid] ) do
 						if v2 and IsValid(v2.ent) then

--- a/lua/entities/gmod_wire_expression2/core/hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/hologram.lua
@@ -25,7 +25,7 @@ util.AddNetworkString("wire_holograms_set_player_color")
 
 
 -- context = chip.context = self
--- uid = context.uid = self.uid = chip.uid = player:AccountID()
+-- uid = context.uid = self.uid = chip.uid = player:SteamID()
 -- Holo = { ent = prop, scale = scale, e2owner = context }
 -- E2HoloRepo[uid][-index] = Holo <-- global holos
 -- E2HoloRepo[uid][Holo] = Holo <-- local holos

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -286,7 +286,7 @@ registerCallback("destruct",function(self)
 end)
 
 local function UpdateKeys(ply, bind, key, state)
-	local uid = ply:UniqueID()
+	local uid = ply:AccountID()
 
 	local keystate = {
 		runByKey = ply,
@@ -333,7 +333,7 @@ local function toggleRunOnKeys(self,ply,on,filter)
 	if not IsValid(ply) or not ply:IsPlayer() then return end
 
 	local ent = self.entity
-	local uid = ply:UniqueID()
+	local uid = ply:AccountID()
 
 	if on ~= 0 then
 		if not KeyAlert[ent] then KeyAlert[ent] = {} end

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -286,7 +286,7 @@ registerCallback("destruct",function(self)
 end)
 
 local function UpdateKeys(ply, bind, key, state)
-	local uid = ply:AccountID()
+	local uid = ply:UserID()
 
 	local keystate = {
 		runByKey = ply,
@@ -333,7 +333,7 @@ local function toggleRunOnKeys(self,ply,on,filter)
 	if not IsValid(ply) or not ply:IsPlayer() then return end
 
 	local ent = self.entity
-	local uid = ply:AccountID()
+	local uid = ply:UserID()
 
 	if on ~= 0 then
 		if not KeyAlert[ent] then KeyAlert[ent] = {} end

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -429,7 +429,7 @@ function ENT:Setup(buffer, includes, restore, forcecompile, filepath)
 		self:PCallHook('destruct')
 	end
 
-	self.uid = IsValid(self.player) and self.player:UniqueID() or "World"
+	self.uid = IsValid(self.player) and self.player:AccountID() or "World"
 	self:SetColor(Color(255, 255, 255, self:GetColor().a))
 
 	if forcecompile or self:IsCodeDifferent(buffer, includes) then

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -429,7 +429,7 @@ function ENT:Setup(buffer, includes, restore, forcecompile, filepath)
 		self:PCallHook('destruct')
 	end
 
-	self.uid = IsValid(self.player) and self.player:AccountID() or "World"
+	self.uid = IsValid(self.player) and self.player:SteamID() or "World"
 	self:SetColor(Color(255, 255, 255, self:GetColor().a))
 
 	if forcecompile or self:IsCodeDifferent(buffer, includes) then
@@ -557,10 +557,10 @@ hook.Add("EntityRemoved", "Wire_Expression2_Player_Disconnected", function(ent)
 	end
 end)
 
-hook.Add("PlayerAuthed", "Wire_Expression2_Player_Authed", function(ply, sid, uid)
+hook.Add("PlayerAuthed", "Wire_Expression2_Player_Authed", function(ply, sid)
 	local c
 	for _, ent in ipairs(ents.FindByClass("gmod_wire_expression2")) do
-		if (ent.uid == uid) then
+		if (ent.uid == sid) then
 			ent.context.player = ply
 			ent.player = ply
 			ent:SetNWEntity("player", ply)

--- a/lua/entities/gmod_wire_hologram.lua
+++ b/lua/entities/gmod_wire_hologram.lua
@@ -6,7 +6,7 @@ ENT.DisableDuplicator = true
 
 function ENT:SetPlayer(ply)
 	self:SetVar("Founder", ply)
-	self:SetVar("FounderIndex", ply:UniqueID())
+	self:SetVar("FounderIndex", ply:AccountID())
 
 	self:SetNWString("FounderName", ply:Nick())
 end

--- a/lua/entities/gmod_wire_hologram.lua
+++ b/lua/entities/gmod_wire_hologram.lua
@@ -6,7 +6,7 @@ ENT.DisableDuplicator = true
 
 function ENT:SetPlayer(ply)
 	self:SetVar("Founder", ply)
-	self:SetVar("FounderIndex", ply:AccountID())
+	self:SetVar("FounderIndex", ply:AccountID() or 0)
 
 	self:SetNWString("FounderName", ply:Nick())
 end

--- a/lua/entities/gmod_wire_hudindicator/cl_init.lua
+++ b/lua/entities/gmod_wire_hudindicator/cl_init.lua
@@ -20,7 +20,7 @@ local semicircletexid = surface.GetTextureID("hudindicator/hi_semicircle")
 -- B) is not registered as pod-only
 function ENT:ClientCheckRegister()
 	local ply = LocalPlayer()
-	local plyuid = ply:AccountID()
+	local plyuid = ply:UserID()
 	return ply ~= self:GetPlayer() and not self:GetNWBool(plyuid)
 end
 

--- a/lua/entities/gmod_wire_hudindicator/cl_init.lua
+++ b/lua/entities/gmod_wire_hudindicator/cl_init.lua
@@ -20,7 +20,7 @@ local semicircletexid = surface.GetTextureID("hudindicator/hi_semicircle")
 -- B) is not registered as pod-only
 function ENT:ClientCheckRegister()
 	local ply = LocalPlayer()
-	local plyuid = ply:UniqueID()
+	local plyuid = ply:AccountID()
 	return ply ~= self:GetPlayer() and not self:GetNWBool(plyuid)
 end
 

--- a/lua/entities/gmod_wire_hudindicator/init.lua
+++ b/lua/entities/gmod_wire_hudindicator/init.lua
@@ -164,7 +164,7 @@ end
 
 -- Hook this player to the HUD Indicator
 function ENT:RegisterPlayer(ply, hookhidehud, podonly)
-	local plyuid = ply:AccountID()
+	local plyuid = ply:UserID()
 	local eindex = self:EntIndex()
 
 	-- If player is already registered, this will send an update
@@ -196,18 +196,18 @@ function ENT:UnRegisterPlayer(ply)
 	umsg.Start("HUDIndicatorUnRegister", ply)
 		umsg.Short(self:EntIndex())
 	umsg.End()
-	self.RegisteredPlayers[ply:AccountID()] = nil
+	self.RegisteredPlayers[ply:UserID()] = nil
 end
 
 -- Is this player registered?
 function ENT:CheckRegister(ply)
-	return self.RegisteredPlayers[ply:AccountID()] ~= nil
+	return self.RegisteredPlayers[ply:UserID()] ~= nil
 end
 
 -- Is this player registered only because he is in a linked pod?
 function ENT:CheckPodOnly(ply)
 	if not ply or not ply:IsValid() then return false end
-	local plyuid = ply:AccountID()
+	local plyuid = ply:UserID()
 	return self.RegisteredPlayers[plyuid] ~= nil and self.RegisteredPlayers[plyuid].podonly
 end
 

--- a/lua/entities/gmod_wire_hudindicator/init.lua
+++ b/lua/entities/gmod_wire_hudindicator/init.lua
@@ -164,7 +164,7 @@ end
 
 -- Hook this player to the HUD Indicator
 function ENT:RegisterPlayer(ply, hookhidehud, podonly)
-	local plyuid = ply:UniqueID()
+	local plyuid = ply:AccountID()
 	local eindex = self:EntIndex()
 
 	-- If player is already registered, this will send an update
@@ -196,18 +196,18 @@ function ENT:UnRegisterPlayer(ply)
 	umsg.Start("HUDIndicatorUnRegister", ply)
 		umsg.Short(self:EntIndex())
 	umsg.End()
-	self.RegisteredPlayers[ply:UniqueID()] = nil
+	self.RegisteredPlayers[ply:AccountID()] = nil
 end
 
 -- Is this player registered?
 function ENT:CheckRegister(ply)
-	return self.RegisteredPlayers[ply:UniqueID()] ~= nil
+	return self.RegisteredPlayers[ply:AccountID()] ~= nil
 end
 
 -- Is this player registered only because he is in a linked pod?
 function ENT:CheckPodOnly(ply)
 	if not ply or not ply:IsValid() then return false end
-	local plyuid = ply:UniqueID()
+	local plyuid = ply:AccountID()
 	return self.RegisteredPlayers[plyuid] ~= nil and self.RegisteredPlayers[plyuid].podonly
 end
 

--- a/lua/weapons/gmod_tool/stools/wire_adv.lua
+++ b/lua/weapons/gmod_tool/stools/wire_adv.lua
@@ -137,7 +137,7 @@ if SERVER then
 		local width    = tool:GetClientNumber("width")
 		local color    = Color(tool:GetClientNumber("r"), tool:GetClientNumber("g"), tool:GetClientNumber("b"))
 
-		local uid = ply:AccountID()
+		local uid = ply:AccountID() or 0
 
 		for i=1,#wirings do
 			local wiring = wirings[i]

--- a/lua/weapons/gmod_tool/stools/wire_adv.lua
+++ b/lua/weapons/gmod_tool/stools/wire_adv.lua
@@ -137,7 +137,7 @@ if SERVER then
 		local width    = tool:GetClientNumber("width")
 		local color    = Color(tool:GetClientNumber("r"), tool:GetClientNumber("g"), tool:GetClientNumber("b"))
 
-		local uid = ply:UniqueID()
+		local uid = ply:AccountID()
 
 		for i=1,#wirings do
 			local wiring = wirings[i]

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -685,8 +685,8 @@ function WireLib.WireAll(ply, ient, oent, ipos, opos, material, color, width)
 
 	for iname, _ in pairs(ient.Inputs) do
 		if oent.Outputs[iname] then
-			WireLib.Link_Start(ply:AccountID(), ient, ipos, iname, material or "arrowire/arrowire2", color or Color(255,255,255), width or 0)
-			WireLib.Link_End(ply:AccountID(), oent, opos, iname, ply)
+			WireLib.Link_Start(1, ient, ipos, iname, material or "arrowire/arrowire2", color or Color(255,255,255), width or 0) -- Divran, I'm trusting you on using 1 as index here instead
+			WireLib.Link_End(1, oent, opos, iname, ply)
 		end
 	end
 end
@@ -786,7 +786,7 @@ function WireLib.ApplyDupeInfo( ply, ent, info, GetEntByID )
 	end
 
 	local idx = 0
-	if IsValid(ply) then idx = ply:AccountID() end -- Map Save loading does not have a ply
+	if IsValid(ply) then idx = ply:AccountID() or 0 end -- Map Save loading does not have a ply
 	if (info.Wires) then
 		for k,input in pairs(info.Wires) do
 			local ent2 = GetEntByID(input.Src)

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -685,8 +685,8 @@ function WireLib.WireAll(ply, ient, oent, ipos, opos, material, color, width)
 
 	for iname, _ in pairs(ient.Inputs) do
 		if oent.Outputs[iname] then
-			WireLib.Link_Start(ply:UniqueID(), ient, ipos, iname, material or "arrowire/arrowire2", color or Color(255,255,255), width or 0)
-			WireLib.Link_End(ply:UniqueID(), oent, opos, iname, ply)
+			WireLib.Link_Start(ply:AccountID(), ient, ipos, iname, material or "arrowire/arrowire2", color or Color(255,255,255), width or 0)
+			WireLib.Link_End(ply:AccountID(), oent, opos, iname, ply)
 		end
 	end
 end
@@ -786,7 +786,7 @@ function WireLib.ApplyDupeInfo( ply, ent, info, GetEntByID )
 	end
 
 	local idx = 0
-	if IsValid(ply) then idx = ply:UniqueID() end -- Map Save loading does not have a ply
+	if IsValid(ply) then idx = ply:AccountID() end -- Map Save loading does not have a ply
 	if (info.Wires) then
 		for k,input in pairs(info.Wires) do
 			local ent2 = GetEntByID(input.Src)


### PR DESCRIPTION
Brief explanation:
* AccountID is unique (increasing) number for each Steam account, it is also known as Steam3 ID ("U:1:N"), where N is the AccountID number (it is 32-bit unsigned integer).
* UniqueID is Garry's fault. It is not a unique identifier, please refuse from using it in future, it is equivalent to `util.CRC("gm_" .. SteamID .. "_gm")`. Thus, there are collisions between different SteamIDs (accounts).
* This is to be treated as a rare security exploit, because it was abused in the past - and still can be. (Note, there is a way to force UniqueID in a way, but it goes beyond the scope of this brief explanation...)

Wire Ranger was not modified, it was left unmodified due backward compatibility (and possibility of breaking dupes/contraptions), you should really use `SteamID` output instead.

Discussion about this was done privately between Wire devs and me, on Discord.