### PR TITLE
Fix GPU trying to write past end of RAM when writing to MemBus

### DIFF
--- a/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
+++ b/lua/entities/gmod_wire_gpu/cl_gpuvm.lua
@@ -107,6 +107,18 @@ function ENT:OverrideVM()
     end
   end
 
+  self.VM.ExternalWrite = function(VM, Address, Value)
+    if (Address >= 65536) and (Address <= 131071) then
+      return true
+    elseif Address < 0 then
+      VM:WritePort(-Address - 1, Value)
+      return true
+    end
+
+    VM:Interrupt(7, Address)
+    return false
+  end
+
   -- Add internal registers
   self.VM.InternalRegister[128] = "EntryPoint0"
   self.VM.InternalRegister[129] = "EntryPoint1"


### PR DESCRIPTION
The unconditional BaseWriteCell call was making GPUs with less than 128k of RAM try to write to the MemBus via the default ExternalWrite handler, which halts the VM when called with a MemBus address.