### PR TITLE
Fix CPU/GPU/SPU errors caused by null entity

### DIFF
--- a/lua/entities/gmod_wire_gpu/init.lua
+++ b/lua/entities/gmod_wire_gpu/init.lua
@@ -63,6 +63,8 @@ function ENT:SetMemoryModel(model,initial)
   if not initial then
     timer.Create("wire_gpu_modelupdate_"..math.floor(math.random()*1000000),0.1+math.random()*0.3,1,
       function()
+        if not self:IsValid() then return end
+
         umsg.Start("wire_gpu_memorymodel")
           umsg.Long(self:EntIndex())
           umsg.Long (self.RAMSize)
@@ -80,6 +82,8 @@ end
 function ENT:ResendCache(player)
   timer.Create("wire_gpu_resendtimer_"..math.floor(math.random()*1000000),0.4+math.random()*1.2,1,
     function()
+      if not self:IsValid() then return end
+
       self.Cache:Flush()
       for address,value in pairs(self.Memory) do
         self:WriteCell(address,value,player)

--- a/lua/entities/gmod_wire_gpu/init.lua
+++ b/lua/entities/gmod_wire_gpu/init.lua
@@ -61,7 +61,7 @@ function ENT:SetMemoryModel(model,initial)
   end
 
   if not initial then
-    timer.Create("wire_gpu_modelupdate_"..math.floor(math.random()*1000000),0.1+math.random()*0.3,1,
+    timer.Simple(0.1+math.random()*0.3,
       function()
         if not self:IsValid() then return end
 
@@ -80,7 +80,7 @@ end
 -- Resend all GPU cache to newly spawned player
 --------------------------------------------------------------------------------
 function ENT:ResendCache(player)
-  timer.Create("wire_gpu_resendtimer_"..math.floor(math.random()*1000000),0.4+math.random()*1.2,1,
+  timer.Simple(0.4+math.random()*1.2,
     function()
       if not self:IsValid() then return end
 

--- a/lua/entities/gmod_wire_spu/init.lua
+++ b/lua/entities/gmod_wire_spu/init.lua
@@ -46,7 +46,7 @@ function ENT:Initialize()
     self.SoundSources[i]:PhysicsDestroy()
   end
 
-  timer.Create("wire_spu_soundsources_"..math.floor(math.random()*1000000),0.1+math.random()*0.3,1,
+  timer.Simple(0.1+math.random()*0.3,
     function()
       if not self:IsValid() then return end
 
@@ -88,7 +88,7 @@ function ENT:SetMemoryModel(model,initial)
   end
 
   if not initial then
-    timer.Create("wire_spu_modelupdate_"..math.floor(math.random()*1000000),0.1+math.random()*0.3,1,
+    timer.Simple(0.1+math.random()*0.3,
       function()
         if not self:IsValid() then return end
 
@@ -107,7 +107,7 @@ end
 -- Resend all SPU cache to newly spawned player
 --------------------------------------------------------------------------------
 function ENT:ResendCache(player)
-  timer.Create("wire_spu_resendtimer_"..math.floor(math.random()*1000000),0.4+math.random()*1.2,1,
+  timer.Simple(0.4+math.random()*1.2,
     function()
       if not self:IsValid() then return end
 

--- a/lua/entities/gmod_wire_spu/init.lua
+++ b/lua/entities/gmod_wire_spu/init.lua
@@ -48,6 +48,8 @@ function ENT:Initialize()
 
   timer.Create("wire_spu_soundsources_"..math.floor(math.random()*1000000),0.1+math.random()*0.3,1,
     function()
+      if not self:IsValid() then return end
+
       umsg.Start("wire_spu_soundsources")
         umsg.Long(self:EntIndex())
          for i=0,WireSPU_MaxChannels-1 do
@@ -88,6 +90,8 @@ function ENT:SetMemoryModel(model,initial)
   if not initial then
     timer.Create("wire_spu_modelupdate_"..math.floor(math.random()*1000000),0.1+math.random()*0.3,1,
       function()
+        if not self:IsValid() then return end
+
         umsg.Start("wire_spu_memorymodel")
           umsg.Long(self:EntIndex())
           umsg.Long (self.RAMSize)
@@ -105,6 +109,8 @@ end
 function ENT:ResendCache(player)
   timer.Create("wire_spu_resendtimer_"..math.floor(math.random()*1000000),0.4+math.random()*1.2,1,
     function()
+      if not self:IsValid() then return end
+
       self.Cache:Flush()
       for address,value in pairs(self.Memory) do
         self:WriteCell(address,value,player)

--- a/lua/wire/cpulib.lua
+++ b/lua/wire/cpulib.lua
@@ -484,7 +484,7 @@ if SERVER then
   net.Receive("wire_cpulib_buffer", function(netlen, player)
     local Buffer = CPULib.DataBuffer[player:UserID()]
     if (not Buffer) or (Buffer.Player ~= player) then return end
-    if not Buffer.Entity then return end
+    if not IsValid(Buffer.Entity) then return end
 
     for _ = 1, net.ReadUInt(16) do
       Buffer.Data[net.ReadUInt(24)] = net.ReadDouble()


### PR DESCRIPTION
Fixes #1994.

Fixes errors caused by a CPU/GPU/SPU being deleted before its queued upload/cache resend/model reset/sound source init happens.
