### PR TITLE
Bugfix/disallow invalid materials

### DIFF
--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1184,9 +1184,9 @@ local invalidMaterialCacheSizeLimit = 500
 local invalidMaterialCache = {}
 
 local function cacheInvalidMaterial(material)
-    local cacheIsOversized = #invalidMaterialCache >= invalidMaterialCacheSizeLimit
+    local cacheIsOversized = table.count( invalidMaterialCache ) >= invalidMaterialCacheSizeLimit
 
-    if cacheIsOversized then table.remove( invalidMaterialCache, 1 ) end
+    if cacheIsOversized then invalidMaterialCache[next( invalidMaterialCache )] = nil end
 
     invalidMaterialCache[material] = true
 end

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1179,6 +1179,10 @@ function WireLib.IsValidMaterial(material)
 	material = string.sub(material, 1, 260)
 	local path = string.StripExtension(string.GetNormalizedFilepath(string.lower(material)))
 	if material_blacklist[path] then return "" end
+
+	local materialTest = Material( material )
+	if materialTest:IsError() then return "" end
+
 	return material
 end
 

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1180,23 +1180,26 @@ function WireLib.BlacklistMaterial(material)
     materialBlacklist[material] = true
 end
 
+local invalidMaterialCache = {}
+local invalidMaterialCacheCount = 0
 local invalidMaterialCacheSizeLimit = 500
 
-local invalidMaterialCache = {}
-
 local function removeOldestCachedMaterial()
-    local sortedCacheTimes = table.SortByKey( invalidMaterialCache )
-    local oldestMaterial = sortedCacheTimes[#sortedCacheTimes]
+    local oldestMaterial = math.min( unpack( table.ClearKeys( invalidMaterialCache ) ) )
 
-    invalidMaterialCache[oldestMaterial] = nil
+    table.RemoveByValue( invalidMaterialCache, oldestMaterial )
+
+    invalidMaterialCacheCount = invalidMaterialCacheCount - 1
 end
 
 local function cacheInvalidMaterial(material)
-    local cacheIsOversized = table.count( invalidMaterialCache ) >= invalidMaterialCacheSizeLimit
+    local cacheIsOversized = invalidMaterialCacheCount >= invalidMaterialCacheSizeLimit
 
     if cacheIsOversized then removeOldestCachedMaterial() end
 
     invalidMaterialCache[material] = CurTime()
+
+    invalidMaterialCacheCount = invalidMaterialCacheCount + 1
 end
 
 local function materialIsInvalid(material)

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1185,17 +1185,19 @@ local invalidMaterialCacheCount = 0
 local invalidMaterialCacheSizeLimit = 500
 
 local function removeOldestCachedMaterial()
-    local oldestMaterial = math.min( unpack( table.ClearKeys( invalidMaterialCache ) ) )
+    local oldestMaterial
+    local oldest = math.huge
+    for k, v in pairs(invalidMaterialCache) do
+        if v < oldest then oldest = v oldestMaterial = k end
+    end
 
-    table.RemoveByValue( invalidMaterialCache, oldestMaterial )
+    invalidMaterialCache[oldestMaterial] = nil
 
     invalidMaterialCacheCount = invalidMaterialCacheCount - 1
 end
 
 local function cacheInvalidMaterial(material)
-    local cacheIsOversized = invalidMaterialCacheCount >= invalidMaterialCacheSizeLimit
-
-    if cacheIsOversized then removeOldestCachedMaterial() end
+    if invalidMaterialCacheCount >= invalidMaterialCacheSizeLimit then removeOldestCachedMaterial() end
 
     invalidMaterialCache[material] = CurTime()
 

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1181,20 +1181,38 @@ function WireLib.BlacklistMaterial(material)
 end
 
 local invalidMaterialCacheSizeLimit = 500
+
 local invalidMaterialCache = {}
+
+local function removeOldestCachedMaterial()
+    local sortedCacheTimes = table.SortByKey( invalidMaterialCache )
+    local oldestMaterial = sortedCacheTimes[#sortedCacheTimes]
+
+    invalidMaterialCache[oldestMaterial] = nil
+end
 
 local function cacheInvalidMaterial(material)
     local cacheIsOversized = table.count( invalidMaterialCache ) >= invalidMaterialCacheSizeLimit
 
-    if cacheIsOversized then invalidMaterialCache[next( invalidMaterialCache )] = nil end
+    if cacheIsOversized then removeOldestCachedMaterial() end
 
-    invalidMaterialCache[material] = true
+    invalidMaterialCache[material] = CurTime()
+end
+
+local function materialIsInvalid(material)
+    if invalidMaterialCache[material] then
+        invalidMaterialCache[material] = CurTime()
+
+        return true
+    end
 end
 
 function WireLib.IsValidMaterial(material)
 	material = string.sub(material, 1, 260)
 
-    if invalidMaterialCache[material] then return "" end
+	if material == "" then return "" end
+
+	if materialIsInvalid(material) then return "" end
 
 	local path = string.StripExtension(string.GetNormalizedFilepath(string.lower(material)))
 


### PR DESCRIPTION
## The problem
Our server has been experiencing intermittent freezing when entering/leaving area portals throughout the map. After a lot of debugging and testing, we discovered that the issue had to do with holograms that were set to invalid materials (materials that don't exist) freezing the clients when they are loaded (i.e. when you enter an area portal that causes the client to render them).

Here's a video of us testing, and subsequently narrowing the problem down to E2, and then later to hologram materials. This displays the freezing issue I'm referencing: https://www.youtube.com/watch?v=DGxiyeAGl1I

## Proposed solution
When using the `Material()` function, I found that it can determine if a given material is valid or not.

As an example:

```lua
local materialTest = Material( "this/doesnt/exist" )
print( materialTest:IsError() )
=> true
```

We already pass all materials through a wiremod util to check if it's valid. Currently, it only checks if the given material is blacklisted, and not whether or not the material is actually _valid_.

In this PR I use this solution to check if the given material is valid;
```lua
local materialTest = Material( material )
if not materialTest or materialTest:IsError() then return "" end
```

There is one issue with this, making `Material()`s comes with a negative performance implication. During clientside testing, I found that creating 500 `Material()`s with random strings in a for loop caused the client to hang for about 3-8 seconds. On a run with 5000, the freezing lasted about 18 seconds.

During some practical serverside testing (I won't go into my methods here, DM me for more info) I found that this solution could potentially open up opportunity for bad actors to slow down the server by abusing SetMaterial() on a hologram.

I added a cache for invalid materials so that we're not performing expensive functions on materials that we already know are invalid, but this only protects against accidental abuse, not intentional malice.


Ideally, we'd find a way to decide if a material is invalid without having to actually call 
```lua
Material( string )
```

This _does_ fix the issue, though, I'm currently running this branch on my server with almost no freezing at all (none relating to e2, anyway).