### PR TITLE
prevent exponential memory usage with string replacement

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -395,19 +395,20 @@ end
 --- Finds and replaces every occurrence of <needle> with <new> without regular expressions
 e2function string string:replace(string needle, string new)
 	if needle == "" then return this end
-	local ret = this:Replace(needle, new)
-	self.prf = self.prf + #ret * 0.3 + #self * 0.1 + #needle * 0.1 + #string * 0.1
-	return ret
+	self.prf = self.prf + #this * 0.1 + #new * 0.1
+	if self.prf > e2_tickquota then error("perf", 0) end
+	return this:Replace(needle, new)
 end
 
 ---  Finds and replaces every occurrence of <pattern> with <new> using regular expressions. Prints malformed string errors to the chat area.
 e2function string string:replaceRE(string pattern, string new)
+	self.prf = self.prf + #this * 0.1 + #new * 0.1
+	if self.prf > e2_tickquota then error("perf", 0) end
 	local OK, Ret = pcall(function() checkregex(this, pattern) return gsub(this, pattern, new) end)
 	if not OK then
 		self.player:ChatPrint(Ret)
 		return ""
 	else
-		self.prf = self.prf + #Ret * 0.3 + #self * 0.1 + #string * 0.1
 		return Ret or ""
 	end
 end

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -395,7 +395,9 @@ end
 --- Finds and replaces every occurrence of <needle> with <new> without regular expressions
 e2function string string:replace(string needle, string new)
 	if needle == "" then return this end
-	return this:Replace( needle, new)
+	local ret = this:Replace(needle, new)
+	self.prf = self.prf + #ret * 0.3 + #self * 0.1 + #needle * 0.1 + #string * 0.1
+	return ret
 end
 
 ---  Finds and replaces every occurrence of <pattern> with <new> using regular expressions. Prints malformed string errors to the chat area.
@@ -405,6 +407,7 @@ e2function string string:replaceRE(string pattern, string new)
 		self.player:ChatPrint(Ret)
 		return ""
 	else
+		self.prf = self.prf + #Ret * 0.3 + #self * 0.1 + #string * 0.1
 		return Ret or ""
 	end
 end

--- a/lua/wire/gates/string.lua
+++ b/lua/wire/gates/string.lua
@@ -178,15 +178,10 @@ GateActions["string_replace"] = {
 	inputtypes = { "STRING" , "STRING" , "STRING" },
 	outputtypes = { "STRING" },
 	output = function(gate, A, B, C)
-		if  (A and #A or 0)
-		  + (B and #B or 0)
-		  + (C and #C or 0)  > MAX_LEN
-		then
-			return false
-		end
 		if !A then A = "" end
 		if !B then B = "" end
 		if !C then C = "" end
+		if #A + #B + #C > MAX_LEN then return false end
 		return string.gsub(A,B,C)
 	end,
 	label = function(Out, A, B, C)

--- a/lua/wire/gates/string.lua
+++ b/lua/wire/gates/string.lua
@@ -178,6 +178,12 @@ GateActions["string_replace"] = {
 	inputtypes = { "STRING" , "STRING" , "STRING" },
 	outputtypes = { "STRING" },
 	output = function(gate, A, B, C)
+		if  (A and #A or 0)
+		  + (B and #B or 0)
+		  + (C and #C or 0)  > MAX_LEN
+		then
+			return false
+		end
 		if !A then A = "" end
 		if !B then B = "" end
 		if !C then C = "" end


### PR DESCRIPTION
it's currently pretty trivial to cause a string replacement operation to feed back into itself endlessly, allowing a wiremod contraption to easily allocate enormous amounts of memory

this pull request stops that from happening by applying MAX_LEN to the inputs of the replace gate and applying a tick penalty to the replace() and replaceRE() expression 2 functions