### PR TITLE
Reference to Holo object on the holo entity

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/hologram.lua
@@ -584,6 +584,8 @@ local function CreateHolo(self, index, pos, scale, ang, color, model)
 
 	reset_clholo(Holo, scale) -- Reset scale, clips, and visible status
 
+	prop.Holo = Holo
+
 	return prop
 end
 

--- a/lua/entities/gmod_wire_expression2/core/hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/hologram.lua
@@ -584,7 +584,7 @@ local function CreateHolo(self, index, pos, scale, ang, color, model)
 
 	reset_clholo(Holo, scale) -- Reset scale, clips, and visible status
 
-	prop.Holo = Holo
+	prop.E2HoloData = Holo
 
 	return prop
 end


### PR DESCRIPTION
Small change but it will help with external compatibility 

For example, avoiding nonsense like [this](https://github.com/shadowscion/Prop2Mesh/blob/master/lua/weapons/gmod_tool/stools/prop2mesh.lua#L358) just to access the scale and clips serverside