### PR TITLE
Fix incorrect pod controller relative mode angle output, RC error

### DIFF
--- a/lua/entities/gmod_wire_pod.lua
+++ b/lua/entities/gmod_wire_pod.lua
@@ -458,9 +458,11 @@ function ENT:Think()
 				if (self.RC) then
 					originalangle = self.RC.InitialAngle
 				else
-					originalangle = pod:GetAngles()
-					if pod:GetClass() ~= "prop_vehicle_prisoner_pod" then
-						originalangle.y = originalangle.y + 90
+					local attachment = pod:LookupAttachment( "vehicle_driver_eyes" )
+					if (attachment > 0) then
+						originalangle = pod:GetAttachment( attachment ).Ang
+					else
+						originalangle = pod:GetAngles()
 					end
 				end
 				WireLib.TriggerOutput( self, "Bearing", fixupangle( angle.y - originalangle.y ) )

--- a/lua/entities/gmod_wire_pod.lua
+++ b/lua/entities/gmod_wire_pod.lua
@@ -456,7 +456,7 @@ function ENT:Think()
 			if (self.Relative) then
 				local originalangle
 				if (self.RC) then
-					originalangle = ply.InitialAngle
+					originalangle = self.RC.InitialAngle
 				else
 					originalangle = pod:GetAngles()
 					if pod:GetClass() ~= "prop_vehicle_prisoner_pod" then

--- a/lua/weapons/remotecontroller.lua
+++ b/lua/weapons/remotecontroller.lua
@@ -75,6 +75,7 @@ function SWEP:On()
 
 	self.Active = true
 	self.OldMoveType = not ply:InVehicle() and ply:GetMoveType() or MOVETYPE_WALK
+	self.InitialAngle = ply:EyeAngles()
 	ply:SetMoveType(MOVETYPE_NONE)
 	ply:DrawViewModel(false)
 


### PR DESCRIPTION
Fixes the pod controller erroring out when linked to a remote control and relative angles are enabled.
Fixes incorrect relative angles being returned for linked vehicles.