### PR TITLE
Uneditable credits box @wire_expression2_editor.lua

### DIFF
--- a/lua/wire/client/text_editor/wire_expression2_editor.lua
+++ b/lua/wire/client/text_editor/wire_expression2_editor.lua
@@ -787,7 +787,8 @@ function Editor:InitComponents()
 
 	self.C.Control = self:addComponent(vgui.Create("Panel", self), -350, 52, 342, -32) -- Control Panel
 	self.C.Credit = self:addComponent(vgui.Create("DTextEntry", self), -160, 52, 150, 150) -- Credit box
-
+	self.C.Credit:SetEditable(false)
+	
 	self:CreateTab("generic")
 
 	-- extra component options


### PR DESCRIPTION
Just added self.C.Credit:SetEditable(false) at line 790
Not sure if anyone cares about this