### PR TITLE
add getGateName to cl

### DIFF
--- a/lua/entities/gmod_wire_expression2/cl_init.lua
+++ b/lua/entities/gmod_wire_expression2/cl_init.lua
@@ -91,6 +91,10 @@ local function wtfgarry( str )
 	return w, h
 end
 
+function ENT:GetGateName()
+    return self:GetNWString("name", self.name)
+end
+
 local h_of_lower = 100 -- height of the lower section (the prfbench/percent bar section)
 function ENT:GetWorldTipBodySize()
 	local data = self:GetOverlayData()


### PR DESCRIPTION
adds GetGateName to clientside code, this is needed for e:getChipName() to work on @client in starfall chips
edit: getting the name of sf chip from @client works but getting the name of e2 chips doesnt, this fixes that