### PR TITLE
Clear clientside hologram buffers

### DIFF
--- a/lua/entities/gmod_wire_hologram.lua
+++ b/lua/entities/gmod_wire_hologram.lua
@@ -26,19 +26,19 @@ if CLIENT then
 	net.Receive( "holoQueueClear", function()
 		local id = net.ReadUInt(16)
 
-		--clip_buffer
+		--Holo Clips
 		clip_buffer[id] = nil
 
-		--scale_buffer
+		--Holo Scales
 		scale_buffer[id] = nil
 
-		--bone_scale_buffer
+		--Holo Bone Scales
 		bone_scale_buffer[id] = nil
 
-		--vis_buffer
+		--Holo Enable/Disable
 		vis_buffer[id] = nil
 
-		--Clips
+		--Holo Colors
 		player_color_buffer[id] = nil
 	end)
 

--- a/lua/entities/gmod_wire_hologram.lua
+++ b/lua/entities/gmod_wire_hologram.lua
@@ -25,27 +25,21 @@ if CLIENT then
 
 	net.Receive( "holoQueueClear", function()
 		local id = net.ReadUInt(16)
-		print("Clearing: ", id)
+
 		--clip_buffer
-		if not (clip_buffer[id] == nil) then
-			clip_buffer[id] = nil
-		end
+		clip_buffer[id] = nil
+
 		--scale_buffer
-		if not (scale_buffer[id] == nil) then
-			scale_buffer[id] = nil
-		end
+		scale_buffer[id] = nil
+
 		--bone_scale_buffer
-		if not (bone_scale_buffer[id] == nil) then
-			bone_scale_buffer[id] = nil
-		end
+		bone_scale_buffer[id] = nil
+
 		--vis_buffer
-		if not (vis_buffer[id] == nil) then
-			vis_buffer[id] = nil
-		end
+		vis_buffer[id] = nil
+
 		--Clips
-		if not (player_color_buffer[id] == nil) then
-			player_color_buffer[id] = nil
-		end
+		player_color_buffer[id] = nil
 	end)
 
 	function ENT:Initialize()

--- a/lua/entities/gmod_wire_hologram.lua
+++ b/lua/entities/gmod_wire_hologram.lua
@@ -24,7 +24,7 @@ if CLIENT then
 	local player_color_buffer = {}
 
 	net.Receive( "holoQueueClear", function()
-		local id = net.ReadUInt(18)
+		local id = net.ReadUInt(16)
 		print("Clearing: ", id)
 		--clip_buffer
 		if not (clip_buffer[id] == nil) then
@@ -415,7 +415,7 @@ util.AddNetworkString( "holoQueueClear" )
 function ENT:OnRemove()
 	-- Let all clients know this holo was removed, incase it was in a different PVS from them since creation
 	net.Start( "holoQueueClear" )
-		net.WriteUInt( self:EntIndex(), 18 )
+		net.WriteUInt( self:EntIndex(), 16 )
 	net.Broadcast()
 end
 

--- a/lua/entities/gmod_wire_hologram.lua
+++ b/lua/entities/gmod_wire_hologram.lua
@@ -23,6 +23,31 @@ if CLIENT then
 	local vis_buffer = {}
 	local player_color_buffer = {}
 
+	net.Receive( "holoQueueClear", function()
+		local id = net.ReadUInt(18)
+		print("Clearing: ", id)
+		--clip_buffer
+		if not (clip_buffer[id] == nil) then
+			clip_buffer[id] = nil
+		end
+		--scale_buffer
+		if not (scale_buffer[id] == nil) then
+			scale_buffer[id] = nil
+		end
+		--bone_scale_buffer
+		if not (bone_scale_buffer[id] == nil) then
+			bone_scale_buffer[id] = nil
+		end
+		--vis_buffer
+		if not (vis_buffer[id] == nil) then
+			vis_buffer[id] = nil
+		end
+		--Clips
+		if not (player_color_buffer[id] == nil) then
+			player_color_buffer[id] = nil
+		end
+	end)
+
 	function ENT:Initialize()
 		self.bone_scale = {}
 		self:DoScale()
@@ -385,6 +410,14 @@ if CLIENT then
 end
 
 -- Server
+util.AddNetworkString( "holoQueueClear" )
+
+function ENT:OnRemove()
+	-- Let all clients know this holo was removed, incase it was in a different PVS from them since creation
+	net.Start( "holoQueueClear" )
+		net.WriteUInt( self:EntIndex(), 18 )
+	net.Broadcast()
+end
 
 function ENT:Initialize()
 	self:SetSolid(SOLID_NONE)


### PR DESCRIPTION
Clear buffers clientside for holograms upon the holograms remove hook being called serverside, 
As the buffers currently will stay populated clientside after holo has been removed if the client has never been in the same PVS as the holo, meaning those buffers can end up being applied to the wrong holograms if and when the ent ids get reused later.

Fixes what 69c7e9a262bf0a463135715f07bd99f1d3c627ba attemted to fix