### PR TITLE
Fix parent tree traversal

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/constraint.lua
+++ b/lua/entities/gmod_wire_expression2/core/constraint.lua
@@ -144,7 +144,7 @@ getConnectedEntities = function(ent, filter_lookup, result, already_added)
 
 	if filter_lookup then
 		if filter_lookup.Parented then -- add parented entities
-			getConnectedEx(ent:GetChildren(),filter_lookup, result, already_added)
+			getConnectedEx(ent:GetParent(),filter_lookup, result, already_added)
 			for _, e in pairs(ent:GetChildren()) do
 				getConnectedEx( e, filter_lookup, result, already_added )
 			end


### PR DESCRIPTION
Fixed apparent typo causing getConnectedEntities to only traverse up a parent tree and not down it, causing incomplete results.