### PR TITLE
Allow E2 to write (and read) files other than .txt

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/cl_files.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_files.lua
@@ -104,7 +104,7 @@ end )
 /* --- File Write --- */
 net.Receive("wire_expression2_file_download_begin", function( netlen )
 	local fpath,fname = process_filepath( net.ReadString() )
-	if !E2Lib.isValidFilePath(fname) then return end
+	if !E2Lib.isValidFileWritePath(fname) then return end
 	if not file.Exists(fpath, "DATA") then file.CreateDir(fpath) end
 	download_buffer = {
 		name = fpath .. fname,

--- a/lua/entities/gmod_wire_expression2/core/cl_files.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_files.lua
@@ -104,7 +104,7 @@ end )
 /* --- File Write --- */
 net.Receive("wire_expression2_file_download_begin", function( netlen )
 	local fpath,fname = process_filepath( net.ReadString() )
-	if string.GetExtensionFromFilename( string.lower(fname) ) != "txt" then return end
+	if !E2Lib.isValidFilePath(fname) then return end
 	if not file.Exists(fpath, "DATA") then file.CreateDir(fpath) end
 	download_buffer = {
 		name = fpath .. fname,

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -755,7 +755,8 @@ local file_extensions = {
 	["ogg"] = true
 }
 
-function E2Lib.isValidFilePath(path)
+-- Returns whether the file has an extension garrysmod can write to, to avoid useless net messages, etc
+function E2Lib.isValidFileWritePath(path)
 	local ext = string.GetExtensionFromFilename(path)
 	if ext then return file_extensions[string.lower(ext)] end
 end

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -736,3 +736,26 @@ hook.Add("InitPostEntity", "e2lib", function()
 		end
 	end
 end)
+
+--- Valid file extensions kept to avoid trying to make files with extensions gmod doesn't allow.
+-- https://wiki.facepunch.com/gmod/file.Write
+local file_extensions = {
+	["txt"] = true,
+	["dat"] = true,
+	["json"] = true,
+	["xml"] = true,
+	["csv"] = true,
+	["jpg"] = true,
+	["jpeg"] = true,
+	["png"] = true,
+	["vtf"] = true,
+	["vmt"] = true,
+	["mp3"] = true,
+	["wav"] = true,
+	["ogg"] = true
+}
+
+function E2Lib.isValidFilePath(path)
+	local ext = string.GetExtensionFromFilename(path)
+	if ext then return file_extensions[string.lower(ext)] end
+end

--- a/lua/entities/gmod_wire_expression2/core/files.lua
+++ b/lua/entities/gmod_wire_expression2/core/files.lua
@@ -53,7 +53,7 @@ end
 util.AddNetworkString("wire_expression2_request_file_sp")
 util.AddNetworkString("wire_expression2_request_file")
 local function file_Upload( ply, entity, filename )
-	if !file_canUpload( ply ) or !IsValid( entity ) or !IsValid( ply ) or !ply:IsPlayer() or string.Right( filename, 4 ) != ".txt" then return false end
+	if !file_canUpload( ply ) or !IsValid( entity ) or !IsValid( ply ) or !ply:IsPlayer() or !E2Lib.isValidFilePath(filename) then return false end
 
 	uploads[ply] = {
 		name = filename,
@@ -82,7 +82,7 @@ local function file_canDownload( ply )
 end
 
 local function file_Download( ply, filename, data, append )
-	if !file_canDownload( ply ) or !IsValid( ply ) or !ply:IsPlayer() or string.Right( filename, 4 ) != ".txt" then return false end
+	if !file_canDownload( ply ) or !IsValid( ply ) or !ply:IsPlayer() or !E2Lib.isValidFilePath(filename) then return false end
 	if string.len( data ) > (cv_max_transfer_size:GetInt() * 1024) then return false end
 
 	-- if we're trying to append an empty string then we don't need to queue up

--- a/lua/entities/gmod_wire_expression2/core/files.lua
+++ b/lua/entities/gmod_wire_expression2/core/files.lua
@@ -53,7 +53,7 @@ end
 util.AddNetworkString("wire_expression2_request_file_sp")
 util.AddNetworkString("wire_expression2_request_file")
 local function file_Upload( ply, entity, filename )
-	if !file_canUpload( ply ) or !IsValid( entity ) or !IsValid( ply ) or !ply:IsPlayer() or !E2Lib.isValidFilePath(filename) then return false end
+	if !file_canUpload( ply ) or !IsValid( entity ) or !IsValid( ply ) or !ply:IsPlayer() or !E2Lib.isValidFileWritePath(filename) then return false end
 
 	uploads[ply] = {
 		name = filename,
@@ -82,7 +82,7 @@ local function file_canDownload( ply )
 end
 
 local function file_Download( ply, filename, data, append )
-	if !file_canDownload( ply ) or !IsValid( ply ) or !ply:IsPlayer() or !E2Lib.isValidFilePath(filename) then return false end
+	if !file_canDownload( ply ) or !IsValid( ply ) or !ply:IsPlayer() or !E2Lib.isValidFileWritePath(filename) then return false end
 	if string.len( data ) > (cv_max_transfer_size:GetInt() * 1024) then return false end
 
 	-- if we're trying to append an empty string then we don't need to queue up


### PR DESCRIPTION
Allows E2 to write and read txt, dat json, jpg, xml, csv, and any other file extensions that are allowed by garrysmod. Useful if you for some unholy reason make a PNG writing library in E2 (I definitely didn't do that)

Adds a SHARED E2Lib function ``isValidFilePath`` that simply returns if it has an extension, and if that extension is on the whitelist.
