### PR TITLE
Fix E2 Permission Escalation Using Code Upload

### DIFF
--- a/lua/wire/stools/expression2.lua
+++ b/lua/wire/stools/expression2.lua
@@ -270,10 +270,10 @@ if SERVER then
 
 			if ply ~= toent.player then
 				toent.player = ply
-				toent:SetOwner(ply)
 				toent:SetPlayer(ply) -- This function doesn't even exist in the wiki, along with ENT:GetPlayer() and ENT:GetPlayerName() which is used for the chip overlay
 				toent:SetNWEntity("player", ply)
-				if CPPI then toent:CPPISetOwner(ply) end
+
+				-- Note that the SENT and CPPI owners aren't set here to allow the original owner to still access their chip
 			end
 
 			toent:Setup(code, includes, nil, nil, filepath)

--- a/lua/wire/stools/expression2.lua
+++ b/lua/wire/stools/expression2.lua
@@ -268,6 +268,14 @@ if SERVER then
 
 			local filepath = ret[3]
 
+			if ply ~= toent.player then
+				toent.player = ply
+				toent:SetOwner(ply)
+				toent:SetPlayer(ply) -- This function doesn't even exist in the wiki, along with ENT:GetPlayer() and ENT:GetPlayerName() which is used for the chip overlay
+				toent:SetNWEntity("player", ply)
+				if CPPI then toent:CPPISetOwner(ply) end
+			end
+
 			toent:Setup(code, includes, nil, nil, filepath)
 		end
 	end)


### PR DESCRIPTION
Updates a chip's owner when uploading into it if the current chip owner does not match the uploading player.  
Fixes #929 *(thanks to @adosikas for mentioning this here https://github.com/wiremod/wire/pull/2157#issuecomment-821809937)*  

Solution is only a few lines, only difficulty was updating the E2 chip's overlay which uses a completely undocumented function `ENT:GetPlayerName()`, which is set using another undocumented function `ENT:SetPlayer()`.