### PR TITLE
Cleanup laser pointer when dropped

### DIFF
--- a/lua/weapons/laserpointer/cl_init.lua
+++ b/lua/weapons/laserpointer/cl_init.lua
@@ -40,7 +40,7 @@ function SWEP:ViewModelDrawn()
 end
 function SWEP:DrawWorldModel()
 	self.Weapon:DrawModel()
-	if self.Weapon:GetNWBool("Active") and self.WM then
+	if self.Weapon:GetNWBool("Active") and self.WM and self.IsHeld then
         //Draw the laser beam.
         render.SetMaterial( LASER )
 		local posang = self.WM:GetAttachment(self.WAttach)

--- a/lua/weapons/laserpointer/init.lua
+++ b/lua/weapons/laserpointer/init.lua
@@ -47,17 +47,12 @@ function SWEP:SecondaryAttack()
 	return true
 end
 
-function SWEP:OnDrop()
-	self:TriggerOutput("Active", 0)
-	self.Receiver = nil
-end
-
 function SWEP:TriggerOutput(name, value)
 	Wire_TriggerOutput(self.Receiver, name, value)
 end
 
 function SWEP:Think()
-	if not self.Active and self.Receiver and self.Receiver:IsValid() then return end
+	if not ( self.Active and self.Receiver and self.Receiver:IsValid() ) then return end
 
 	local beamTrace = self:GetBeamTrace()
 	local point = beamTrace.HitPos

--- a/lua/weapons/laserpointer/init.lua
+++ b/lua/weapons/laserpointer/init.lua
@@ -41,6 +41,13 @@ function SWEP:SecondaryAttack()
 	end
 end
 
+function SWEP:OnDrop()
+	self.Weapon:SetNWBool("Active", false)
+	self.Pointing = false
+	Wire_TriggerOutput(self.Receiver,"Active",0)
+	self.Receiver = nil
+end
+
 function SWEP:Think()
 	if(self.Pointing && self.Receiver && self.Receiver:IsValid())then
 		local trace = self:GetOwner():GetEyeTrace()

--- a/lua/weapons/laserpointer/shared.lua
+++ b/lua/weapons/laserpointer/shared.lua
@@ -19,3 +19,7 @@ SWEP.Secondary.ClipSize = -1
 SWEP.Secondary.DefaultClip = -1
 SWEP.Secondary.Automatic = false
 SWEP.Secondary.Ammo = "none"
+
+function SWEP:OwnerChanged()
+    self.IsHeld = IsValid(self:GetOwner())
+end

--- a/lua/weapons/laserpointer/shared.lua
+++ b/lua/weapons/laserpointer/shared.lua
@@ -21,5 +21,26 @@ SWEP.Secondary.Automatic = false
 SWEP.Secondary.Ammo = "none"
 
 function SWEP:OwnerChanged()
-    self.IsHeld = IsValid(self:GetOwner())
+	local owner = IsValid(self:GetOwner()) and self:GetOwner()
+	local isValidOwner = owner ~= false
+
+	self.IsHeld = isValidOwner
+	self.Wielder = isValidOwner and owner or nil
 end
+
+function SWEP:GetBarrelTip()
+	return self:GetPos() + self:GetForward() * 2
+end
+
+function SWEP:GetBeamTrace(beamStart)
+	if self.IsHeld then return self.Wielder:GetEyeTrace() end
+
+	beamStart = beamStart or self:GetBarrelTip()
+
+	return trace.TraceLine({
+		start = beamStart,
+		endpos = beamStart + self:GetForward() * 1000,
+		filter = self
+	})
+end
+

--- a/lua/weapons/laserpointer/shared.lua
+++ b/lua/weapons/laserpointer/shared.lua
@@ -4,7 +4,7 @@ SWEP.Purpose = ""
 SWEP.Instructions = "Left Click to designate targets. Right click to select laser receiver."
 SWEP.Category = "Wiremod"
 
-SWEP.Spawnable = true;
+SWEP.Spawnable = true
 SWEP.AdminOnly = false
 
 SWEP.viewModel = "models/weapons/v_pistol.mdl";
@@ -20,12 +20,16 @@ SWEP.Secondary.DefaultClip = -1
 SWEP.Secondary.Automatic = false
 SWEP.Secondary.Ammo = "none"
 
-function SWEP:OwnerChanged()
+function SWEP:UpdateHeldStatus()
 	local owner = IsValid(self:GetOwner()) and self:GetOwner()
 	local isValidOwner = owner ~= false
 
 	self.IsHeld = isValidOwner
 	self.Wielder = isValidOwner and owner or nil
+end
+
+function SWEP:OwnerChanged()
+	timer.Simple(0, function() self:UpdateHeldStatus() end)
 end
 
 function SWEP:GetBarrelTip()

--- a/lua/weapons/laserpointer/shared.lua
+++ b/lua/weapons/laserpointer/shared.lua
@@ -37,7 +37,7 @@ function SWEP:GetBeamTrace(beamStart)
 
 	beamStart = beamStart or self:GetBarrelTip()
 
-	return trace.TraceLine({
+	return util.TraceLine({
 		start = beamStart,
 		endpos = beamStart + self:GetForward() * 1000,
 		filter = self


### PR DESCRIPTION
**When an active laser pointer is dropped (via `Player:DropWeapon`) it triggers a lot of errors clientside until the weapon is picked up or removed.**

```
[wire] addons/wire/lua/weapons/laserpointer/cl_init.lua:48: attempt to call method 'GetEyeTrace' (a nil value)
  1. unknown - addons/wire/lua/weapons/laserpointer/cl_init.lua:48 (x67)
```

This error happens because the clientside code expects `SWEP:GetOwner()` to exist so it can perform a trace while drawing the beam, but after it's dropped, it won't have an owner.

**My patch just adds some cleanup functionality on `SWEP:OnDrop` serverside, and sets an `IsHeld` parameters in shared**, which the client then looks at to determine if it should draw the beam. Just setting the `IsHeld` should fix this error, so if the cleanup functionality is unwanted (could technically break some things, I guess? maybe?) I could remove it.

**This has been tested in sandbox; confirmed that it doesn't error anymore**

Another option which might be fun:
On drop, disconnect the laser pointer from all receivers, but _keep it active_, then modify the clientside code to say "if it has an owner, draw the beam between the owner and the owner's aimpos, but if there is no owner (dropped), draw the beam in a forward-ly direction."

That way a dropped, active laserpointer could sit on the ground with the laser still on.

I dunno, sounds fun to me. If that's preferable to y'all, I can implement that instead, but I figured just solving the error was a good first step.