### PR TITLE
Add a system for automatically cleaning up tables with player keys on disconnect

### DIFF
--- a/lua/entities/gmod_wire_egp/lib/egplib/framecontrol.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/framecontrol.lua
@@ -7,19 +7,18 @@ local EGP = EGP
 EGP.Frames = WireLib.RegisterPlayerTable()
 
 function EGP:SaveFrame( ply, Ent, index )
-	if (!EGP.Frames[ply]) then EGP.Frames[ply] = {} end
+	if not EGP.Frames[ply] then EGP.Frames[ply] = {} end
 	EGP.Frames[ply][index] = table.Copy(Ent.RenderTable)
 end
 
 function EGP:LoadFrame( ply, Ent, index )
-	if (!EGP.Frames[ply]) then EGP.Frames[ply] = {} return false end
-	if (SERVER) then
-		local bool = (EGP.Frames[ply][index] != nil)
-		if (!bool) then return false end
+	if not EGP.Frames[ply] then EGP.Frames[ply] = {} return false end
+	if SERVER then
+		if not EGP.Frames[ply][index] then return false end
 		return true, table.Copy(EGP.Frames[ply][index])
 	else
 		local frame = EGP.Frames[ply][index]
-		if (!frame) then return false end
+		if not frame then return false end
 		Ent.RenderTable = table.Copy(frame)
 		Ent:EGP_Update()
 	end

--- a/lua/entities/gmod_wire_egp/lib/egplib/framecontrol.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/framecontrol.lua
@@ -18,6 +18,7 @@ function EGP:LoadFrame( ply, Ent, index )
 		return true, table.Copy(EGP.Frames[ply][index])
 	else
 		local frame = EGP.Frames[ply][index]
+		-- TODO This looks like there should be a return true or something like that at the end of the function
 		if not frame then return false end
 		Ent.RenderTable = table.Copy(frame)
 		Ent:EGP_Update()

--- a/lua/entities/gmod_wire_egp/lib/egplib/framecontrol.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/framecontrol.lua
@@ -4,7 +4,7 @@
 
 local EGP = EGP
 
-EGP.Frames = {}
+EGP.Frames = WireLib.RegisterPlayerTable()
 
 function EGP:SaveFrame( ply, Ent, index )
 	if (!EGP.Frames[ply]) then EGP.Frames[ply] = {} end

--- a/lua/entities/gmod_wire_egp/lib/egplib/queuesystem.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/queuesystem.lua
@@ -130,10 +130,10 @@ end
 timer.Create("EGP_Queue_Process", 1, 0, function()
 	local removetab = {}
 	for ply, tab in pairs(EGP.Queue) do
-		if not IsValid(ply) then
-			removetab[ply] = true
-		else
+		if IsValid(ply) then
 			EGP:SendQueueItem(ply)
+		else
+			removetab[ply] = true
 		end
 	end
 	for ply in pairs(removetab) do EGP.Queue[ply] = nil end

--- a/lua/entities/gmod_wire_egp/lib/egplib/queuesystem.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/queuesystem.lua
@@ -3,7 +3,7 @@
 --------------------------------------------------------
 local EGP = EGP
 
-EGP.Queue = {}
+EGP.Queue = WireLib.RegisterPlayerTable()
 
 function EGP:AddQueueObject( Ent, ply, Function, Object )
 	if (!self.Queue[ply]) then self.Queue[ply] = {} end

--- a/lua/entities/gmod_wire_egp/lib/egplib/queuesystem.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/queuesystem.lua
@@ -6,7 +6,7 @@ local EGP = EGP
 EGP.Queue = WireLib.RegisterPlayerTable()
 
 function EGP:AddQueueObject( Ent, ply, Function, Object )
-	if (!self.Queue[ply]) then self.Queue[ply] = {} end
+	if not self.Queue[ply] then self.Queue[ply] = {} end
 	local n = #self.Queue[ply]
 	if (n > 0) then
 		local LastItem = self.Queue[ply][n]
@@ -18,7 +18,7 @@ function EGP:AddQueueObject( Ent, ply, Function, Object )
 
 					if (Object.remove) then -- The object has been removed
 						table.remove( LastItem.Args[1], k )
-					elseif (v.ID != Object.ID) then -- Not the same kind of object, create new
+					elseif (v.ID ~= Object.ID) then -- Not the same kind of object, create new
 						found = true
 						if (v.OnRemove) then v:OnRemove() end
 						local Obj = self:GetObjectByID( Object.ID )
@@ -34,7 +34,7 @@ function EGP:AddQueueObject( Ent, ply, Function, Object )
 					break
 				end
 			end
-			if (!found) then
+			if not found then
 				LastItem.Args[1][#LastItem.Args[1]+1] = Object
 			end
 		else
@@ -46,7 +46,7 @@ function EGP:AddQueueObject( Ent, ply, Function, Object )
 end
 
 function EGP:AddQueue( Ent, ply, Function, Action, ... )
-	if (!self.Queue[ply]) then self.Queue[ply] = {} end
+	if not self.Queue[ply] then self.Queue[ply] = {} end
 	local n = #self.Queue[ply]
 	if (n > 0) then
 		local LastItem = self.Queue[ply][n]
@@ -58,7 +58,7 @@ function EGP:AddQueue( Ent, ply, Function, Action, ... )
 end
 
 function EGP:InsertQueueObjects( Ent, ply, Function, Objects )
-	if (!self.Queue[ply]) then self.Queue[ply] = {} end
+	if not self.Queue[ply] then self.Queue[ply] = {} end
 	local n = #self.Queue[ply]
 	if (n > 0) then
 		local FirstItem = self.Queue[ply][1]
@@ -76,12 +76,12 @@ function EGP:InsertQueueObjects( Ent, ply, Function, Objects )
 end
 
 function EGP:InsertQueue( Ent, ply, Function, Action, ... )
-	if (!self.Queue[ply]) then self.Queue[ply] = {} end
+	if not self.Queue[ply] then self.Queue[ply] = {} end
 	table.insert( self.Queue[ply], 1, { Action = Action, Function = Function, Ent = Ent, Args = {...} } )
 end
 
 function EGP:GetNextItem( ply )
-	if (!self.Queue[ply]) then return false end
+	if not self.Queue[ply] then return false end
 	if (#self.Queue[ply] <= 0) then return false end
 	return table.remove( self.Queue[ply], 1 )
 end
@@ -90,7 +90,7 @@ local AlreadyChecking = 0
 
 function EGP:SendQueueItem( ply )
 	local NextAction = self:GetNextItem( ply )
-	if (NextAction != false) then
+	if (NextAction ~= false) then
 		local Func = NextAction.Function
 		local Ent = NextAction.Ent
 		local Args = NextAction.Args
@@ -100,7 +100,7 @@ function EGP:SendQueueItem( ply )
 			Func( Ent, ply )
 		end
 
-		if (CurTime() != AlreadyChecking) then -- Had to use this hacky way of checking, because the E2 triggered 4 times for some strange reason. If anyone can figure out why, go ahead and tell me.
+		if (CurTime() ~= AlreadyChecking) then -- Had to use this hacky way of checking, because the E2 triggered 4 times for some strange reason. If anyone can figure out why, go ahead and tell me.
 			AlreadyChecking = CurTime()
 
 			-- Check if the queue has no more items for this screen
@@ -130,14 +130,14 @@ end
 timer.Create("EGP_Queue_Process", 1, 0, function()
 	local removetab = {}
 	for ply, tab in pairs(EGP.Queue) do
-		if !IsValid(ply) then removetab[ply] = true continue end
+		if not IsValid(ply) then removetab[ply] = true continue end
 		EGP:SendQueueItem(ply)
 	end
 	for ply in pairs(removetab) do EGP.Queue[ply] = nil end
 end)
 
 function EGP:GetQueueItemsForScreen( ply, Ent )
-	if (!self.Queue[ply]) then return {} end
+	if not self.Queue[ply] then return {} end
 	local ret = {}
 	for k,v in ipairs( self.Queue[ply] ) do
 		if (v.Ent == Ent) then

--- a/lua/entities/gmod_wire_egp/lib/egplib/queuesystem.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/queuesystem.lua
@@ -130,8 +130,11 @@ end
 timer.Create("EGP_Queue_Process", 1, 0, function()
 	local removetab = {}
 	for ply, tab in pairs(EGP.Queue) do
-		if not IsValid(ply) then removetab[ply] = true continue end
-		EGP:SendQueueItem(ply)
+		if not IsValid(ply) then
+			removetab[ply] = true
+		else
+			EGP:SendQueueItem(ply)
+		end
 	end
 	for ply in pairs(removetab) do EGP.Queue[ply] = nil end
 end)

--- a/lua/entities/gmod_wire_egp/lib/egplib/transmitreceive.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/transmitreceive.lua
@@ -9,11 +9,7 @@ if (SERVER) then
 	----------------------------
 	-- Umsgs per second check
 	----------------------------
-	EGP.IntervalCheck = {}
-
-	function EGP:PlayerDisconnect( ply ) EGP.IntervalCheck[ply] = nil EGP.Queue[ply] = nil end
-	hook.Add("PlayerDisconnected","EGP_PlayerDisconnect",function( ply ) EGP:PlayerDisconnect( ply ) end)
-
+	EGP.IntervalCheck = WireLib.RegisterPlayerTable()
 
 	function EGP:CheckInterval( ply )
 		if (!self.IntervalCheck[ply]) then self.IntervalCheck[ply] = { bytes = 0, time = 0 } end

--- a/lua/entities/gmod_wire_egp/lib/egplib/transmitreceive.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/transmitreceive.lua
@@ -12,7 +12,7 @@ if (SERVER) then
 	EGP.IntervalCheck = WireLib.RegisterPlayerTable()
 
 	function EGP:CheckInterval( ply )
-		if (!self.IntervalCheck[ply]) then self.IntervalCheck[ply] = { bytes = 0, time = 0 } end
+		if not self.IntervalCheck[ply] then self.IntervalCheck[ply] = { bytes = 0, time = 0 } end
 
 		local maxcount = self.ConVars.MaxPerSec:GetInt()
 
@@ -34,7 +34,7 @@ if (SERVER) then
 			return
 		end
 
-		if (!EGP.umsg.Start( "EGP_Transmit_Data", ply )) then return end
+		if not EGP.umsg.Start( "EGP_Transmit_Data", ply ) then return end
 			net.WriteEntity( Ent )
 			net.WriteString( "ClearScreen" )
 		EGP.umsg.End()
@@ -51,7 +51,7 @@ if (SERVER) then
 		end
 
 		util.AddNetworkString( FrameName )
-		if (!EGP.umsg.Start( "EGP_Transmit_Data", ply )) then return end
+		if not EGP.umsg.Start( "EGP_Transmit_Data", ply ) then return end
 			net.WriteEntity( Ent )
 			net.WriteString( "SaveFrame" )
 			net.WriteEntity( ply )
@@ -70,9 +70,9 @@ if (SERVER) then
 		end
 
 		local bool, _ = EGP:LoadFrame( ply, Ent, FrameName )
-		if (!bool) then return end
+		if not bool then return end
 
-		if (!EGP.umsg.Start( "EGP_Transmit_Data", ply )) then return end
+		if not EGP.umsg.Start( "EGP_Transmit_Data", ply ) then return end
 			net.WriteEntity( Ent )
 			net.WriteString( "LoadFrame" )
 			net.WriteEntity( ply )
@@ -93,7 +93,7 @@ if (SERVER) then
 
 		local bool, k, v = EGP:HasObject( Ent, index )
 		if (bool) then
-			if (!EGP.umsg.Start("EGP_Transmit_Data", ply)) then return end
+			if not EGP.umsg.Start("EGP_Transmit_Data", ply) then return end
 				net.WriteEntity( Ent )
 				net.WriteString( "AddVertex" )
 				net.WriteInt( index, 16 )
@@ -125,7 +125,7 @@ if (SERVER) then
 
 		local bool, k, v = EGP:HasObject( Ent, index )
 		if (bool) then
-			if (!EGP.umsg.Start("EGP_Transmit_Data", ply)) then return end
+			if not EGP.umsg.Start("EGP_Transmit_Data", ply) then return end
 				net.WriteEntity( Ent )
 				net.WriteString( "SetVertex" )
 				net.WriteInt( index, 16 )
@@ -156,7 +156,7 @@ if (SERVER) then
 
 		local bool, k, v = EGP:HasObject( Ent, index )
 		if (bool) then
-			if (!EGP.umsg.Start("EGP_Transmit_Data", ply)) then return end
+			if not EGP.umsg.Start("EGP_Transmit_Data", ply) then return end
 				net.WriteEntity( Ent )
 				net.WriteString( "AddText" )
 				net.WriteInt( index, 16 )
@@ -178,7 +178,7 @@ if (SERVER) then
 
 		local bool, k, v = EGP:HasObject( Ent, index )
 		if (bool) then
-			if (!EGP.umsg.Start("EGP_Transmit_Data", ply)) then return end
+			if not EGP.umsg.Start("EGP_Transmit_Data", ply) then return end
 				net.WriteEntity( Ent )
 				net.WriteString( "SetText" )
 				net.WriteInt( index, 16 )
@@ -206,7 +206,7 @@ if (SERVER) then
 			EGP:InsertQueue( Ent, ply, EditFiltering, "EditFiltering", filtering )
 			return
 		end
-		if (!EGP.umsg.Start("EGP_Transmit_Data", ply)) then return end
+		if not EGP.umsg.Start("EGP_Transmit_Data", ply) then return end
 			net.WriteEntity( Ent )
 			net.WriteString( "EditFiltering" )
 			net.WriteUInt( filtering, 2 )
@@ -217,7 +217,7 @@ if (SERVER) then
 
 	util.AddNetworkString( "ReceiveObjects" )
 	local function SendObjects( Ent, ply, DataToSend )
-		if (!Ent or !Ent:IsValid() or !ply or !ply:IsValid() or !DataToSend) then return end
+		if not Ent or not Ent:IsValid() or not ply or not ply:IsValid() or not DataToSend then return end
 
 		-- Check duped
 		if (Ent.EGP_Duplicated) then
@@ -234,7 +234,7 @@ if (SERVER) then
 
 		local order_was_changed = false
 
-		if (!EGP.umsg.Start( "EGP_Transmit_Data", ply )) then return end
+		if not EGP.umsg.Start( "EGP_Transmit_Data", ply ) then return end
 			net.WriteEntity( Ent )
 			net.WriteString( "ReceiveObjects" )
 
@@ -242,7 +242,7 @@ if (SERVER) then
 			for k,v in ipairs( DataToSend ) do
 
 				-- Check if the object doesn't exist serverside anymore (It may have been removed by a command in the queue before this, like egpClear or egpRemove)
-				--if (!EGP:HasObject( Ent, v.index )) then
+				--if not EGP:HasObject( Ent, v.index ) then
 				--	EGP:CreateObject( Ent, v.ID, v )
 				--end
 
@@ -306,7 +306,7 @@ if (SERVER) then
 	function EGP:DoAction( Ent, E2, Action, ... )
 		if (Action == "SendObject") then
 			local Data = {...}
-			if (!Data[1]) then return end
+			if not Data[1] then return end
 
 			if (E2 and E2.entity and E2.entity:IsValid()) then
 				E2.prf = E2.prf + 30
@@ -315,7 +315,7 @@ if (SERVER) then
 			self:AddQueueObject( Ent, E2.player, SendObjects, Data[1] )
 		elseif (Action == "RemoveObject") then
 			local Data = {...}
-			if (!Data[1]) then return end
+			if not Data[1] then return end
 
 			if (E2 and E2.entity and E2.entity:IsValid()) then
 				E2.prf = E2.prf + 20
@@ -335,7 +335,7 @@ if (SERVER) then
 				E2.prf = E2.prf + 20
 			end
 
-			// Remove all queued actions for this screen
+			-- Remove all queued actions for this screen
 			local queue = self.Queue[E2.player] or {}
 			local i = 1
 			while i<=#queue do
@@ -352,7 +352,7 @@ if (SERVER) then
 			self:AddQueue( Ent, E2.player, ClearScreen, "ClearScreen" )
 		elseif (Action == "SaveFrame") then
 			local Data = {...}
-			if (!Data[1]) then return end
+			if not Data[1] then return end
 
 			if (E2 and E2.entity and E2.entity:IsValid()) then
 				E2.prf = E2.prf + 10
@@ -362,7 +362,7 @@ if (SERVER) then
 			self:AddQueue( Ent, E2.player, SaveFrame, "SaveFrame", Data[1] )
 		elseif (Action == "LoadFrame") then
 			local Data = {...}
-			if (!Data[1]) then return end
+			if not Data[1] then return end
 
 			if (E2 and E2.entity and E2.entity:IsValid()) then
 				E2.prf = E2.prf + 10
@@ -388,7 +388,7 @@ if (SERVER) then
 else -- SERVER/CLIENT
 	function EGP:Receive( netlen )
 		local Ent = net.ReadEntity()
-		if (!self:ValidEGP( Ent ) or !Ent.RenderTable) then return end
+		if not self:ValidEGP(Ent) or not Ent.RenderTable then return end
 
 		local Action = net.ReadString()
 		if (Action == "ClearScreen") then
@@ -500,7 +500,7 @@ else -- SERVER/CLIENT
 					local current_obj
 					local bool, k, v = self:HasObject( Ent, index )
 					if (bool) then -- Object already exists
-						if (v.ID != ID) then -- Not the same kind of object, create new
+						if (v.ID ~= ID) then -- Not the same kind of object, create new
 							if (v.OnRemove) then v:OnRemove() end
 							local Obj = self:GetObjectByID( ID )
 							local data = Obj:Receive()
@@ -517,7 +517,7 @@ else -- SERVER/CLIENT
 							self:EditObject( v, v:Receive() )
 
 							-- If parented, reset the parent indexes
-							if (v.parent and v.parent != 0) then
+							if (v.parent and v.parent ~= 0) then
 								EGP:AddParentIndexes( v )
 							end
 
@@ -563,10 +563,10 @@ if (SERVER) then
 	EGP.DataStream = {}
 
 	concommand.Add("EGP_Request_Reload",function(ply,cmd,args)
-		if (!EGP.DataStream[ply]) then EGP.DataStream[ply] = {} end
+		if not EGP.DataStream[ply] then EGP.DataStream[ply] = {} end
 		local tbl = EGP.DataStream[ply]
-		if (!tbl.SingleTime) then tbl.SingleTime = 0 end
-		if (!tbl.AllTime) then tbl.AllTime = 0 end
+		if not tbl.SingleTime then tbl.SingleTime = 0 end
+		if not tbl.AllTime then tbl.AllTime = 0 end
 		if (args[1]) then
 			if (tbl.SingleTime > CurTime()) then
 				ply:ChatPrint("[EGP] This command has anti-spam protection. Try again after 10 seconds.")
@@ -590,7 +590,7 @@ if (SERVER) then
 	end)
 
 	function EGP:SendDataStream( ply, entid )
-		if (!ply or !ply:IsValid()) then return false, "ERROR: Invalid ply." end
+		if not ply or not ply:IsValid() then return false, "ERROR: Invalid ply." end
 		local targets
 		if (entid) then
 			local tempent = Entity(entid)
@@ -600,7 +600,7 @@ if (SERVER) then
 				return false, "ERROR: Invalid screen."
 			end
 		end
-		if (!targets) then
+		if not targets then
 			targets = ents.FindByClass("gmod_wire_egp")
 			table.Add( targets, ents.FindByClass("gmod_wire_egp_hud") )
 			table.Add( targets, ents.FindByClass("gmod_wire_egp_emitter") )
@@ -681,7 +681,7 @@ else
 				local Obj = self:GetObjectByID(v.ID)
 				self:EditObject( Obj, v.Settings )
 				-- If parented, reset the parent indexes
-				if (Obj.parent and Obj.parent != 0) then
+				if (Obj.parent and Obj.parent ~= 0) then
 					self:AddParentIndexes( Obj )
 				end
 				Obj.index = v.index

--- a/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
@@ -225,9 +225,12 @@ else
 			end
 		end)
 	end)
+
+	EGP.ScrHW = WireLib.RegisterPlayerTable()
+
 	concommand.Add("EGP_ScrWH",function(ply,cmd,args)
 		if (args and tonumber(args[1]) and tonumber(args[2])) then
-			ply.EGP_ScrHW = { tonumber(args[1]), tonumber(args[2]) }
+			EGP.ScrHW[ply] = { tonumber(args[1]), tonumber(args[2]) }
 		end
 	end)
 end

--- a/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
@@ -1002,18 +1002,18 @@ end
 __e2setcost(10)
 
 e2function vector2 egpScrSize( entity ply )
-	if (!ply or !ply:IsValid() or !ply:IsPlayer() or !ply.EGP_ScrHW) then return {-1,-1} end
-	return ply.EGP_ScrHW
+	if (!ply or !ply:IsValid() or !ply:IsPlayer() or !EGP.ScrHW[ply]) then return {-1,-1} end
+	return EGP.ScrHW[ply]
 end
 
 e2function number egpScrW( entity ply )
-	if (!ply or !ply:IsValid() or !ply:IsPlayer() or !ply.EGP_ScrHW[1]) then return -1 end
-	return ply.EGP_ScrHW[1]
+	if (!ply or !ply:IsValid() or !ply:IsPlayer() or !EGP.ScrHW[ply]) then return -1 end
+	return EGP.ScrHW[ply][1]
 end
 
 e2function number egpScrH( entity ply )
-	if (!ply or !ply:IsValid() or !ply:IsPlayer() or !ply.EGP_ScrHW[2]) then return -1 end
-	return ply.EGP_ScrHW[2]
+	if (!ply or !ply:IsValid() or !ply:IsPlayer() or !EGP.ScrHW[ply]) then return -1 end
+	return EGP.ScrHW[ply][2]
 end
 
 __e2setcost(15)

--- a/lua/entities/gmod_wire_expression2/core/files.lua
+++ b/lua/entities/gmod_wire_expression2/core/files.lua
@@ -22,10 +22,10 @@ E2Lib.registerConstant( "FILE_TIMEOUT", FILE_TIMEOUT )
 E2Lib.registerConstant( "FILE_404", FILE_404 )
 E2Lib.registerConstant( "FILE_TRANSFER_ERROR", FILE_TRANSFER_ERROR )
 
-local delays = {}
-local uploads = {}
-local downloads = {}
-local lists = {}
+local delays = WireLib.RegisterPlayerTable()
+local uploads = WireLib.RegisterPlayerTable()
+local downloads = WireLib.RegisterPlayerTable()
+local lists = WireLib.RegisterPlayerTable()
 local run_on = {
 	file = {
 		run = 0,

--- a/lua/entities/gmod_wire_expression2/core/http.lua
+++ b/lua/entities/gmod_wire_expression2/core/http.lua
@@ -8,7 +8,7 @@ E2Lib.RegisterExtension( "http", false, "Lets E2 chips make web requests to the 
 local cvar_delay = CreateConVar( "wire_expression2_http_delay", "3", FCVAR_ARCHIVE )
 local cvar_timeout = CreateConVar( "wire_expression2_http_timeout", "15", FCVAR_ARCHIVE )
 
-local requests = {}
+local requests = WireLib.RegisterPlayerTable()
 local run_on = {
 	ents = {}
 }

--- a/lua/entities/gmod_wire_expression2/core/init.lua
+++ b/lua/entities/gmod_wire_expression2/core/init.lua
@@ -215,7 +215,7 @@ if SERVER then
 		wire_expression2_prepare_functiondata()
 
 		-- Send everything
-		local targets = {}
+		local targets = WireLib.RegisterPlayerTable()
 		local function sendData(target)
 			if IsValid(target) and target:IsPlayer() and targets[target] == nil then
 				targets[target] = "start"
@@ -250,7 +250,7 @@ if SERVER then
 			end
 		end)
 
-		local antispam = {}
+		local antispam = WireLib.RegisterPlayerTable()
 		function wire_expression2_sendfunctions(ply, isconcmd)
 			if isconcmd and not game.SinglePlayer() then
 				if not antispam[ply] then antispam[ply] = 0 end

--- a/lua/entities/gmod_wire_expression2/core/serialization.lua
+++ b/lua/entities/gmod_wire_expression2/core/serialization.lua
@@ -6,7 +6,7 @@ local DEFAULT = {n={},ntypes={},s={},stypes={},size=0}
 --[[
 wire_expression2_glon = {}
 wire_expression2_glon.history = {}
-wire_expression2_glon.players = {}
+wire_expression2_glon.players = WireLib.RegisterPlayerTable()
 
 local function logGlonCall( self, glonString, ret, safeGlonObject )
 	local logEntry =

--- a/lua/wire/stools/expression2.lua
+++ b/lua/wire/stools/expression2.lua
@@ -611,7 +611,7 @@ elseif CLIENT then
 			local ok, ret = pcall(WireLib.von.deserialize, buffer)
 			buffer, count = "", 0
 			if not ok then
-				WireLib.AddNotify(ply, "Expression 2 download failed! Error message:\n" .. ret, NOTIFY_ERROR, 7, NOTIFYSOUND_DRIP3)
+				WireLib.AddNotify("Expression 2 download failed! Error message:\n" .. ret, NOTIFY_ERROR, 7, NOTIFYSOUND_DRIP3)
 				return
 			end
 			local files = ret
@@ -646,7 +646,7 @@ elseif CLIENT then
 
 		local ok, ret = pcall(WireLib.von.deserialize, buffer)
 		if not ok then
-			WireLib.AddNotify(ply, "Expression 2 file list download failed! Error message:\n" .. ret, NOTIFY_ERROR, 7, NOTIFYSOUND_DRIP3)
+			WireLib.AddNotify("Expression 2 file list download failed! Error message:\n" .. ret, NOTIFY_ERROR, 7, NOTIFYSOUND_DRIP3)
 			print("Expression 2 file list download failed! Error message:\n" .. ret)
 			return
 		end

--- a/lua/wire/stools/expression2.lua
+++ b/lua/wire/stools/expression2.lua
@@ -566,7 +566,7 @@ elseif CLIENT then
 
 		if sending then return end
 		sending = true
-		upload_queue(true) // true means its the first packet, suppressing the delay
+		upload_queue(true) -- true means its the first packet, suppressing the delay
 	end
 
 	net.Receive("wire_expression2_tool_upload", function(len, ply)

--- a/lua/wire/stools/expression2.lua
+++ b/lua/wire/stools/expression2.lua
@@ -191,7 +191,7 @@ if SERVER then
 		end
 	end
 
-	local wantedfiles = {}
+	local wantedfiles = WireLib.RegisterPlayerTable()
 	net.Receive("wire_expression2_download_wantedfiles", function(len, ply)
 		local toent = net.ReadEntity()
 		local uploadandexit = net.ReadBit() ~= 0
@@ -220,8 +220,8 @@ if SERVER then
 	-- ------------------------------------------------------------
 	-- Serverside Receive
 	-- ------------------------------------------------------------
-	local uploads = {}
-	local upload_ents = {}
+	local uploads = WireLib.RegisterPlayerTable()
+	local upload_ents = WireLib.RegisterPlayerTable()
 	net.Receive("wire_expression2_upload", function(len, ply)
 		local toent = Entity(net.ReadUInt(16))
 		local numpackets = net.ReadUInt(16)
@@ -276,7 +276,7 @@ if SERVER then
 	-- Stuff for the remote updater
 	-- ------------------------------------------------------------
 
-	local antispam = {}
+	local antispam = WireLib.RegisterPlayerTable()
 	-- Returns true if they are spamming, false if they can go ahead and use it
 	local function canhas(ply)
 		if not antispam[ply] then antispam[ply] = 0 end
@@ -354,7 +354,7 @@ if SERVER then
 	-- Server part
 	------------------------------------------------------
 
-	local players_synced = {}
+	local players_synced = WireLib.RegisterPlayerTable()
 	util.AddNetworkString( "wire_expression_sync_ops" )
 	concommand.Add("wire_expression_ops_sync", function(player,command,args)
 		if not player:IsAdmin() then return end
@@ -982,7 +982,7 @@ if SERVER then
 
 elseif CLIENT then
 
-	local busy_players = {}
+	local busy_players = WireLib.RegisterPlayerTable()
 	hook.Add("EntityRemoved", "wire_expression2_busy_animation", function(ply)
 		busy_players[ply] = nil
 	end)

--- a/lua/wire/stools/friendslist.lua
+++ b/lua/wire/stools/friendslist.lua
@@ -44,7 +44,7 @@ local function netReadValues()
 end
 
 
-local friends = {}
+local friends = WireLib.RegisterPlayerTable()
 
 if SERVER then
 	util.AddNetworkString( "wire_friendslist" )

--- a/lua/wire/stools/value.lua
+++ b/lua/wire/stools/value.lua
@@ -49,7 +49,7 @@ if SERVER then
 	end
 
 	function TOOL:RightClick(trace)
-		if not IsValid(trace.Entity) or trace.Entity:GetClass() != "gmod_wire_value" then return false end
+		if not IsValid(trace.Entity) or trace.Entity:GetClass() ~= "gmod_wire_value" then return false end
 		playerValues[self:GetOwner()] = trace.Entity.value
 		net.Start("wire_value_values")
 			netWriteValues(trace.Entity.value)

--- a/lua/wire/stools/value.lua
+++ b/lua/wire/stools/value.lua
@@ -39,7 +39,7 @@ local function netReadValues()
 end
 
 if SERVER then
-	local playerValues = {}
+	local playerValues = WireLib.RegisterPlayerTable()
 	util.AddNetworkString( "wire_value_values" )
 	net.Receive( "wire_value_values", function( length, ply )
 		playerValues[ply] = netReadValues()

--- a/lua/wire/wire_paths.lua
+++ b/lua/wire/wire_paths.lua
@@ -42,7 +42,7 @@ if CLIENT then
 end
 
 WireLib.Paths = {}
-local transmit_queues = setmetatable({}, { __index = function(t,p) t[p] = {} return t[p] end })
+local transmit_queues = WireLib.RegisterPlayerTable(setmetatable({}, { __index = function(t,p) t[p] = {} return t[p] end }))
 util.AddNetworkString("WireLib.Paths.RequestPaths")
 util.AddNetworkString("WireLib.Paths.TransmitPath")
 

--- a/lua/wire/wire_paths.lua
+++ b/lua/wire/wire_paths.lua
@@ -80,12 +80,15 @@ end
 
 local function ProcessQueue()
 	for ply, queue in pairs(transmit_queues) do
-		if not ply:IsValid() then transmit_queues[ply] = nil continue end
-		local nextinqueue = table.remove(queue, 1)
-		if nextinqueue then
-			TransmitPath(nextinqueue, ply)
-		else
+		if not ply:IsValid() then
 			transmit_queues[ply] = nil
+		else
+			local nextinqueue = table.remove(queue, 1)
+			if nextinqueue then
+				TransmitPath(nextinqueue, ply)
+			else
+				transmit_queues[ply] = nil
+			end
 		end
 	end
 	if not next(transmit_queues) then

--- a/lua/wire/wire_paths.lua
+++ b/lua/wire/wire_paths.lua
@@ -80,15 +80,15 @@ end
 
 local function ProcessQueue()
 	for ply, queue in pairs(transmit_queues) do
-		if not ply:IsValid() then
-			transmit_queues[ply] = nil
-		else
+		if ply:IsValid() then
 			local nextinqueue = table.remove(queue, 1)
 			if nextinqueue then
 				TransmitPath(nextinqueue, ply)
 			else
 				transmit_queues[ply] = nil
 			end
+		else
+			transmit_queues[ply] = nil
 		end
 	end
 	if not next(transmit_queues) then

--- a/lua/wire/wireshared.lua
+++ b/lua/wire/wireshared.lua
@@ -1210,3 +1210,18 @@ do
 		end)
 	end
 end
+
+-- Generic clean-up system for tables with players as keys
+WireLib.PlayerTables = setmetatable({}, {__mode = "kv"})
+
+function WireLib.RegisterPlayerTable(tbl)
+    tbl = tbl or {}
+    WireLib.PlayerTables[tbl] = tbl
+    return tbl
+end
+
+hook.Add("PlayerDisconnected", "WireLib_PlayerDisconnect", function(ply)
+  for _,tbl in pairs(WireLib.PlayerTables) do
+    tbl[ply] = nil
+  end
+end)


### PR DESCRIPTION
I went through these two:
```bash
git grep '\[ply\]' |grep -v self | less
git grep -i '\[[^]]*player[^]]*\]'
```

There are probably more tables with player keys, but those were the low-hanging fruits and should cover a lot of what we have.