### PR TITLE
Fixed lengthismul for vector thrusters, which have been broken and did not generate force

### DIFF
--- a/lua/entities/gmod_wire_vectorthruster.lua
+++ b/lua/entities/gmod_wire_vectorthruster.lua
@@ -248,8 +248,12 @@ function ENT:TriggerInput(iname, value)
 		end
 	end
 
-	self:SetOn(self.mul ~= 0 and ( (self.bidir) and (math.abs(self.mul) > 0.01) and (math.abs(self.mul) > self.force_min) ) or ( (self.mul > 0.01) and (self.mul > self.force_min) ))
-	self:ShowOutput()
+	if self.lengthismul then
+		self:SetOn(true)
+	else
+		self:SetOn(self.mul ~= 0 and ( (self.bidir) and (math.abs(self.mul) > 0.01) and (math.abs(self.mul) > self.force_min) ) or ( (self.mul > 0.01) and (self.mul > self.force_min) ))
+	end
+		self:ShowOutput()
 end
 
 function ENT:PhysicsSimulate( phys, deltatime )


### PR DESCRIPTION
Simple bypass of the if mul != 0 check, see commit