### PR TITLE
Deactivate pod controller when linked entity is unlinked/removed

### DIFF
--- a/lua/entities/gmod_wire_pod.lua
+++ b/lua/entities/gmod_wire_pod.lua
@@ -232,7 +232,7 @@ function ENT:SetPod( pod )
 	if pod and pod:IsValid() and not pod:IsVehicle() then return false end
 
 	if self:HasPly() then
-		self:PlayerExited(self:GetPly())
+		self:PlayerExited()
 	else
 		self:ColorByLinkStatus(IsValid(pod) and self.LINK_STATUS_LINKED or self.LINK_STATUS_UNLINKED)
 	end
@@ -533,8 +533,10 @@ function ENT:PlayerEntered( ply, RC )
 	self:SetActivated( true )
 end
 
-function ENT:PlayerExited( ply )
+function ENT:PlayerExited()
 	if not self:HasPly() then return end
+
+	local ply = self:GetPly()
 
 	self:HidePlayer( false )
 
@@ -576,7 +578,7 @@ end)
 hook.Add( "PlayerLeaveVehicle", "Wire_Pod_ExitVehicle", function( ply, vehicle )
 	for _, v in pairs( ents.FindByClass( "gmod_wire_pod" ) ) do
 		if (v:HasPod() and v:GetPod() == vehicle) then
-			v:PlayerExited( ply )
+			v:PlayerExited()
 		end
 	end
 end)

--- a/lua/entities/gmod_wire_pod.lua
+++ b/lua/entities/gmod_wire_pod.lua
@@ -217,6 +217,7 @@ function ENT:UnlinkEnt()
 	end
 	self:SetShowCursor( 0 )
 	self.Pod = nil
+	self:PlayerExited()
 	WireLib.SendMarks(self, {})
 	WireLib.TriggerOutput( self, "Entity", NULL )
 	self:ColorByLinkStatus(self.LINK_STATUS_UNLINKED)

--- a/lua/weapons/remotecontroller.lua
+++ b/lua/weapons/remotecontroller.lua
@@ -95,7 +95,7 @@ function SWEP:Off()
 	ply:DrawViewModel(true)
 
 	if IsValid(self.Linked) and self.Linked:GetPly() == ply then
-		self.Linked:PlayerExited(ply)
+		self.Linked:PlayerExited()
 	end
 end
 


### PR DESCRIPTION
Fixes errors caused by the linked vehicle getting deleted while in use.