### PR TITLE
Add findAllowBlockedClasses(N)

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/find.lua
+++ b/lua/entities/gmod_wire_expression2/core/find.lua
@@ -767,7 +767,7 @@ e2function void findUseHardcodedFilter(useHardcodedFilter)
 	if useHardcodedFilter ~= 0 then
 		self.data.find.filter_default = filter_default(self)
 	else
-		self.data.find.filter_default = filter_none
+		self.data.find.filter_default = filter_all
 	end
 end
 

--- a/lua/entities/gmod_wire_expression2/core/find.lua
+++ b/lua/entities/gmod_wire_expression2/core/find.lua
@@ -762,6 +762,7 @@ end
 --[[************************************************************************]]--
 __e2setcost(2)
 
+--- Enables or disables the hardcoded entity class filter, blocking or allowing you to find entities with classes like "prop_dynamic", "physgun_beam" or "gmod_ghost".
 e2function void findUseHardcodedFilter(useHardcodedFilter)
 	if useHardcodedFilter ~= 0 then
 		self.data.find.filter_default = filter_default(self)

--- a/lua/entities/gmod_wire_expression2/core/find.lua
+++ b/lua/entities/gmod_wire_expression2/core/find.lua
@@ -769,12 +769,12 @@ end
 --[[************************************************************************]]--
 __e2setcost(2)
 
---- Enables or disables the hardcoded entity class filter, blocking or allowing you to find entities with classes like "prop_dynamic", "physgun_beam" or "gmod_ghost".
-e2function void findUseHardcodedFilter(useHardcodedFilter)
+--- Allows or disallows finding entities on the hardcoded class blocklist, including classes like "prop_dynamic", "physgun_beam" and "gmod_ghost".
+e2function void findAllowBlockedClasses(useHardcodedFilter)
 	if useHardcodedFilter ~= 0 then
-		self.data.find.filter_default = filter_default(self)
-	else
 		self.data.find.filter_default = filter_default_without_class_blocklist(self)
+	else
+		self.data.find.filter_default = filter_default(self)
 	end
 end
 

--- a/lua/entities/gmod_wire_expression2/core/find.lua
+++ b/lua/entities/gmod_wire_expression2/core/find.lua
@@ -762,6 +762,16 @@ end
 --[[************************************************************************]]--
 __e2setcost(2)
 
+e2function void findUseHardcodedFilter(useHardcodedFilter)
+	if useHardcodedFilter ~= 0 then
+		self.data.find.filter_default = filter_default(self)
+	else
+		self.data.find.filter_default = filter_none
+	end
+end
+
+--[[************************************************************************]]--
+
 --- Returns the indexed entity from the previous find event (valid parameters are 1 to the number of entities found)
 e2function entity findResult(index)
 	return self.data.findlist[index]

--- a/lua/entities/gmod_wire_expression2/core/find.lua
+++ b/lua/entities/gmod_wire_expression2/core/find.lua
@@ -70,6 +70,13 @@ local function filter_default(self)
 	end
 end
 
+local function filter_default_without_class_blocklist(self)
+	local chip = self.entity
+	return function(ent)
+		return ent ~= chip
+	end
+end
+
 -- -- some filter criterion generators -- --
 
 -- Generates a filter that filters out everything not in a lookup table.
@@ -767,7 +774,7 @@ e2function void findUseHardcodedFilter(useHardcodedFilter)
 	if useHardcodedFilter ~= 0 then
 		self.data.find.filter_default = filter_default(self)
 	else
-		self.data.find.filter_default = filter_all
+		self.data.find.filter_default = filter_default_without_class_blocklist(self)
 	end
 end
 

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -993,6 +993,7 @@ E2Helper.Descriptions["findByClass(s)"] = "Find all entities with the given clas
 E2Helper.Descriptions["findPlayerByName(s)"] = "Returns the player with the given name, this is an exception to the rule"
 E2Helper.Descriptions["findPlayerBySteamID(s)"] = "Returns the player with the given SteamID32"
 E2Helper.Descriptions["findPlayerBySteamID64(s)"] = "Returns the player with the given SteamID64"
+E2Helper.Descriptions["findAllowBlockedClasses(n)"] = "Allows or disallows finding entities on the hardcoded class blocklist, including classes like \"prop_dynamic\", \"physgun_beam\" and \"gmod_ghost\"."
 E2Helper.Descriptions["findResult(n)"] = "Returns the indexed entity from the previous find event (valid parameters are 1 to the number of entities found)"
 E2Helper.Descriptions["findClosest(v)"] = "Returns the closest entity to the given point from the previous find event"
 E2Helper.Descriptions["findToArray()"] = "Formats the query as an array, R[Index,entity] to get an entity"


### PR DESCRIPTION
findAllowBlockedClasses(0) - (default behaviour) Use the hardcoded entity type filter from A Land Before Git History
findAllowBlockedClasses(1) - Don't.

As far as I can tell, making the hardcoded filter optional won't add security issues or anything since you can already do this by iterating all the entity IDs and putting them into entity(N).

Removing the filter outright is probably not a good idea since a lot of people's chips depend on the default behaviour being the way it is.