### PR TITLE
now server owners can regulate what this can use

### DIFF
--- a/lua/entities/gmod_wire_user.lua
+++ b/lua/entities/gmod_wire_user.lua
@@ -36,7 +36,7 @@ function ENT:TriggerInput(iname, value)
 		if not IsValid(ply) then ply = self end
 
 		if not hook.Run( "PlayerUse", ply, trace.Entity ) then return false end
-
+		if hook.Run("WireUse",self,trace,ply)==false then return false end
 		if trace.Entity.Use then
 			trace.Entity:Use(ply,ply,USE_ON,0)
 		else


### PR DESCRIPTION
before this tweak, there was no way for server owners to regulate what the wire_user could interact with that didn't affect players pressing E
what if i was a server owner and didn't want players to pick up money with a wire_user?