### PR TITLE
Update HUD Indicator vehicle linking code

### DIFF
--- a/lua/entities/gmod_wire_hudindicator/init.lua
+++ b/lua/entities/gmod_wire_hudindicator/init.lua
@@ -283,7 +283,8 @@ end
 
 -- Despite everything being named "pod", any vehicle will work
 function ENT:LinkVehicle(pod)
-	if not IsValid(pod) or not string.find(pod:GetClass(), "prop_vehicle_") then return false end
+	pod = WireLib.GetClosestRealVehicle(pod, self:GetPos(), self:GetPlayer())
+	if not IsValid(pod) or not pod:IsVehicle() then return false end
 
 	local ply = nil
 	-- Check if a player is in pod first

--- a/lua/entities/gmod_wire_hudindicator/init.lua
+++ b/lua/entities/gmod_wire_hudindicator/init.lua
@@ -282,9 +282,9 @@ function ENT:SendHUDInfo(hidehud)
 end
 
 -- Despite everything being named "pod", any vehicle will work
-function ENT:LinkVehicle(pod)
+function ENT:LinkEnt(pod)
 	pod = WireLib.GetClosestRealVehicle(pod, self:GetPos(), self:GetPlayer())
-	if not IsValid(pod) or not pod:IsVehicle() then return false end
+	if not IsValid(pod) or not pod:IsVehicle() then return false, "Must link to a vehicle" end
 
 	local ply = nil
 	-- Check if a player is in pod first
@@ -306,10 +306,12 @@ function ENT:LinkVehicle(pod)
 	self.Pod = pod
 	self.PodPly = ply
 
+	WireLib.SendMarks(self, {pod})
+
 	return true
 end
 
-function ENT:UnLinkVehicle()
+function ENT:UnlinkEnt()
 	local ply = self.PodPly
 
 	if ply and self:CheckPodOnly(ply) then
@@ -318,6 +320,8 @@ function ENT:UnLinkVehicle()
 	end
 	self.Pod = nil
 	self.PodPly = nil
+
+	WireLib.SendMarks(self, {})
 end
 
 function ENT:Think()

--- a/lua/wire/stools/hudindicator.lua
+++ b/lua/wire/stools/hudindicator.lua
@@ -124,13 +124,6 @@ function TOOL:Reload( trace )
 		self:SetStage(1)
 	elseif (iNum == 1) then
 		if trace.Entity ~= self:GetEnt(1) then
-			if not string.find(trace.Entity:GetClass(), "prop_vehicle_") then
-				WireLib.AddNotify(self:GetOwner(), "HUD Indicators can only be linked to vehicles.", NOTIFY_GENERIC, 7)
-				self:ClearObjects()
-				self:SetStage(0)
-				return false
-			end
-
 			local ent = self:GetEnt(1)
 			local bool = ent:LinkVehicle(trace.Entity)
 

--- a/lua/wire/stools/hudindicator.lua
+++ b/lua/wire/stools/hudindicator.lua
@@ -3,6 +3,10 @@
 WireToolSetup.setCategory( "Visuals/Indicators" )
 WireToolSetup.open( "hudindicator", "Hud Indicator", "gmod_wire_hudindicator", nil, "Hud Indicators" )
 
+-- Pull in DrawHUD from SetupLinking
+-- This needs to be called here to prevent it from overwriting anything
+WireToolSetup.SetupLinking(true, "vehicle")
+
 if ( CLIENT ) then
 	language.Add( "Tool.wire_hudindicator.name", "Hud Indicator Tool (Wire)" )
 	language.Add( "Tool.wire_hudindicator.desc", "Spawns a Hud Indicator for use with the wire system." )
@@ -199,6 +203,8 @@ function TOOL:Think()
 end
 
 if (CLIENT) then
+	-- Override the DrawHUD method from SetupLinking()
+	local _DrawHUD = TOOL.DrawHUD
 	function TOOL:DrawHUD()
 		local isregistered = self:GetWeapon():GetNWBool("HUDIndicatorCheckRegister")
 
@@ -206,18 +212,7 @@ if (CLIENT) then
 			draw.WordBox(8, ScrW() / 2 + 10, ScrH() / 2 + 10, "Registered", "Default", Color(50, 50, 75, 192), Color(255, 255, 255, 255))
 		end
 
-		-- Copied from WireToolSetup.SetupLinking()
-		local trace = self:GetOwner():GetEyeTrace()
-		if self:CheckHitOwnClass(trace) and trace.Entity.Marks then
-			local markerpos = trace.Entity:GetPos():ToScreen()
-			for _, ent in pairs(trace.Entity.Marks) do
-				if IsValid(ent) then
-					local markpos = ent:GetPos():ToScreen()
-					surface.SetDrawColor( 255,255,100,255 )
-					surface.DrawLine( markerpos.x, markerpos.y, markpos.x, markpos.y )
-				end
-			end
-		end
+		_DrawHUD(self)
 	end
 end
 

--- a/lua/wire/stools/hudindicator.lua
+++ b/lua/wire/stools/hudindicator.lua
@@ -127,7 +127,7 @@ function TOOL:Reload( trace )
 			if success then
 				WireLib.AddNotify(self:GetOwner(), "Linked entity: " .. tostring(trace.Entity) .. " to the " .. self.Name, NOTIFY_GENERIC, 5)
 			else
-				WireLib.AddNotify(self:GetOwner(), message or "Could not link " .. self.Name, NOTIFY_ERROR, 5, NOTIFYSOUND_DRIP)
+				WireLib.AddNotify(self:GetOwner(), message or "Could not link " .. self.Name, NOTIFY_ERROR, 5, NOTIFYSOUND_DRIP3)
 				return false
 			end
 		else


### PR DESCRIPTION
Fixes #2091.

Makes the vehicle linking code more consistent with how other entities handle it.
Also makes it compatible with the methods defined in [WireToolSetup.SetupLinking](https://github.com/wiremod/wire/blob/master/lua/wire/tool_loader.lua#L536).