### PR TITLE
Fixed hook in gmod_wire_pod.lua so it ignores nil

### DIFF
--- a/lua/entities/gmod_wire_pod.lua
+++ b/lua/entities/gmod_wire_pod.lua
@@ -190,7 +190,7 @@ function ENT:LinkEnt( pod )
 
 	-- if pod is still not a vehicle even after all of the above, then error out
 	if not IsValid(pod) or not pod:IsVehicle() then return false, "Must link to a vehicle" end
-	if not hook.Run( "CanTool", self:GetPlayer(), WireLib.dummytrace(pod), "wire_pod" ) then return false, "You do not have permission to access this vehicle" end
+	if hook.Run( "CanTool", self:GetPlayer(), WireLib.dummytrace(pod), "wire_pod" ) == false then return false, "You do not have permission to access this vehicle" end
 
 	self:SetPod( pod )
 	WireLib.SendMarks(self, {pod})


### PR DESCRIPTION
This was found by @Stromic
Our server is using GProtect and we came across an issue where we could not use any Advanced Dupe with Wire Pods. It turns out it was because the `hook.Run` was checking for `false` and `nil` instead of just `false`.