### PR TITLE
ZCPU Сompiler bugfix 

### DIFF
--- a/lua/wire/client/hlzasm/hc_compiler.lua
+++ b/lua/wire/client/hlzasm/hc_compiler.lua
@@ -627,6 +627,7 @@ end
 -- Set special labels
 function HCOMP:SetSpecialLabels()
   -- Set special labels
+  self:DefineLabel("__PTR__").Type = "Pointer"
   self:SetLabel("programsize",self.WritePointer)
   self:SetLabel("__PROGRAMSIZE__",self.WritePointer)
   self:SetLabel("__DATE_YEAR__",  tonumber(os.date("%Y")))

--- a/lua/wire/client/hlzasm/hc_compiler.lua
+++ b/lua/wire/client/hlzasm/hc_compiler.lua
@@ -510,6 +510,8 @@ function HCOMP:UnprotectedCompile()
 
     return true
   else
+    -- Reset compiler to start point and return false when work is done
+    self.Stage = 1
     return false
   end
 end

--- a/lua/wire/client/hlzasm/hc_output.lua
+++ b/lua/wire/client/hlzasm/hc_output.lua
@@ -43,6 +43,17 @@ function HCOMP:Resolve(block)
     else -- Fixed-size instructions
       self.WritePointer = self.WritePointer + 6
     end
+    -- Preventive setting up __PTR__ as constant number (const = currentOpcodeOffset + currentOpcodeSize)
+    for i=1,#block.Operands do
+      if istable(block.Operands[i].Constant) then
+        for j=1, #block.Operands[i].Constant do
+          if (block.Operands[i].Constant[j].Data == "__PTR__") then
+              block.Operands[i].Constant[j].Data = self.WritePointer
+              block.Operands[i].Constant[j].Type = self.TOKEN.NUMBER
+          end
+        end
+      end
+    end
   end
 
   -- Account for extra data in the block
@@ -176,8 +187,6 @@ function HCOMP:Output(block)
     self:OutputLibrary(block)
     return
   end
-  -- Update absolute pointer to current opcode(block)
-  self:SetLabel("__PTR__",self.WritePointer)
   -- Resolve constant values in the block
   if block.Opcode then
     for i=1,#block.Operands do

--- a/lua/wire/client/hlzasm/hc_output.lua
+++ b/lua/wire/client/hlzasm/hc_output.lua
@@ -12,7 +12,7 @@
 function HCOMP:Resolve(block)
   -- Set offset for the block
   block.Offset = self.WritePointer
-  self:SetLabel("__PTR__",self.WritePointer)
+  
 
   -- Set pointer offset
   block.PointerOffset = self.PointerOffset
@@ -176,7 +176,8 @@ function HCOMP:Output(block)
     self:OutputLibrary(block)
     return
   end
-
+  -- Update absolute pointer to current opcode(block)
+  self:SetLabel("__PTR__",self.WritePointer)
   -- Resolve constant values in the block
   if block.Opcode then
     for i=1,#block.Operands do

--- a/lua/wire/client/hlzasm/hc_syntax.lua
+++ b/lua/wire/client/hlzasm/hc_syntax.lua
@@ -732,7 +732,7 @@ function HCOMP:Statement() local TOKEN = self.TOKEN
   if self.CurrentToken == 1 then
 	while not(self:MatchToken(TOKEN.EOF)) do
       if self:MatchToken(TOKEN.IDENT) then
-        if(self:PeekToken() == TOKEN.DCOLON) and self:SourceLineEnd() then
+        if(self:PeekToken() == TOKEN.DCOLON) then
           local label = self:DefineLabel(self.TokenData)
           label.Type = "Pointer"
           label.Defined = true
@@ -1485,11 +1485,11 @@ function HCOMP:Statement() local TOKEN = self.TOKEN
       end
       self:MatchToken(TOKEN.COLON)
       return true
-    elseif (self:PeekToken() == TOKEN.DCOLON) and self:SourceLineEnd() then
+    elseif (self:PeekToken() == TOKEN.DCOLON) then
 	    local label = self:GetLabel(self.TokenData)
 	    label.Leaf = self:NewLeaf()
-      label.Leaf.Opcode = "LABEL"
-      label.Leaf.Label = label
+            label.Leaf.Opcode = "LABEL"
+            label.Leaf.Label = label
 	    self:AddLeafToTail(label.Leaf)
 	    self:ExpectToken(TOKEN.DCOLON)
 	  return true

--- a/lua/wire/client/hlzasm/hc_tokenizer.lua
+++ b/lua/wire/client/hlzasm/hc_tokenizer.lua
@@ -516,7 +516,10 @@ function HCOMP:NextToken()
   self.CurrentToken = self.CurrentToken + 1
 end
 
-
+-- Go to previous token
+function HCOMP:PreviousToken()
+  self.CurrentToken = self.CurrentToken - 1
+end
 
 
 -- Returns next token type. Looks forward into stream if offset is specified
@@ -578,5 +581,15 @@ function HCOMP:CurrentSourcePosition()
     return self.Tokens[self.CurrentToken-1].Position
   else
     return { Line = 1, Col = 1, File = "HL-ZASM" }
+  end
+end
+
+
+-- Returns true if token is last at source file line (necessary, for example to see the difference between SS:EAX and LABEL:) 
+function HCOMP:SourceLineEnd()
+  if (self.Tokens[self.CurrentToken].Position.Line ~= self.Tokens[self.CurrentToken+1].Position.Line) then
+    return true
+  else
+    return false
   end
 end

--- a/lua/wire/client/hlzasm/hc_tokenizer.lua
+++ b/lua/wire/client/hlzasm/hc_tokenizer.lua
@@ -583,13 +583,3 @@ function HCOMP:CurrentSourcePosition()
     return { Line = 1, Col = 1, File = "HL-ZASM" }
   end
 end
-
-
--- Returns true if token is last at source file line (necessary, for example to see the difference between SS:EAX and LABEL:) 
-function HCOMP:SourceLineEnd()
-  if (self.Tokens[self.CurrentToken].Position.Line ~= self.Tokens[self.CurrentToken+1].Position.Line) then
-    return true
-  else
-    return false
-  end
-end


### PR DESCRIPTION
Bug occurs when you trying to calculate constant expression if the label is placed after the constant expression
For example following code:
```
jmp label+label
test:
jmp eax, label+label
```
Will be compiled into this:
```
mov eax, label
add eax, label
jmp eax
test:
jmp (label+label)
```
This is annoying because it additionally uses an absolutely unnecessary operations and resets the important register. 

Also fixed `__PTR__` pointer which is constant and indicates the current address of the operation, without it impossible to make address independent code (`JMPR` opcode for example).