### PR TITLE
Overall optimizations, Normalize DEFAULT usage to a new E2Lib functio…

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/array.lua
+++ b/lua/entities/gmod_wire_expression2/core/array.lua
@@ -19,9 +19,7 @@ local blocked_types = {
 }
 
 -- Fix return values
-local function fixdef( val )
-	return istable(val) and table.Copy(val) or val
-end
+local fixDefault = E2Lib.fixDefault
 
 -- Uppercases the first letter
 local function upperfirst( word )
@@ -139,7 +137,7 @@ registerCallback( "postinit", function()
 			__e2setcost(5)
 
 			local function getter( self, array, index, doremove )
-				if (!array or !index) then return fixdef( default ) end -- Make sure array and index are value
+				if (!array or !index) then return fixDefault( default ) end -- Make sure array and index are value
 				local ret
 				if (doremove) then
 					ret = table_remove( array, index )
@@ -147,7 +145,7 @@ registerCallback( "postinit", function()
 				else
 					ret = array[floor(index)]
 				end
-				if (typecheck and typecheck( ret )) then return fixdef( default ) end -- If typecheck returns true, the type is wrong.
+				if (typecheck and typecheck( ret )) then return fixDefault( default ) end -- If typecheck returns true, the type is wrong.
 				return ret
 			end
 
@@ -169,10 +167,10 @@ registerCallback( "postinit", function()
 			--------------------------------------------------------------------------------
 
 			local function setter( self, array, index, value, doinsert )
-				if (!array or !index) then return fixdef( default ) end -- Make sure array and index are valid
-				if (typecheck and typecheck( value )) then return fixdef( default ) end -- If typecheck returns true, the type is wrong.
+				if (!array or !index) then return fixDefault( default ) end -- Make sure array and index are valid
+				if (typecheck and typecheck( value )) then return fixDefault( default ) end -- If typecheck returns true, the type is wrong.
 				if (doinsert) then
-					if index > 2^31 or index < 0 then return fixdef( default ) end -- too large, possibility of crashing gmod
+					if index > 2^31 or index < 0 then return fixDefault( default ) end -- too large, possibility of crashing gmod
 					table_insert( array, index, value )
 				else
 					array[floor(index)] = value
@@ -223,7 +221,7 @@ registerCallback( "postinit", function()
 			registerFunction( "pop" .. nameupperfirst, "r:", id, function(self,args)
 				local op1 = args[2]
 				local array = op1[1](self,op1)
-				if (!array) then return fixdef( default ) end
+				if (!array) then return fixDefault( default ) end
 				return getter( self, array, #array, true )
 			end)
 
@@ -244,7 +242,7 @@ registerCallback( "postinit", function()
 			registerFunction( "shift" .. nameupperfirst, "r:", id, function(self,args)
 				local op1 = args[2]
 				local array = op1[1](self,op1)
-				if (!array) then return fixdef( default ) end
+				if (!array) then return fixDefault( default ) end
 				return getter( self, array, 1, true )
 			end)
 
@@ -255,7 +253,7 @@ registerCallback( "postinit", function()
 			registerFunction( "remove" .. nameupperfirst, "r:n", id, function(self,args)
 				local op1, op2 = args[2], args[3]
 				local array, index = op1[1](self,op1), op2[1](self,op2)
-				if (!array or !index) then return fixdef( default ) end
+				if (!array or !index) then return fixDefault( default ) end
 				return getter( self, array, index, true )
 			end)
 

--- a/lua/entities/gmod_wire_expression2/core/datasignal.lua
+++ b/lua/entities/gmod_wire_expression2/core/datasignal.lua
@@ -237,9 +237,7 @@ end
 
 local non_allowed_types = { xgt = true } -- If anyone can think of any other types that should never be allowed, enter them here.
 
-local function fixdefault( var )
-	return istable(var) and copy(var) or var
-end
+local fixDefault = E2Lib.fixDefault
 
 registerCallback("postinit",function()
 	-- Add support for EVERY SINGLE type. Yeah!!
@@ -294,7 +292,7 @@ registerCallback("postinit",function()
 
 			-- Get variable
 			registerFunction("dsGet" .. upperfirst( k ), "", v[1], function(self,args)
-				if not self.data.currentsignal or self.data.currentsignal.vartype ~= k then return fixdefault(v[2]) end
+				if not self.data.currentsignal or self.data.currentsignal.vartype ~= k then return fixDefault(v[2]) end
 				return self.data.currentsignal.var
 			end)
 

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -39,6 +39,18 @@ function E2Lib.setSubMaterial(ent, index, material)
 	duplicator.StoreEntityModifier(ent, "submaterial", { ["SubMaterialOverride_"..index] = material })
 end
 
+-- Returns a default e2 table.
+function E2Lib.newE2Table(extend)
+	return {n={},ntypes={},s={},stypes={},size=0}
+end
+
+-- Returns a cloned table of the variable given if it is a table.
+local istable = istable
+local table_Copy = table.Copy
+function E2Lib.fixDefault(var)
+	return istable(var) and table_Copy(var) or var
+end
+
 -- getHash
 -- Returns a hash for the given string
 

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -40,7 +40,7 @@ function E2Lib.setSubMaterial(ent, index, material)
 end
 
 -- Returns a default e2 table.
-function E2Lib.newE2Table(extend)
+function E2Lib.newE2Table()
 	return {n={},ntypes={},s={},stypes={},size=0}
 end
 

--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -924,9 +924,7 @@ local function upperfirst( word )
 	return word:Left(1):upper() .. word:Right(-2):lower()
 end
 
-local function fixdef( def )
-	return istable(def) and table.Copy(def) or def
-end
+local fixDefault = E2Lib.fixDefault
 
 local non_allowed_types = {
 	xgt = true,
@@ -945,10 +943,10 @@ registerCallback("postinit",function()
 			local function getf( self, args )
 				local op1, op2 = args[2], args[3]
 				local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
-				if not IsValid(rv1) or not rv2 then return fixdef( v[2] ) end
+				if not IsValid(rv1) or not rv2 then return fixDefault( v[2] ) end
 				local id = self.uid
-				if not rv1["EVar_"..id] then return fixdef( v[2] ) end
-				return rv1["EVar_"..id][rv2] or fixdef( v[2] )
+				if not rv1["EVar_"..id] then return fixDefault( v[2] ) end
+				return rv1["EVar_"..id][rv2] or fixDefault( v[2] )
 			end
 
 			local function setf( self, args )

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -272,13 +272,6 @@ number_of_keys = number_of_keys + 7
 -- add three more for flashlight "impulse 100" and next/prev weapon binds
 number_of_keys = number_of_keys + 3
 
-registerCallback("destruct",function(self)
-	KeyAlert[self.entity] = nil
-	--Used futher below. Didn't want to create more then one of these per file
-	spawnAlert[self.entity] = nil
-	leaveAlert[self.entity] = nil
-end)
-
 local function UpdateKeys(ply, bind, key, state)
 	local uid = ply:UniqueID()
 
@@ -696,40 +689,45 @@ e2function entity lastDisconnectedPlayer()
 	return lastLeft
 end
 
------ Deaths+Spawns, Dev: Vurv, 12/28/19 -----
-local DeathAlert = {} -- table of e2s that have runOnDeath(1)
+----- Death+Respawns by Vurv -----
+
+local DeathAlert = {}
 local RespawnAlert = {}
-local DeathList = { last = {} }
-local RespawnList = { last = {} }
+local DeathList = { last = { timestamp = 0, victim = NULL, inflictor = NULL, attacker = NULL } }
+local RespawnList = { last = { timestamp = 0, ply = NULL } }
 
 hook.Add("PlayerDeath","Exp2PlayerDetDead",function(victim,inflictor,attacker)
-	local entry = {} -- default table
+	local entry = {}
 	entry.victim = victim
 	entry.inflictor = inflictor
 	entry.timestamp = CurTime()
 	entry.attacker = attacker
-	DeathList[victim:EntIndex()] = entry -- victim's death is saved in victims death list.
+	DeathList[victim] = entry -- victim's death is saved in victims death list.
 	DeathList.last = entry -- the most recent death's table is stored here for later use.
-	for ex,_ in pairs(DeathAlert) do -- loops over all chips in deathalert, ignores key.
-		if IsValid(ex) then
-			ex.context.data.runByDeath = entry
-			ex:Execute()
-			ex.context.data.runByDeath = nil
+	for e2 in next,DeathAlert do
+		if IsValid(e2) then
+			e2.context.data.runByDeath = true
+			e2:Execute()
+			e2.context.data.runByDeath = nil
+		else
+			DeathAlert[e2] = nil
 		end
 	end
 end)
 
-hook.Add("PlayerSpawn","Exp2PlayerDetRespn",function(player,transition)
+hook.Add("PlayerSpawn","Exp2PlayerDetRespn",function(player)
 	local entry = {}
 	entry.ply = player
 	entry.timestamp = CurTime()
-	RespawnList[player:EntIndex()] = entry
+	RespawnList[player] = entry
 	RespawnList.last = entry
-	for ex,_ in pairs(RespawnAlert) do
-		if IsValid(ex) then
-			ex.context.data.runByRespawned = entry
-			ex:Execute()
-			ex.context.data.runByRespawned = nil
+	for e2 in next,RespawnAlert do
+		if IsValid(e2) then
+			e2.context.data.runByRespawned = true
+			e2:Execute()
+			e2.context.data.runByRespawned = nil
+		else
+			RespawnAlert[e2] = nil
 		end
 	end
 end)
@@ -737,97 +735,98 @@ end)
 __e2setcost(5)
 
 --- If active is 0, the chip will no longer run on death.
-e2function void runOnDeath(number activate)
-	if activate ~= 0 then
-		DeathAlert[self.entity] = true
-	else
-		DeathAlert[self.entity] = nil
-	end
+e2function void runOnDeath(number active)
+	DeathAlert[self.entity] = active~=0 and true or nil
 end
 
---If ran by death, (defined in e2 data), gives 1 or 0 (ternary)
+-- Give 1 or 0 depending on whether the chip was run by a death event.
 e2function number deathClk()
 	return self.data.runByDeath and 1 or 0
 end
 
-e2function number lastDeathTime() -- returns when the last death happened
-	local Timestamp = DeathList.last.timestamp
-	if not IsValid(Timestamp) then return 0 end
-	return Timestamp -- Checks if num is valid, if so then returns the timestamp from the table, else returns 0.
+e2function number lastDeathTime()
+	return DeathList.last.timestamp or 0
 end
 
-e2function number lastDeathTime(entity ply) -- returns when the player provided last died
-	if not IsValid(ply) then return NULL end
-	if not ply:IsPlayer() then return NULL end
-	local Timestamp = DeathList[ply:EntIndex()].timestamp
-	if not IsValid(Timestamp) then return 0 end
-	return Timestamp -- Checks if num is valid, if so then returns the timestamp from the table, else returns 0. (also checks if ply is player and valid)
+-- To avoid a lot of repeated checks
+local function getDeathEntry(ply,key)
+	if not IsValid(ply) then return end
+	if not ply:IsPlayer() then return end
+	local entry = DeathList[ply]
+	if not entry then return end -- Player has never died.
+	return entry[key]
 end
 
-e2function entity lastDeathVictim() -- Gives Death Victim
-	local Victim = DeathList.last.victim
-	if not IsValid(Victim) then return NULL end
-	return Victim
+local function getRespawnEntry(ply,key)
+	if not IsValid(ply) then return end
+	if not ply:IsPlayer() then return end
+	local entry = RespawnList[ply]
+	if not entry then return end -- Player has never respawned.
+	return entry[key]
+end
+
+e2function number lastDeathTime(entity ply) -- When the player provided last died.
+	return getDeathEntry(ply,"timestamp") or 0
+end
+
+e2function entity lastDeathVictim()
+	return DeathList.last.victim
 end
 
 e2function entity lastDeathInflictor()
-	local Inflictor = DeathList.last.inflictor
-	if not IsValid(Inflictor) then return NULL end
-	return Inflictor
+	return DeathList.last.inflictor
 end
 
 e2function entity lastDeathInflictor(entity ply)
-	if not IsValid(ply) then return NULL end
-	if not ply:IsPlayer() then return NULL end
-	local Inflictor = DeathList[ply:EntIndex()].inflictor
-	if not IsValid(Inflictor) then return NULL end
-	return Inflictor
+	return getDeathEntry(ply,"inflictor") or NULL
 end
 
 e2function entity lastDeathAttacker()
-	local Attacker = DeathList.last.attacker
-	if not IsValid(Attacker) then return NULL end
-	return Attacker
+	return DeathList.last.attacker
 end
 
 e2function entity lastDeathAttacker(entity ply)
-	if not IsValid(ply) then return NULL end
-	if not ply:IsPlayer() then return NULL end
-	local Attacker = DeathList[ply:EntIndex()].attacker
-	if not IsValid(Attacker) then return NULL end
-	return Attacker
+	return getDeathEntry(ply,"attacker") or NULL
 end
 
--- Spawn Functions
+-- Respawn Functions
 e2function number spawnClk()
 	return self.data.runByRespawned and 1 or 0
 end
 
-e2function void runOnSpawn(number activate)
-	if activate ~= 0 then
-		RespawnAlert[self.entity] = true
-	else
-		RespawnAlert[self.entity] = nil
-	end
+e2function void runOnSpawn(number activate) -- If 1, make the chip run on a player RESPAWNING. Not joining.
+	RespawnAlert[self.entity] = active~=0 and true or nil
 end
 
 e2function number lastSpawnTime()
-	local Timestamp = RespawnList.last.timestamp
-	if not IsValid(Timestamp) then return 0 end
-	return Timestamp
+	return RespawnList.last.timestamp or 0
 end
 
-e2function number lastSpawnTime(entity ply) -- returns the last time player provided spawned.
-	if not IsValid(ply) then return 0 end
-	if not ply:IsPlayer() then return 0 end
-	local Timestamp = SpawnList[ply:EntIndex()].timestamp
-	if not IsValid(Timestamp) then return 0 end
-	return Timestamp
+e2function number lastSpawnTime(entity ply) -- When the player provided last respawned. (Not joined)
+	return getRespawnEntry(ply,"timestamp") or 0
 end
 
 e2function entity lastSpawnedPlayer()
-	local Ply = RespawnList.last.ply
-	if not IsValid(Ply) then return NULL end
-	return Ply
+	return RespawnList.last.ply
 end
 --******************************************--
+
+
+-- Destructor to avoid invalid chips being called in hooks.
+-- Moved down here to avoid memory leak with Death/Respawn alerts
+
+registerCallback("destruct",function(self)
+	KeyAlert[self.entity] = nil
+	--Used futher below. Didn't want to create more then one of these per file
+	spawnAlert[self.entity] = nil
+	leaveAlert[self.entity] = nil
+	-- Even further below.
+	DeathAlert[self.entity] = nil
+	RespawnAlert[self.entity] = nil
+end)
+
+-- Memory leak with the list of deaths, as before the list would just keep building as players left.
+hook.Add("PlayerDisconnected","Exp2DRCleanup",function(ply)
+	DeathList[ply] = nil
+	RespawnList[ply] = nil
+end)

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -727,7 +727,7 @@ hook.Add("PlayerDeath","Exp2PlayerDetDead",function(victim,inflictor,attacker)
 end)
 
 hook.Add("PlayerSpawn","Exp2PlayerDetRespn",function(player)
-	local entry = { 
+	local entry = {
 		timestamp = CurTime(),
 		ply = player
 	}
@@ -806,7 +806,7 @@ e2function number spawnClk()
 	return self.data.runByRespawned and 1 or 0
 end
 
-e2function void runOnSpawn(number activate) -- If 1, make the chip run on a player RESPAWNING. Not joining.
+e2function void runOnSpawn(number activate) -- If 1, make the chip run on a player respawning. Not joining.
 	RespawnAlert[self.entity] = active~=0 and true or nil
 end
 
@@ -814,7 +814,7 @@ e2function number lastSpawnTime()
 	return RespawnList.last.timestamp or 0
 end
 
-e2function number lastSpawnTime(entity ply) -- When the player provided last respawned. (Not joined)
+e2function number lastSpawnTime(entity ply)
 	return getRespawnEntry(ply,"timestamp") or 0
 end
 
@@ -830,10 +830,8 @@ end
 -- Maybe another E2Lib / WireLib function could be made for this to be automated?
 registerCallback("destruct",function(self)
 	KeyAlert[self.entity] = nil
-	--Used futher below. Didn't want to create more then one of these per file
 	spawnAlert[self.entity] = nil
 	leaveAlert[self.entity] = nil
-	-- Even further below.
 	DeathAlert[self.entity] = nil
 	RespawnAlert[self.entity] = nil
 end)

--- a/lua/entities/gmod_wire_expression2/core/ranger.lua
+++ b/lua/entities/gmod_wire_expression2/core/ranger.lua
@@ -555,12 +555,13 @@ local ids = {
 	["HitBoxBone"] = "n"
 }
 
-local DEFAULT = {n={},ntypes={},s={},stypes={},size=0}
+
+local newE2Table = E2Lib.newE2Table
 
 -- Converts the ranger into a table. This allows you to manually get any and all raw data from the trace.
 e2function table ranger:toTable()
 	if not this then return {} end
-	local ret = table.Copy(DEFAULT)
+	local ret = newE2Table()
 	local size = 0
 	for k,v in pairs( this ) do
 		if (ids[k]) then

--- a/lua/entities/gmod_wire_expression2/core/selfaware.lua
+++ b/lua/entities/gmod_wire_expression2/core/selfaware.lua
@@ -58,10 +58,12 @@ local function setOutput( self, args, Type )
 	end
 end
 
+local fixDefault = E2Lib.fixDefault
+
 local function getInput( self, args, default, Type )
 	local op1 = args[2]
 	local rv1 = op1[1](self,op1)
-	if istable(default) then default = table.Copy(default) end
+	default = fixDefault(default)
 	if (self.entity.Inputs[rv1] and self.entity.Inputs[rv1].Type == Type) then
 		return self.GlobalScope[rv1] or default
 	end

--- a/lua/entities/gmod_wire_expression2/core/serialization.lua
+++ b/lua/entities/gmod_wire_expression2/core/serialization.lua
@@ -1,7 +1,7 @@
 E2Lib.RegisterExtension("serialization", true, "Adds functions to serialize data structures into a string and back again.")
 
 -- GLON output validation
-local DEFAULT = {n={},ntypes={},s={},stypes={},size=0}
+local newE2Table = E2Lib.newE2Table
 
 --[[
 wire_expression2_glon = {}
@@ -125,7 +125,7 @@ typeSanitizers = {
 					return safeGlonObjectMap["t"][glonOutputObject]
 				end
 
-				local safeTable = table.Copy(DEFAULT)
+				local safeTable = newE2Table()
 				if not glonOutputObject then return safeTable end
 				safeGlonObjectMap["t"][glonOutputObject] = safeTable
 
@@ -298,7 +298,7 @@ if glon then
 
 	-- decodes a glon string and returns an table
 	e2function table glonDecodeTable(string data)
-		if not data or data == "" then return table.Copy(DEFAULT) end
+		if not data or data == "" then return newE2Table() end
 
 		self.prf = self.prf + #data / 2
 
@@ -306,11 +306,11 @@ if glon then
 		if not ok then
 			last_glon_error = ret
 			ErrorNoHalt("glon.decode error: "..ret)
-			return table.Copy(DEFAULT)
+			return newE2Table()
 		end
 
 		local safeTable = sanitizeGlonOutput( self, ret, "t" )
-		return safeTable or table.Copy(DEFAULT)
+		return safeTable or newE2Table()
 	end
 end
 
@@ -371,20 +371,20 @@ __e2setcost(25)
 
 -- decodes a glon string and returns an table
 e2function table vonDecodeTable(string data)
-	if not data or data == "" then return table.Copy(DEFAULT) end
+	if not data or data == "" then return newE2Table() end
 
 	self.prf = self.prf + #data / 2
 
 	local ok, ret = pcall(WireLib.von.deserialize, data)
 	if not ok then
 		last_von_error = ret
-		if not antispam(self) then return table.Copy(DEFAULT) end
+		if not antispam(self) then return newE2Table() end
 		WireLib.ClientError("von.decode error: "..ret, self.player)
-		return table.Copy(DEFAULT)
+		return newE2Table()
 	end
 
 	local safeTable = sanitizeGlonOutput( self, ret, "t" )
-	return safeTable or table.Copy(DEFAULT)
+	return safeTable or newE2Table()
 end
 
 ---------------------------------------------------------------------------
@@ -517,7 +517,7 @@ e2function string jsonEncode( table data, prettyprint ) return jsonEncode_start(
 
 -- this function converts a lua table into an E2 table
 local function jsonDecode_recurse( self, luatable, copied_tables )
-	local e2table = table.Copy(DEFAULT)
+	local e2table = newE2Table()
 
 	local wire_expression_types = wire_expression_types
 
@@ -527,7 +527,7 @@ local function jsonDecode_recurse( self, luatable, copied_tables )
 		-- if it's a table, recurse through it and convert all the tables it contains
 		if typeid == "t" then
 			local val = v
-			v = table.Copy(DEFAULT)
+			v = newE2Table()
 
 			if copied_tables[val] then
 				v = copied_tables[val]

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -464,7 +464,6 @@ local table_Copy = table.Copy
 -- Helper function for gmatch (below)
 -- (By Divran)
 local newE2Table = E2Lib.newE2Table
--- It seems we don't need 'istable' and 'depth' params in an e2 table. So we are going to disregard them.
 
 local function gmatch( self, this, pattern )
 	local ret = newE2Table()

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -463,9 +463,11 @@ local table_Copy = table.Copy
 
 -- Helper function for gmatch (below)
 -- (By Divran)
-local DEFAULT = {n={},ntypes={},s={},stypes={},size=0,istable=true,depth=0}
+local newE2Table = E2Lib.newE2Table
+-- It seems we don't need 'istable' and 'depth' params in an e2 table. So we are going to disregard them.
+
 local function gmatch( self, this, pattern )
-	local ret = table_Copy( DEFAULT )
+	local ret = newE2Table()
 	local num = 0
 	local iter = this:gmatch( pattern )
 	local v
@@ -487,7 +489,7 @@ e2function table string:gmatch(string pattern)
 	local OK, ret = pcall( gmatch, self, this, pattern )
 	if (!OK) then
 		self.player:ChatPrint( ret or "Unknown error in str:gmatch" )
-		return table_Copy( DEFAULT )
+		return newE2Table()
 	else
 		return ret
 	end
@@ -500,7 +502,7 @@ e2function table string:gmatch(string pattern, position)
 	local OK, ret = pcall( gmatch, self, this, pattern )
 	if (!OK) then
 		self.player:ChatPrint( ret or "Unknown error in str:gmatch" )
-		return table_Copy( DEFAULT )
+		return newE2Table()
 	else
 		return ret
 	end

--- a/lua/entities/gmod_wire_expression2/core/table.lua
+++ b/lua/entities/gmod_wire_expression2/core/table.lua
@@ -33,12 +33,12 @@ end
 -- Type defining
 --------------------------------------------------------------------------------
 
-local DEFAULT = {n={},ntypes={},s={},stypes={},size=0}
+local newE2Table = E2Lib.newE2Table
 
-registerType("table", "t", table.Copy(DEFAULT),
+registerType("table", "t", newE2Table(),
 	function(self, input)
 		if input.size == 0 then
-			return table.Copy(DEFAULT)
+			return newE2Table()
 		end
 		return input
 	end,
@@ -116,9 +116,7 @@ end)
 --------------------------------------------------------------------------------
 
 -- Fix default values
-local function fixdef( def )
-	return istable(def) and table.Copy(def) or def
-end
+local fixDefault = E2Lib.fixDefault
 
 -- Uppercases the first letter
 local function upperfirst( word )
@@ -290,8 +288,7 @@ end
 __e2setcost(nil)
 
 registerOperator( "kvtable", "", "t", function( self, args )
-	local ret = table.Copy( DEFAULT )
-
+	local ret = newE2Table()
 
 	local types = args[3]
 
@@ -331,8 +328,8 @@ __e2setcost(1)
 -- Creates a table
 e2function table table(...)
 	local tbl = {...}
-	if (#tbl == 0) then return table.Copy(DEFAULT) end
-	local ret = table.Copy(DEFAULT)
+	if (#tbl == 0) then return newE2Table() end
+	local ret = newE2Table()
 	local size = 0
 	for k,v in ipairs( tbl ) do
 		if (!blocked_types[typeids[k]]) then
@@ -406,7 +403,7 @@ __e2setcost(5)
 
 -- Flip the numbers and strings of the table
 e2function table table:flip()
-	local ret = table.Copy(DEFAULT)
+	local ret = newE2Table()
 	for k,v in pairs( this.n ) do
 		if (this.ntypes[k] == "s") then
 			ret.s[v] = k
@@ -425,7 +422,7 @@ end
 
 -- Returns an table with the typesids of both the array- and table-parts
 e2function table table:typeids()
-	local ret = table.Copy(DEFAULT)
+	local ret = newE2Table()
 	ret.n = table.Copy(this.ntypes)
 	for k,v in pairs( ret.n ) do
 		ret.ntypes[k] = "s"
@@ -485,7 +482,7 @@ e2function number table:unset( string index ) = e2function number table:remove( 
 
 -- Removes all variables not of the type
 e2function table table:clipToTypeid( string typeid )
-	local ret = table.Copy(DEFAULT)
+	local ret = newE2Table()
 	for k,v in pairs( this.n ) do
 		if (this.ntypes[k] == typeid) then
 			local n = #ret.n+1
@@ -515,7 +512,7 @@ end
 
 -- Removes all variables of the type
 e2function table table:clipFromTypeid( string typeid )
-	local ret = table.Copy(DEFAULT)
+	local ret = newE2Table()
 	for k,v in pairs( this.n ) do
 		if (this.ntypes[k] != typeid) then
 			if istable(v) then
@@ -656,7 +653,7 @@ end
 
 -- Removes all variables from 'this' which have keys which exist in rv2
 e2function table table:difference( table rv2 )
-	local ret = table.Copy(DEFAULT)
+	local ret = newE2Table()
 	local cost = 0
 	local size = 0
 
@@ -685,7 +682,7 @@ end
 
 -- Removes all variables from 'this' which don't have keys which exist in rv2
 e2function table table:intersect( table rv2 )
-	local ret = table.Copy(DEFAULT)
+	local ret = newE2Table()
 	local cost = 0
 	local size = 0
 
@@ -839,7 +836,7 @@ __e2setcost(20)
 
 -- Returns the find in the array part of an table
 e2function table findToTable()
-	local ret = table.Copy(DEFAULT)
+	local ret = newE2Table()
 	for k,v in ipairs( self.data.findlist ) do
 		ret.n[k] = v
 		ret.ntypes[k] = "e"
@@ -904,7 +901,7 @@ __e2setcost(5)
 --- Returns a lookup table for <arr>. Usage: Index = T:number(toString(Value)).
 --- Don't overuse this function, as it can become expensive for arrays with > 10 entries!
 e2function table invert(array arr)
-	local ret = table.Copy(DEFAULT)
+	local ret = newE2Table()
 	local c = 0
 	local size = 0
 	for i,v in ipairs(arr) do
@@ -926,7 +923,7 @@ end
 --- Returns a lookup table for <tbl>. Usage: Key = T:string(toString(Value)).
 --- Don't overuse this function, as it can become expensive for tables with > 10 entries!
 e2function table invert(table tbl)
-	local ret = table.Copy(DEFAULT)
+	local ret = newE2Table()
 	local c = 0
 	local size = 0
 	for i,v in pairs(tbl.n) do
@@ -1014,16 +1011,16 @@ registerCallback( "postinit", function()
 		registerOperator("idx",	id.."=ts"		, id, function(self,args)
 			local op1, op2 = args[2], args[3]
 			local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
-			if (!rv1.s[rv2] or rv1.stypes[rv2] != id) then return fixdef(v[2]) end
-			if (v[6] and v[6](rv1.s[rv2])) then return fixdef(v[2]) end -- Type check
+			if (!rv1.s[rv2] or rv1.stypes[rv2] != id) then return fixDefault(v[2]) end
+			if (v[6] and v[6](rv1.s[rv2])) then return fixDefault(v[2]) end -- Type check
 			return rv1.s[rv2]
 		end)
 
 		registerOperator("idx",	id.."=tn"		, id, function(self,args)
 			local op1, op2 = args[2], args[3]
 			local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
-			if (!rv1.n[rv2] or rv1.ntypes[rv2] != id) then return fixdef(v[2]) end
-			if (v[6] and v[6](rv1.n[rv2])) then return fixdef(v[2]) end -- Type check
+			if (!rv1.n[rv2] or rv1.ntypes[rv2] != id) then return fixDefault(v[2]) end
+			if (v[6] and v[6](rv1.n[rv2])) then return fixDefault(v[2]) end -- Type check
 			return rv1.n[rv2]
 		end)
 
@@ -1058,9 +1055,9 @@ registerCallback( "postinit", function()
 		__e2setcost(8)
 
 		local function removefunc( self, rv1, rv2, numidx )
-			if (!rv1 or !rv2) then return fixdef(v[2]) end
+			if (!rv1 or !rv2) then return fixDefault(v[2]) end
 			if (numidx) then
-				if (!rv1.n[rv2] or rv1.ntypes[rv2] != id) then return fixdef(v[2]) end
+				if (!rv1.n[rv2] or rv1.ntypes[rv2] != id) then return fixDefault(v[2]) end
 				local ret = rv1.n[rv2]
 				if rv2 < 1 then -- table.remove doesn't work if the index is below 1
 					rv1.n[rv2] = nil
@@ -1073,7 +1070,7 @@ registerCallback( "postinit", function()
 				self.GlobalScope.vclk[rv1] = true
 				return ret
 			else
-				if (!rv1.s[rv2] or rv1.stypes[rv2] != id) then return fixdef(v[2]) end
+				if (!rv1.s[rv2] or rv1.stypes[rv2] != id) then return fixDefault(v[2]) end
 				local ret = rv1.s[rv2]
 				rv1.s[rv2] = nil
 				rv1.stypes[rv2] = nil


### PR DESCRIPTION
…n, newE2Table, Fix D+R Functions

Really long title, but that's because I ended up putting A LOT into the PR. This fixes #2006, as I replaced the usage of the DEFAULT e2 table variable with a new function in the E2Lib, newE2Table, which returns a default e2 table structure. Used grep to find all instances of DEFAULT and table.Copy, but there may still be some left.

Also noticed that there was a 'fixdef' or 'fixdefault' function that was repeated in a lot of code, so that has been turned into an E2Lib function as well and were localized and normalized in name in their respective files. They are now fixDefault in E2Lib.fixDefault.

Also fixed and optimized the Death + Respawn functions I added a year ago. Some functions were broken actually and overall I didn't like the code at all. It is much smaller / neater and avoids memory leaks.

I will avoid making long PRs in the future, I know it'll make review tedious.

Some test code for the D+R functions:
```golo
@name Death+Respawn Function Test
if(first()){
    runOnDeath(1)
    runOnSpawn(1)
    
    assert(lastDeathTime(owner())==0) # Place this when you barely join a server so you haven't died.
    print("You haven't died yet!")
}elseif(deathClk()){
    local Ply = lastDeathVictim()
    print(Ply:name(),"Just died.")
    print(lastDeathTime(Ply))
}elseif(spawnClk()){
    local Ply = lastSpawnedPlayer()
    print(Ply:name(),"Just respawned.")
    assert(lastSpawnTime(Ply)==lastSpawnTime())
}
```

Swapping the use of DEFAULT shouldn't and hasn't appeared to have broken anything.
```golo
@name New Default Table Test

T = table(1,2,3,4)
print(T:count(),T[1,number],T:clone():remove(1))
```