### PR TITLE
Fixes seat switching bug on Pod Controllers

### DIFF
--- a/lua/entities/gmod_wire_pod.lua
+++ b/lua/entities/gmod_wire_pod.lua
@@ -482,7 +482,7 @@ function ENT:Think()
 		-- Button pressing
 		if (self.AllowButtons and distance < 82) then
 			local button = trace.Entity
-			if IsValid(button) and (ply:KeyDown( IN_ATTACK ) and not self.MouseDown) and !button:IsVehicle() and button.Use then
+			if IsValid(button) and (ply:KeyDown( IN_ATTACK ) and not self.MouseDown) and not button:IsVehicle() and button.Use then
 				-- Generic support (Buttons, Dynamic Buttons, Levers, EGP screens, etc)
 				self.MouseDown = true
 				button:Use(ply, self, USE_ON, 0)

--- a/lua/entities/gmod_wire_pod.lua
+++ b/lua/entities/gmod_wire_pod.lua
@@ -482,7 +482,7 @@ function ENT:Think()
 		-- Button pressing
 		if (self.AllowButtons and distance < 82) then
 			local button = trace.Entity
-			if IsValid(button) and (ply:KeyDown( IN_ATTACK ) and not self.MouseDown) and button.Use then
+			if IsValid(button) and (ply:KeyDown( IN_ATTACK ) and not self.MouseDown) and !button:IsVehicle() and button.Use then
 				-- Generic support (Buttons, Dynamic Buttons, Levers, EGP screens, etc)
 				self.MouseDown = true
 				button:Use(ply, self, USE_ON, 0)


### PR DESCRIPTION
Noticed a bug which was possibly introduced by commit d6662b2ed49d0756f7af5cdaf55e0b6491d1bacc where left clicking on a seat would transfer the player to said seat, and the player would then not be able to enter the original seat until it is respawned/the player rejoins.

I've recently returned to GMod after about 4-5 years, and do not remember this being an issue.

It is possible that this is intended functionality, and the returning to seat issue is just a bug.

Fixes seat switching bug on Pod Controllers with "Allow Buttons" enabled.