### PR TITLE
Fixed physenv error for Linux

### DIFF
--- a/lua/wire/wireshared.lua
+++ b/lua/wire/wireshared.lua
@@ -1008,6 +1008,7 @@ end
 -- Ensures that the force is within the range of a float, to prevent
 -- physics engine crashes
 -- 2*maxmass*maxvelocity should be enough impulse to do whatever you want.
+-- Timer resolves issue with table not existing until next tick on Linux
 local max_force, min_force
 hook.Add("InitPostEntity","WireForceLimit",function()
 	timer.Simple(0, function()

--- a/lua/wire/wireshared.lua
+++ b/lua/wire/wireshared.lua
@@ -1010,8 +1010,10 @@ end
 -- 2*maxmass*maxvelocity should be enough impulse to do whatever you want.
 local max_force, min_force
 hook.Add("InitPostEntity","WireForceLimit",function()
-	max_force = 100000*physenv.GetPerformanceSettings().MaxVelocity
-	min_force = -max_force
+	timer.Simple(0, function()
+		max_force = 100000*physenv.GetPerformanceSettings().MaxVelocity
+		min_force = -max_force
+	end)
 end)
 
 -- Nan never equals itself, so if the value doesn't equal itself replace it with 0.


### PR DESCRIPTION
On Linux for some reason `physenv.GetPerformanceSettings()` table will come to existence the tick following `InitPostEntity`, resulting in this error:
```
[ERROR] addons/wire/lua/wire/wireshared.lua:1013: attempt to index a nil value
  1. v - addons/wire/lua/wire/wireshared.lua:1013
   2. unknown - lua/includes/modules/hook.lua:84
```
A simple timer fixes the problem, it shouldn't affect anything else.