### PR TITLE
Issue #1974: E2: Ctrl+H Replace 'Match Whole Word' doesn't work

### DIFF
--- a/lua/wire/client/text_editor/texteditor.lua
+++ b/lua/wire/client/text_editor/texteditor.lua
@@ -1116,7 +1116,7 @@ function EDITOR:ReplaceAll( str, replacewith )
 		self:SelectAll()
 		self:SetSelection( txt2 )
 	else
-			txt = string_gsub( txt, str, replacewith )
+		txt = string_gsub( txt, pattern, replacewith )
 
 		self:SelectAll()
 		self:SetSelection( txt )


### PR DESCRIPTION
Corrected issue with ReplaceAll function not taking Match Whole Word cases into account.