### PR TITLE
Change user to have the activator as it's self

### DIFF
--- a/lua/entities/gmod_wire_user.lua
+++ b/lua/entities/gmod_wire_user.lua
@@ -38,7 +38,7 @@ function ENT:TriggerInput(iname, value)
 		if not hook.Run( "PlayerUse", ply, trace.Entity ) then return false end
 
 		if trace.Entity.Use then
-			trace.Entity:Use(ply,ply,USE_ON,0)
+			trace.Entity:Use(self,ply,USE_ON,0)
 		else
 			trace.Entity:Fire("use","1",0)
 		end


### PR DESCRIPTION
Wiki states that activator might be a proxy. Why doesn't it send its self already?