### PR TITLE
Remove a broken E2 peephole optimization

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/optimizer.lua
+++ b/lua/entities/gmod_wire_expression2/base/optimizer.lua
@@ -142,8 +142,6 @@ function peephole.mul(instruction)
     end
     -- (mul 1 x) → x
     if instruction[3][1] == "literal" and instruction[3][3] == 1 then return instruction[4] end
-    -- (mul 0 x) → 0
-    if instruction[3][1] == "literal" and instruction[3][3] == 0 then return instruction[3] end
     -- (mul -1 x) → (neg x)
     if instruction[3][1] == "literal" and instruction[3][3] == -1 then
         return {"neg", instruction[2], instruction[4]}


### PR DESCRIPTION
Previously, the E2 optimizer would replace `(mul 0 x)` with 0, for any x. This also included when x is a vector, which means that the optimizer produced incorrect results. The correct thing to do would be to replace it with the zero value of the same type as the result of `(mul 0 x)`, but this optimizer unfortunately runs before type-checking so that information isn't available.

Fixes #1975.