### PR TITLE
Add slight tolerance for floating point math

### DIFF
--- a/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
@@ -321,12 +321,12 @@ function EGP:DrawPath( vertices, size, closed )
 						else
 							local dot = dir.x*lastdir.x + dir.y*lastdir.y
 							local scaling = size*math.tan(math.acos(dot)/2) -- complicated math, could be also be `size*sqrt(1-dot)/sqrt(dot+1)` (no idea what is faster)
-							if dot >= 1 then -- also account for rounding errors, somehow the dot product can be >1, which makes scaling nan
+							if dot > 0.999 then -- also account for rounding errors, somehow the dot product can be >1, which makes scaling nan
 								-- direction stays the same, no need for a corner, just skip this point, unless it is the last segment of a closed path (last segment of a open path is handled explicitly above)
 								if i == num+1 then
 									corners[#corners+1] = { r={x=x1-dir.y*size, y=y1+dir.x*size}, l={x=x1+dir.y*size, y=y1-dir.x*size} }
 								end
-							elseif dot <= -1 then -- new direction is inverse, just add perpendicular nodes
+							elseif dot < -0.999 then -- new direction is inverse, just add perpendicular nodes
 								corners[#corners+1] = { r={x=x1-dir.y*size, y=y1+dir.x*size}, l={x=x1+dir.y*size, y=y1-dir.x*size} }
 							elseif dir.x*-lastdir.y + dir.y*lastdir.x > 0 then -- right bend, checked by getting the dot product between dir and lastDir:rotate(90)
 								local offsetx = -lastdir.y*size-lastdir.x*scaling


### PR DESCRIPTION
Fixes #1965

Fixes almost infinitely long line extensions in certain situations when a line returns back in the direction it came from and floating point math decides to return *almost* -1 instead of -1 (but just a *little* below).