### PR TITLE
optimize base_wire_entity client and serverside

### DIFF
--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -195,7 +195,8 @@ if CLIENT then
 
 	-- Custom better version of this base_gmodentity function
 	function ENT:BeingLookedAtByLocalPlayer()
-		local trbool = BaseClass.BeingLookedAtByLocalPlayer(self)
+		local trace = LocalPlayer():GetEyeTrace()
+		local trbool = (trace.Entity == self and trace.HitPos:DistToSqr(LocalPlayer():GetShootPos()) > 40000) --this is 200^2
 
 		if self.playerWasLookingAtMe ~= trbool then
 			net.Start( "wire_overlay_request" )
@@ -304,23 +305,41 @@ end
 -- It allows us to optionally send values rather than entire strings, which saves networking
 -- It also allows us to only update overlays when someone is looking at the entity.
 
+local function cleanInvalidPlayers()
+	for k, v in ipairs( self.playersRequestingOverlayNumeric ) do
+		if !IsValid(v) then table.remove( self.playersRequestingOverlayNumeric, k ) end
+	end
+end
+
 function ENT:SetOverlayText( txt )
 	if not self.OverlayData then
 		self.OverlayData = {}
 	end
-	if txt and #txt > 1024 then
-		txt = string.sub(txt,1,1024)
+	if txt and #txt > 5000 then
+		txt = string.sub(txt,1,5000)
 	end
-	self.OverlayData.__dirty = self.OverlayData.txt ~= txt
 	self.OverlayData.txt = txt
+	if CLIENT then return end
+	if #self.playersRequestingOverlayNumeric == 0 then return end
+	cleanInvalidPlayers()
+	net.Start( "wire_overlay_txt", true )
+		net.WriteEntity( self )
+		net.WriteString( self.OverlayData.txt )
+	net.Send(self.playersRequestingOverlayNumeric)
 end
 
 function ENT:SetOverlayData( data )
-	if data.txt and #data.txt > 1024 then
-		data.txt = string.sub(data.txt,1,1024)
+	if data.txt and #data.txt > 5000 then
+		data.txt = string.sub(data.txt,1,5000)
 	end
 	self.OverlayData = data
-	self.OverlayData.__dirty = true
+	if CLIENT then return end
+	if #self.playersRequestingOverlayNumeric == 0 then return end
+	cleanInvalidPlayers()
+	net.Start( "wire_overlay_data", true )
+		net.WriteEntity( self )
+		net.WriteTable( self.OverlayData )
+	net.Send(self.playersRequestingOverlayNumeric)
 end
 
 function ENT:GetOverlayData()
@@ -341,40 +360,23 @@ util.AddNetworkString( "wire_overlay_request" )
 -- Other functions
 --------------------------------------------------------------------------------
 
-local function sendWireOverlays()
-	local found = {}
-	for _, ply in ipairs(player.GetAll()) do
-		local sendEnt = ply.wireSendOverlay
-		if sendEnt and sendEnt:IsValid() then
-			found[sendEnt.OverlayData] = true
-			if sendEnt.OverlayData.__dirty then
-				net.Start( "wire_overlay_data", true )
-					net.WriteEntity( sendEnt )
-					net.WriteTable( sendEnt.OverlayData )
-				net.Send(ply)
-			end
-		else
-			ply.wireSendOverlay = nil
-		end
-	end
-	if next(found) then
-		for OverlayData in pairs(found) do
-			OverlayData.__dirty = false
-		end
-	else
-		hook.Remove("Think","Wire_SendOverlayData")
-	end
-end
+ENT.playersRequestingOverlayNumeric = {}
 
 net.Receive( "wire_overlay_request", function( len, ply )
 	local ent = net.ReadEntity()
 	if not IsValid(ent) then return end
 	if net.ReadBool() then
-		ply.wireSendOverlay = ent
-		ent.OverlayData.__dirty = true
-		hook.Add("Think","Wire_SendOverlayData",sendWireOverlays)
+		if not table.HasValue(ent.playersRequestingOverlayNumeric,ply) then
+			table.insert(ent.playersRequestingOverlayNumeric,ply)
+		end
+		if ent.OverlayData then
+			net.Start( "wire_overlay_data" )
+				net.WriteEntity( ent )
+				net.WriteTable( ent.OverlayData )
+			net.Send(ply)
+		end
 	else
-		ply.wireSendOverlay = nil
+		table.RemoveByValue(ent.playersRequestingOverlayNumeric,ply)
 	end
 end )
 

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -12,9 +12,10 @@ ENT.IsWire = true
 if CLIENT then
 	local wire_drawoutline = CreateClientConVar("wire_drawoutline", 1, true, false)
 
+	ENT.playerWasLookingAtMe = false
+
 	function ENT:Initialize()
 		self.NextRBUpdate = CurTime() + 0.25
-		self.playerWasLookingAtMe = false
 	end
 
 	function ENT:Draw()
@@ -354,6 +355,8 @@ util.AddNetworkString( "wire_overlay_request" )
 -- Other functions
 --------------------------------------------------------------------------------
 
+ENT.playersRequestingOverlayNumeric = {}
+
 net.Receive( "wire_overlay_request", function( len, ply )
 	local ent = net.ReadEntity()
 	if not IsValid(ent) then return end
@@ -373,7 +376,7 @@ net.Receive( "wire_overlay_request", function( len, ply )
 end )
 
 hook.Add("PlayerDisconnected","wire_playersRequestingOverlay_cleanup",function(ply)
-	table.RemoveByValue(self.playersRequestingOverlayNumeric,ply)
+	table.RemoveByValue(ENT.playersRequestingOverlayNumeric,ply)
 end)
 
 function ENT:Initialize()
@@ -381,7 +384,6 @@ function ENT:Initialize()
 	self:PhysicsInit(SOLID_VPHYSICS)
 	self:SetMoveType(MOVETYPE_VPHYSICS)
 	self:SetSolid(SOLID_VPHYSICS)
-	self.playersRequestingOverlayNumeric = {}
 	self.WireDebugName = self.WireDebugName or (self.PrintName and self.PrintName:sub(6)) or self:GetClass():gsub("gmod_wire", "")
 end
 

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -325,9 +325,8 @@ function ENT:SetOverlayText( txt )
 	if txt == self.OverlayData.txt then return end
 	self.OverlayData.txt = txt
 	if CLIENT then return end
+	if self.lastWireOverlayUpdate < (CurTime()+0.1) then return end
 	self.lastWireOverlayUpdate = CurTime()
-	if self.WireLastOverlayUpdateTick == engine.TickCount() then return end
-	self.WireLastOverlayUpdateTick = engine.TickCount()
 	if #self.playersRequestingOverlayNumeric == 0 then return end
 	cleanInvalidPlayers(self)
 	net.Start( "wire_overlay_txt", true )
@@ -342,9 +341,8 @@ function ENT:SetOverlayData( data )
 	end
 	self.OverlayData = data
 	if CLIENT then return end
+	if self.lastWireOverlayUpdate < (CurTime()+0.1) then return end
 	self.lastWireOverlayUpdate = CurTime()
-	if self.WireLastOverlayUpdateTick == engine.TickCount() then return end
-	self.WireLastOverlayUpdateTick = engine.TickCount()
 	if #self.playersRequestingOverlayNumeric == 0 then return end
 	cleanInvalidPlayers(self)
 	net.Start( "wire_overlay_data", true )
@@ -398,7 +396,6 @@ function ENT:Initialize()
 	self:SetMoveType(MOVETYPE_VPHYSICS)
 	self:SetSolid(SOLID_VPHYSICS)
 	self.WireDebugName = self.WireDebugName or (self.PrintName and self.PrintName:sub(6)) or self:GetClass():gsub("gmod_wire", "")
-	self.WireLastOverlayUpdateTick = 0
 end
 
 function ENT:OnRemove()
@@ -428,11 +425,11 @@ end
 
 function ENT:OnEntityCopyTableFinish(dupedata)
 	-- Called by Garry's duplicator, to modify the table that will be saved about an ent
-
 	-- Remove anything with non-string keys, or util.TableToJSON will crash the game
 	dupedata.OverlayData = nil
 	dupedata.lastWireOverlayUpdate = nil
 	dupedata.playersRequestingOverlayNumeric = nil
+	dupedata.WireDebugName = nil
 end
 
 local function EntityLookup(CreatedEntities)

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -367,14 +367,13 @@ end
 net.Receive( "wire_overlay_request", function( len, ply )
 	if net.ReadBool() then
 		local ent = net.ReadEntity()
-		if not (IsValid(ent) and ent.OverlayData) then return end
+		if not (IsValid(ent) and ent.OverlayData and ent.OverlayData.__time) then return end
 
 		local lastUpdate = net.ReadFloat()
-		overlayRequests[ ply ] = { lastUpdate, ent }
-
-		if ent.OverlayData and ent.OverlayData.__time and ent.OverlayData.__time > lastUpdate then
+		if ent.OverlayData.__time > lastUpdate then
 			syncWireOverlay( ply, ent )
 		end
+		overlayRequests[ ply ] = { ent.OverlayData.__time, ent }
 
 		if not timer.Exists( "WireOverlayUpdate" ) then
 			timer.Create( "WireOverlayUpdate", 0.1, 0, syncWireOverlayTimer )

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -9,7 +9,7 @@ ENT.AdminOnly = false
 
 ENT.IsWire = true
 
-ENT.lastUpdate = 0
+ENT.lastWireOverlayUpdate = 0
 
 if CLIENT then
 	local wire_drawoutline = CreateClientConVar("wire_drawoutline", 1, true, false)
@@ -203,7 +203,7 @@ if CLIENT then
 			net.Start( "wire_overlay_request" )
 				net.WriteEntity(self)
 				net.WriteBool(trbool)
-				net.WriteFloat(self.lastUpdate)
+				net.WriteFloat(self.lastWireOverlayUpdate)
 			net.SendToServer()
 			self.playerWasLookingAtMe = trbool
 		end
@@ -284,7 +284,7 @@ if CLIENT then
 		local ent = net.ReadEntity()
 		if IsValid( ent ) then
 			ent.OverlayData = net.ReadTable()
-			self.lastUpdate = CurTime()
+			self.lastWireOverlayUpdate = CurTime()
 		end
 	end )
 
@@ -295,7 +295,7 @@ if CLIENT then
 				ent.OverlayData = {}
 			end
 			ent.OverlayData.txt = net.ReadString()
-			self.lastUpdate = CurTime()
+			self.lastWireOverlayUpdate = CurTime()
 		end
 	end )
 end
@@ -325,7 +325,7 @@ function ENT:SetOverlayText( txt )
 	if txt == self.OverlayData.txt then return end
 	self.OverlayData.txt = txt
 	if CLIENT then return end
-	self.lastUpdate = CurTime()
+	self.lastWireOverlayUpdate = CurTime()
 	if #self.playersRequestingOverlayNumeric == 0 then return end
 	cleanInvalidPlayers()
 	net.Start( "wire_overlay_txt", true )
@@ -341,7 +341,7 @@ function ENT:SetOverlayData( data )
 	if data == self.OverlayData then return end
 	self.OverlayData = data
 	if CLIENT then return end
-	self.lastUpdate = CurTime()
+	self.lastWireOverlayUpdate = CurTime()
 	if #self.playersRequestingOverlayNumeric == 0 then return end
 	cleanInvalidPlayers()
 	net.Start( "wire_overlay_data", true )
@@ -377,7 +377,7 @@ net.Receive( "wire_overlay_request", function( len, ply )
 		if not table.HasValue(ent.playersRequestingOverlayNumeric,ply) then
 			table.insert(ent.playersRequestingOverlayNumeric,ply)
 		end
-		if net.ReadFloat() > self.lastUpdate then return end
+		if net.ReadFloat() > self.lastWireOverlayUpdate then return end
 		if ent.OverlayData then
 			net.Start( "wire_overlay_data" )
 				net.WriteEntity( ent )

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -372,6 +372,10 @@ net.Receive( "wire_overlay_request", function( len, ply )
 	end
 end )
 
+hook.Add("PlayerDisconnected","wire_playersRequestingOverlay_cleanup",function(ply)
+	table.RemoveByValue(self.playersRequestingOverlayNumeric,ply)
+end)
+
 function ENT:Initialize()
 	BaseClass.Initialize(self)
 	self:PhysicsInit(SOLID_VPHYSICS)

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -353,6 +353,8 @@ local function sendWireOverlays()
 					net.WriteTable( sendEnt.OverlayData )
 				net.Send(ply)
 			end
+		else
+			ply.wireSendOverlay = nil
 		end
 	end
 	if next(found) then

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -309,9 +309,9 @@ end
 -- It allows us to optionally send values rather than entire strings, which saves networking
 -- It also allows us to only update overlays when someone is looking at the entity.
 
-local function cleanInvalidPlayers()
-	for k, v in ipairs( self.playersRequestingOverlayNumeric ) do
-		if !IsValid(v) then table.remove( self.playersRequestingOverlayNumeric, k ) end
+local function cleanInvalidPlayers(ent)
+	for k, v in ipairs( ent.playersRequestingOverlayNumeric ) do
+		if !IsValid(v) then table.remove( ent.playersRequestingOverlayNumeric, k ) end
 	end
 end
 
@@ -327,7 +327,7 @@ function ENT:SetOverlayText( txt )
 	if CLIENT then return end
 	self.lastWireOverlayUpdate = CurTime()
 	if #self.playersRequestingOverlayNumeric == 0 then return end
-	cleanInvalidPlayers()
+	cleanInvalidPlayers(self)
 	net.Start( "wire_overlay_txt", true )
 		net.WriteEntity( self )
 		net.WriteString( self.OverlayData.txt )
@@ -343,7 +343,7 @@ function ENT:SetOverlayData( data )
 	if CLIENT then return end
 	self.lastWireOverlayUpdate = CurTime()
 	if #self.playersRequestingOverlayNumeric == 0 then return end
-	cleanInvalidPlayers()
+	cleanInvalidPlayers(self)
 	net.Start( "wire_overlay_data", true )
 		net.WriteEntity( self )
 		net.WriteTable( self.OverlayData )

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -325,7 +325,7 @@ function ENT:SetOverlayText( txt )
 	if txt == self.OverlayData.txt then return end
 	self.OverlayData.txt = txt
 	if CLIENT then return end
-	if self.lastWireOverlayUpdate < (CurTime()+0.1) then return end
+	if self.lastWireOverlayUpdate + 0.1 > CurTime() then return end
 	self.lastWireOverlayUpdate = CurTime()
 	if #self.playersRequestingOverlayNumeric == 0 then return end
 	cleanInvalidPlayers(self)
@@ -341,7 +341,7 @@ function ENT:SetOverlayData( data )
 	end
 	self.OverlayData = data
 	if CLIENT then return end
-	if self.lastWireOverlayUpdate < (CurTime()+0.1) then return end
+	if self.lastWireOverlayUpdate + 0.1 > CurTime() then return end
 	self.lastWireOverlayUpdate = CurTime()
 	if #self.playersRequestingOverlayNumeric == 0 then return end
 	cleanInvalidPlayers(self)

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -335,8 +335,8 @@ function ENT:SetOverlayText( txt )
 end
 
 function ENT:SetOverlayData( data )
-	if data and self.OverlayData.txt and #self.OverlayData.txt > 12000 then
-		self.OverlayData.txt = string.sub(self.OverlayData.txt,1,12000)
+	if data and data.txt and #data.txt > 12000 then
+		data.txt = string.sub(data.txt,1,12000)
 	end
 	if data == self.OverlayData then return end
 	self.OverlayData = data

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -315,9 +315,10 @@ function ENT:SetOverlayText( txt )
 	if not self.OverlayData then
 		self.OverlayData = {}
 	end
-	if txt and #txt > 5000 then
-		txt = string.sub(txt,1,5000)
+	if txt and #txt > 12000 then
+		txt = string.sub(txt,1,12000) -- I have tested this and 12000 chars is enough to cover the entire screen at 1920x1080. You're unlikely to need more
 	end
+	if txt == self.OverlayData.txt then return end
 	self.OverlayData.txt = txt
 	if CLIENT then return end
 	if #self.playersRequestingOverlayNumeric == 0 then return end
@@ -329,15 +330,17 @@ function ENT:SetOverlayText( txt )
 end
 
 function ENT:SetOverlayData( data )
-	if data.txt and #data.txt > 5000 then
-		data.txt = string.sub(data.txt,1,5000)
+	if data and self.OverlayData.txt and #self.OverlayData.txt > 12000 then
+		self.OverlayData.txt = string.sub(self.OverlayData.txt,1,12000)
 	end
+	if data == self.OverlayData then return end
 	self.OverlayData = data
 	if CLIENT then return end
 	if #self.playersRequestingOverlayNumeric == 0 then return end
 	cleanInvalidPlayers()
 	net.Start( "wire_overlay_data", true )
 		net.WriteEntity( self )
+		net.WriteUInt( )
 		net.WriteTable( self.OverlayData )
 	net.Send(self.playersRequestingOverlayNumeric)
 end
@@ -360,7 +363,7 @@ util.AddNetworkString( "wire_overlay_request" )
 -- Other functions
 --------------------------------------------------------------------------------
 
-ENT.playersRequestingOverlayNumeric = {}
+--ENT.playersRequestingOverlayNumeric = {}
 
 net.Receive( "wire_overlay_request", function( len, ply )
 	local ent = net.ReadEntity()
@@ -386,6 +389,7 @@ function ENT:Initialize()
 	self:SetMoveType(MOVETYPE_VPHYSICS)
 	self:SetSolid(SOLID_VPHYSICS)
 	self.WireDebugName = self.WireDebugName or (self.PrintName and self.PrintName:sub(6)) or self:GetClass():gsub("gmod_wire", "")
+	self.playersRequestingOverlayNumeric = {}
 end
 
 function ENT:OnRemove()

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -315,7 +315,7 @@ function ENT:SetOverlayText( txt )
 	end
 	self.OverlayData.txt = txt
 	if CLIENT then return end
-	if not self.playersRequestingOverlayNumeric or #self.playersRequestingOverlayNumeric == 0 then return end
+	if #self.playersRequestingOverlayNumeric == 0 then return end
 
 	net.Start( "wire_overlay_txt", true )
 		net.WriteEntity( self )
@@ -329,7 +329,7 @@ function ENT:SetOverlayData( data )
 	end
 	self.OverlayData = data
 	if CLIENT then return end
-	if not self.playersRequestingOverlayNumeric or #self.playersRequestingOverlayNumeric == 0 then return end
+	if #self.playersRequestingOverlayNumeric == 0 then return end
 
 	net.Start( "wire_overlay_data", true )
 		net.WriteEntity( self )

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -367,8 +367,8 @@ end
 net.Receive( "wire_overlay_request", function( len, ply )
 	if net.ReadBool() then
 		local ent = net.ReadEntity()
-		local lastUpdate = net.ReadFloat()
 		if not (IsValid(ent) and ent.OverlayData and ent.OverlayData.__time) then return end
+		local lastUpdate = net.ReadFloat()
 
 		overlayRequests[ ply ] = { lastUpdate, ent }
 

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -338,7 +338,6 @@ function ENT:SetOverlayData( data )
 	if data and data.txt and #data.txt > 12000 then
 		data.txt = string.sub(data.txt,1,12000)
 	end
-	if data == self.OverlayData then return end
 	self.OverlayData = data
 	if CLIENT then return end
 	self.lastWireOverlayUpdate = CurTime()

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -351,7 +351,7 @@ local function sendWireOverlays()
 				net.Start( "wire_overlay_data", true )
 					net.WriteEntity( sendEnt )
 					net.WriteTable( sendEnt.OverlayData )
-				net.Send(self.playersRequestingOverlayNumeric)
+				net.Send(ply)
 			end
 		end
 	end

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -350,10 +350,11 @@ end
 local function syncWireOverlayTimer()
 	for ply, row in pairs(overlayRequests) do
 		local ent = row[2]
-		if IsValid(ent) then
-			if ent.OverlayData and ent.OverlayData.__time and ent.OverlayData.__time > row[1] then
+		if ent and ent:IsValid() then
+			local overlayData = ent.OverlayData
+			if overlayData and overlayData.__time and overlayData.__time > row[1] then
 				syncWireOverlay( ply, ent )
-				row[1] = ent.OverlayData.__time
+				row[1] = overlayData.__time
 			end
 		else
 			overlayRequests[ply] = nil
@@ -367,7 +368,7 @@ end
 net.Receive( "wire_overlay_request", function( len, ply )
 	if net.ReadBool() then
 		local ent = net.ReadEntity()
-		if not (IsValid(ent) and ent.OverlayData and ent.OverlayData.__time) then return end
+		if not (ent and ent:IsValid()) then return end
 		local lastUpdate = net.ReadFloat()
 
 		overlayRequests[ ply ] = { lastUpdate, ent }

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -14,6 +14,7 @@ if CLIENT then
 
 	function ENT:Initialize()
 		self.NextRBUpdate = CurTime() + 0.25
+		self.playerWasLookingAtMe = false
 	end
 
 	function ENT:Draw()
@@ -191,8 +192,6 @@ if CLIENT then
 
 		ent:DrawWorldTip()
 	end)
-
-	ENT.playerWasLookingAtMe = false
 
 	-- Custom better version of this base_gmodentity function
 	function ENT:BeingLookedAtByLocalPlayer()
@@ -380,6 +379,7 @@ function ENT:Initialize()
 	self:PhysicsInit(SOLID_VPHYSICS)
 	self:SetMoveType(MOVETYPE_VPHYSICS)
 	self:SetSolid(SOLID_VPHYSICS)
+	self.playersRequestingOverlayNumeric = {}
 	self.WireDebugName = self.WireDebugName or (self.PrintName and self.PrintName:sub(6)) or self:GetClass():gsub("gmod_wire", "")
 end
 

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -332,7 +332,6 @@ if CLIENT then return end -- no more client
 --------------------------------------------------------------------------------
 
 util.AddNetworkString( "wire_overlay_data" )
-util.AddNetworkString( "wire_overlay_txt" )
 util.AddNetworkString( "wire_overlay_request" )
 
 --------------------------------------------------------------------------------

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -377,7 +377,7 @@ net.Receive( "wire_overlay_request", function( len, ply )
 		if not table.HasValue(ent.playersRequestingOverlayNumeric,ply) then
 			table.insert(ent.playersRequestingOverlayNumeric,ply)
 		end
-		if net.ReadFloat() > self.lastWireOverlayUpdate then return end
+		if net.ReadFloat() > ent.lastWireOverlayUpdate then return end
 		if ent.OverlayData then
 			net.Start( "wire_overlay_data" )
 				net.WriteEntity( ent )

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -305,13 +305,14 @@ end
 
 -- It allows us to optionally send values rather than entire strings, which saves networking
 -- It also allows us to only update overlays when someone is looking at the entity.
+-- I have tested this and 12000 chars is enough to cover the entire screen at 1920x1080. You're unlikely to need more
 
 function ENT:SetOverlayText( txt )
 	if not self.OverlayData then
 		self.OverlayData = {}
 	end
-	if txt and #txt > 512 then
-		txt = string.sub(txt,1,512)
+	if txt and #txt > 12000 then
+		txt = string.sub(txt,1,12000)
 	end
 	self.OverlayData.txt = txt
 	if CLIENT then return end
@@ -324,8 +325,8 @@ function ENT:SetOverlayText( txt )
 end
 
 function ENT:SetOverlayData( data )
-	if data.txt and #data.txt > 512 then
-		data.txt = string.sub(data.txt,1,512)
+	if data.txt and #data.txt > 12000 then
+		data.txt = string.sub(data.txt,1,12000)
 	end
 	self.OverlayData = data
 	if CLIENT then return end
@@ -376,7 +377,11 @@ net.Receive( "wire_overlay_request", function( len, ply )
 end )
 
 hook.Add("PlayerDisconnected","wire_playersRequestingOverlay_cleanup",function(ply)
-	table.RemoveByValue(ENT.playersRequestingOverlayNumeric,ply)
+	for _, v in pairs( ents.GetAll() ) do
+		if v.playersRequestingOverlayNumeric then
+			table.RemoveByValue(v.playersRequestingOverlayNumeric,ply)
+		end
+	end
 end)
 
 function ENT:Initialize()

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -284,7 +284,7 @@ if CLIENT then
 		local ent = net.ReadEntity()
 		if IsValid( ent ) then
 			ent.OverlayData = net.ReadTable()
-			self.lastWireOverlayUpdate = CurTime()
+			ent.lastWireOverlayUpdate = CurTime()
 		end
 	end )
 
@@ -295,7 +295,7 @@ if CLIENT then
 				ent.OverlayData = {}
 			end
 			ent.OverlayData.txt = net.ReadString()
-			self.lastWireOverlayUpdate = CurTime()
+			ent.lastWireOverlayUpdate = CurTime()
 		end
 	end )
 end

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -391,7 +391,6 @@ end
 
 function ENT:OnRemove()
 	WireLib.Remove(self)
-	overlayRequests[self] = nil
 end
 
 function ENT:OnRestore()

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -362,7 +362,7 @@ local function sendWireOverlays()
 			OverlayData.dirty = false
 		end
 	else
-		timer.Remove("Wire_SendOverlayData")
+		hook.Remove("Think","Wire_SendOverlayData")
 	end
 end
 
@@ -372,7 +372,7 @@ net.Receive( "wire_overlay_request", function( len, ply )
 	if net.ReadBool() then
 		ply.wireSendOverlay = ent
 		ent.OverlayData.dirty = true
-		timer.Create("Wire_SendOverlayData",0.1,0,sendWireOverlays)
+		hook.Add("Think","Wire_SendOverlayData",sendWireOverlays)
 	else
 		ply.wireSendOverlay = nil
 	end

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -197,7 +197,7 @@ if CLIENT then
 	-- Custom better version of this base_gmodentity function
 	function ENT:BeingLookedAtByLocalPlayer()
 		local trace = LocalPlayer():GetEyeTrace()
-		local trbool = trace.Entity == self
+		local trbool = (trace.Entity == self and trace.HitPos:DistToSqr(LocalPlayer():GetShootPos()) > 40000) --this is 200^2
 
 		if self.playerWasLookingAtMe ~= trbool then
 			net.Start( "wire_overlay_request" )

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -311,7 +311,7 @@ function ENT:SetOverlayText( txt )
 	if txt and #txt > 1024 then
 		txt = string.sub(txt,1,1024)
 	end
-	self.OverlayData.dirty = self.OverlayData.txt ~= txt
+	self.OverlayData.__dirty = self.OverlayData.txt ~= txt
 	self.OverlayData.txt = txt
 end
 
@@ -320,7 +320,7 @@ function ENT:SetOverlayData( data )
 		data.txt = string.sub(data.txt,1,1024)
 	end
 	self.OverlayData = data
-	self.OverlayData.dirty = true
+	self.OverlayData.__dirty = true
 end
 
 function ENT:GetOverlayData()
@@ -347,7 +347,7 @@ local function sendWireOverlays()
 		local sendEnt = ply.wireSendOverlay
 		if sendEnt and sendEnt:IsValid() then
 			found[sendEnt.OverlayData] = true
-			if sendEnt.OverlayData.dirty then
+			if sendEnt.OverlayData.__dirty then
 				net.Start( "wire_overlay_data", true )
 					net.WriteEntity( sendEnt )
 					net.WriteTable( sendEnt.OverlayData )
@@ -359,7 +359,7 @@ local function sendWireOverlays()
 	end
 	if next(found) then
 		for OverlayData in pairs(found) do
-			OverlayData.dirty = false
+			OverlayData.__dirty = false
 		end
 	else
 		hook.Remove("Think","Wire_SendOverlayData")
@@ -371,7 +371,7 @@ net.Receive( "wire_overlay_request", function( len, ply )
 	if not IsValid(ent) then return end
 	if net.ReadBool() then
 		ply.wireSendOverlay = ent
-		ent.OverlayData.dirty = true
+		ent.OverlayData.__dirty = true
 		hook.Add("Think","Wire_SendOverlayData",sendWireOverlays)
 	else
 		ply.wireSendOverlay = nil

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -367,13 +367,10 @@ end
 net.Receive( "wire_overlay_request", function( len, ply )
 	if net.ReadBool() then
 		local ent = net.ReadEntity()
+		local lastUpdate = net.ReadFloat()
 		if not (IsValid(ent) and ent.OverlayData and ent.OverlayData.__time) then return end
 
-		local lastUpdate = net.ReadFloat()
-		if ent.OverlayData.__time > lastUpdate then
-			syncWireOverlay( ply, ent )
-		end
-		overlayRequests[ ply ] = { ent.OverlayData.__time, ent }
+		overlayRequests[ ply ] = { lastUpdate, ent }
 
 		if not timer.Exists( "WireOverlayUpdate" ) then
 			timer.Create( "WireOverlayUpdate", 0.1, 0, syncWireOverlayTimer )

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -340,20 +340,16 @@ util.AddNetworkString( "wire_overlay_request" )
 -- table structure: overlayRequests[ply] = { lastUpdate, ent }
 local overlayRequests = WireLib.RegisterPlayerTable()
 
-local function syncWireOverlay( ply, ent )
-	net.Start( "wire_overlay_data" )
-		net.WriteEntity( ent )
-		net.WriteTable( ent.OverlayData )
-	net.Send(ply)
-end
-
 local function syncWireOverlayTimer()
 	for ply, row in pairs(overlayRequests) do
 		local ent = row[2]
 		if ent and ent:IsValid() then
 			local overlayData = ent.OverlayData
 			if overlayData and overlayData.__time and overlayData.__time > row[1] then
-				syncWireOverlay( ply, ent )
+				net.Start( "wire_overlay_data" )
+					net.WriteEntity( ent )
+					net.WriteTable( overlayData )
+				net.Send(ply)
 				row[1] = overlayData.__time
 			end
 		else

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -311,7 +311,7 @@ function ENT:SetOverlayText( txt )
 		self.OverlayData = {}
 	end
 	if txt and #txt > 512 then
-		txt = string.sub(txt,1,512) -- I have tested this and 12000 chars is enough to cover the entire screen at 1920x1080. You're unlikely to need more
+		txt = string.sub(txt,1,512)
 	end
 	self.OverlayData.txt = txt
 	if CLIENT then return end

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -200,8 +200,8 @@ if CLIENT then
 		if self.playerWasLookingAtMe ~= trbool then
 			net.Start( "wire_overlay_request" )
 				if trbool then
-					net.WriteEntity(self)
 					net.WriteBool(true)
+					net.WriteEntity(self)
 				else
 					net.WriteBool(false)
 				end

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -9,8 +9,6 @@ ENT.AdminOnly = false
 
 ENT.IsWire = true
 
-ENT.lastWireOverlayUpdate = 0
-
 if CLIENT then
 	local wire_drawoutline = CreateClientConVar("wire_drawoutline", 1, true, false)
 

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -346,7 +346,7 @@ local function syncWireOverlay( ply, ent )
 	net.Send(ply)
 end
 
-local function sendWireOverlays()
+local function syncWireOverlayTimer()
 	for ply, ent in pairs(overlayRequests) do
 		if ent and ent:IsValid() then
 			if ent.OverlayData.__dirty then

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -368,7 +368,7 @@ util.AddNetworkString( "wire_overlay_request" )
 -- Other functions
 --------------------------------------------------------------------------------
 
---ENT.playersRequestingOverlayNumeric = {}
+ENT.playersRequestingOverlayNumeric = {}
 
 net.Receive( "wire_overlay_request", function( len, ply )
 	local ent = net.ReadEntity()
@@ -395,7 +395,6 @@ function ENT:Initialize()
 	self:SetMoveType(MOVETYPE_VPHYSICS)
 	self:SetSolid(SOLID_VPHYSICS)
 	self.WireDebugName = self.WireDebugName or (self.PrintName and self.PrintName:sub(6)) or self:GetClass():gsub("gmod_wire", "")
-	self.playersRequestingOverlayNumeric = {}
 end
 
 function ENT:OnRemove()

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -350,8 +350,6 @@ util.AddNetworkString( "wire_overlay_data" )
 util.AddNetworkString( "wire_overlay_txt" )
 util.AddNetworkString( "wire_overlay_request" )
 
-ENT.playersRequestingOverlayNumeric = {}
-
 --------------------------------------------------------------------------------
 -- Other functions
 --------------------------------------------------------------------------------

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -421,6 +421,15 @@ function ENT:PreEntityCopy()
 	end
 end
 
+function ENT:OnEntityCopyTableFinish(dupedata)
+	-- Called by Garry's duplicator, to modify the table that will be saved about an ent
+
+	-- Remove anything with non-string keys, or util.TableToJSON will crash the game
+	dupedata.OverlayData = nil
+	dupedata.lastWireOverlayUpdate = nil
+	dupedata.playersRequestingOverlayNumeric = nil
+end
+
 local function EntityLookup(CreatedEntities)
 	return function(id, default)
 		if id == nil then return default end

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -326,6 +326,8 @@ function ENT:SetOverlayText( txt )
 	self.OverlayData.txt = txt
 	if CLIENT then return end
 	self.lastWireOverlayUpdate = CurTime()
+	if self.WireLastOverlayUpdateTick == engine.TickCount() then return end
+	self.WireLastOverlayUpdateTick = engine.TickCount()
 	if #self.playersRequestingOverlayNumeric == 0 then return end
 	cleanInvalidPlayers(self)
 	net.Start( "wire_overlay_txt", true )
@@ -341,6 +343,8 @@ function ENT:SetOverlayData( data )
 	self.OverlayData = data
 	if CLIENT then return end
 	self.lastWireOverlayUpdate = CurTime()
+	if self.WireLastOverlayUpdateTick == engine.TickCount() then return end
+	self.WireLastOverlayUpdateTick = engine.TickCount()
 	if #self.playersRequestingOverlayNumeric == 0 then return end
 	cleanInvalidPlayers(self)
 	net.Start( "wire_overlay_data", true )
@@ -394,6 +398,7 @@ function ENT:Initialize()
 	self:SetMoveType(MOVETYPE_VPHYSICS)
 	self:SetSolid(SOLID_VPHYSICS)
 	self.WireDebugName = self.WireDebugName or (self.PrintName and self.PrintName:sub(6)) or self:GetClass():gsub("gmod_wire", "")
+	self.WireLastOverlayUpdateTick = 0
 end
 
 function ENT:OnRemove()


### PR DESCRIPTION
doing eyetraces on serverside is a heavy function, and this eliminates that in favor of the cached(and thus essentially free) clientside eyetrace, sending a netmessage to the server when the client starts and stops looking at the entity.  This adds/removes the player to/from a list of players that the entity is sending its overlay to.  It also only sends overlay once when the player starts looking and whenever the overlay is updated serverside.  Overlay update messages(not the initial one on look start) are changed to unreliable and also limited to 512 to avoid too high reliable channel/net message data rates.  Distance check is removed from client as that is a very expensive function to be running in a per frame hook per wire entity.
I have been running this in my busy server and it all seems to be working well.