### PR TITLE
Fixed E2Editor missing "Save As" prompt after fresh install.

### DIFF
--- a/lua/wire/client/text_editor/wire_expression2_editor.lua
+++ b/lua/wire/client/text_editor/wire_expression2_editor.lua
@@ -1949,8 +1949,9 @@ function Editor:Setup(nTitle, nLocation, nEditorType)
 
 	if nEditorType == "E2" then
 		self.E2 = true
-		self:NewScript(true) -- insert default code
 	end
+
+	self:NewScript(true) -- Opens initial tab, in case OpenOldTabs is disabled or fails.
 
 	if wire_expression2_editor_openoldtabs:GetBool() then
 		self:OpenOldTabs()


### PR DESCRIPTION
Fixes a minor bug while trying to leverage the E2 editor, similar to how CPU, GPU, and SPU do it.

On a completely fresh install, Editor:OpenOldTabs will silently fail, leaving the initial "generic" tab in an inconsistent state. Attempting to save while in this state silently fails without error, and does not write the file nor bring up the "Save As" prompt.

PR fixes this by hoisting out a call to Editor:NewScript which is called before Editor:OpenOldTabs. Previously, this was done only for E2 editors, but is now done for any editor. If Editor:OpenOldTabs does _not_ fail, then it automatically removes the initial tab, making this change transparent in cases not addressed by the bugfix.