### PR TITLE
Mitigate table crash exploits

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/table.lua
+++ b/lua/entities/gmod_wire_expression2/core/table.lua
@@ -2,7 +2,7 @@
 -- Formerly known as "mtable", this extension has now (15-11-2010) replaced the old table extension.
 -- Made by Divran
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
-local function IsEmpty( t ) return !next(t) end
+local IsEmpty = table.IsEmpty
 local rep = string.rep
 local tostring = tostring
 local table = table
@@ -19,13 +19,13 @@ local tbls = {
 
 -- Types not allowed in tables
 local blocked_types = {
-	xgt = true,
+	xgt = true
 }
 
 --------------------------------------------------------------------------------
 
 local function checkOwner(self)
-	return IsValid(self.player);
+	return IsValid(self.player)
 end
 
 
@@ -327,20 +327,59 @@ __e2setcost(1)
 
 -- Creates a table
 e2function table table(...)
-	local tbl = {...}
-	if (#tbl == 0) then return newE2Table() end
 	local ret = newE2Table()
+	if select("#", ...) == 0 then return ret end -- Don't construct table
+
+	local tbl = {...}
 	local size = 0
-	for k,v in ipairs( tbl ) do
-		if (!blocked_types[typeids[k]]) then
+
+	for k, v in ipairs( tbl ) do
+		local tid = typeids[k]
+		if blocked_types[tid] then
+			self:throw("Type '" .. wire_expression_types2[tid][1] .. "' is not allowed inside of a table")
+		else
 			size = size + 1
 			ret.n[k] = v
-			ret.ntypes[k] = typeids[k]
+			ret.ntypes[k] = tid
 		end
 	end
+
 	ret.size = size
 	self.prf = self.prf + size * opcost
 	return ret
+end
+
+-- Clones a table while adding prf for the size of the clone.
+local function prf_clone(self, tbl, lookup)
+	local copy = {}
+
+	lookup = lookup or {}
+	lookup[tbl] = copy
+
+	if self.prf > e2_tickquota then
+		error("perf", 0)
+	end
+
+	local prf = 0
+
+	for k, v in pairs(tbl) do
+		if istable(v) then
+			if lookup[v] then
+				prf = prf + opcost -- simple assign operation
+				copy[k] = lookup[v]
+			else
+				self.prf = self.prf + prf + opcost * 3 -- creating new table
+				prf = 0
+				copy[k] = prf_clone(self, v, lookup)
+			end
+		else
+			prf = prf + opcost -- simple assign operation
+			copy[k] = v
+		end
+	end
+
+	self.prf = self.prf + prf
+	return copy
 end
 
 __e2setcost(1)
@@ -372,17 +411,17 @@ end
 __e2setcost(1)
 -- Returns 1 if any value exists at the specified index, else 0
 e2function number table:exists( index )
-	return this.n[index] != nil and 1 or 0
+	return this.n[index] ~= nil and 1 or 0
 end
 e2function number table:exists( string index )
-	return this.s[index] != nil and 1 or 0
+	return this.s[index] ~= nil and 1 or 0
 end
 
 __e2setcost(5)
 
 e2function void printTable( table tbl )
-	if (not checkOwner(self)) then return; end
-	if (tbl.size > 200) then
+	if not checkOwner(self) then return end
+	if tbl.size > 200 then
 		self.player:ChatPrint("Table has more than 200 ("..tbl.size..") elements. PrintTable cancelled to prevent lag")
 		return
 	end
@@ -423,14 +462,17 @@ end
 -- Returns an table with the typesids of both the array- and table-parts
 e2function table table:typeids()
 	local ret = newE2Table()
-	ret.n = table.Copy(this.ntypes)
+	ret.n = prf_clone(self, this.ntypes)
+
 	for k,v in pairs( ret.n ) do
 		ret.ntypes[k] = "s"
 	end
-	ret.s = table.Copy( this.stypes )
+
+	ret.s = prf_clone(self, this.stypes )
 	for k,v in pairs( ret.s ) do
 		ret.stypes[k] = "s"
 	end
+
 	ret.size = this.size
 	self.prf = self.prf + this.size * opcost
 	return ret
@@ -482,30 +524,38 @@ e2function number table:unset( string index ) = e2function number table:remove( 
 
 -- Removes all variables not of the type
 e2function table table:clipToTypeid( string typeid )
-	local ret = newE2Table()
-	for k,v in pairs( this.n ) do
-		if (this.ntypes[k] == typeid) then
-			local n = #ret.n+1
+	local ret, ret_size = newE2Table(), 0
+
+	local this_ntypes, this_stypes = this.ntypes, this.stypes
+	local ret_ntypes, ret_stypes = ret.ntypes, ret.stypes
+	local ret_n, ret_s = ret.n, ret.s
+
+	for k, v in pairs( this.n ) do
+		if this_ntypes[k] == typeid then
+			local n = ret_size + 1
 			if istable(v) then
-				ret.n[n] = table.Copy(v)
+				ret_n[n] = prf_clone(self, v)
 			else
-				ret.n[n] = v
+				ret_n[n] = v
 			end
-			ret.ntypes[n] = this.ntypes[k]
-			ret.size = ret.size + 1
+			ret_ntypes[n] = this_ntypes[k]
+			ret_size = ret_size + 1
 		end
 	end
-	for k,v in pairs( this.s ) do
-		if (this.stypes[k] == typeid) then
+
+	for k, v in pairs( this.s ) do
+		if this_stypes[k] == typeid then
 			if istable(v) then
-				ret.s[k] = table.Copy(v)
+				ret_s[k] = prf_clone(self, v)
 			else
-				ret.s[k] = v
+				ret_s[k] = v
 			end
-			ret.stypes[k] = this.stypes[k]
-			ret.size = ret.size + 1
+			ret_stypes[k] = this_stypes[k]
+			ret_size = ret_size + 1
 		end
 	end
+
+	ret.size = ret_size
 	self.prf = self.prf + this.size * opcost
 	return ret
 end
@@ -513,10 +563,11 @@ end
 -- Removes all variables of the type
 e2function table table:clipFromTypeid( string typeid )
 	local ret = newE2Table()
+
 	for k,v in pairs( this.n ) do
 		if (this.ntypes[k] != typeid) then
 			if istable(v) then
-				ret.n[k] = table.Copy(v)
+				ret.n[k] = prf_clone(self, v)
 			else
 				ret.n[k] = v
 			end
@@ -524,10 +575,11 @@ e2function table table:clipFromTypeid( string typeid )
 			ret.size = ret.size + 1
 		end
 	end
-	for k,v in pairs( this.s ) do
+
+	for k, v in pairs( this.s ) do
 		if (this.stypes[k] != typeid) then
 			if istable(v) then
-				ret.s[k] = table.Copy(v)
+				ret.s[k] = prf_clone(self, v)
 			else
 				ret.s[k] = v
 			end
@@ -535,38 +587,15 @@ e2function table table:clipFromTypeid( string typeid )
 			ret.size = ret.size + 1
 		end
 	end
+
 	self.prf = self.prf + this.size * opcost
 	return ret
 end
 
 __e2setcost(10)
 
-local function clone(self, tbl, lookup)
-	local copy = {}
-
-	lookup = lookup or {}
-	lookup[tbl] = copy
-
-	for k, v in pairs(tbl) do
-		if type(v) == "table" then
-			if lookup[v] then
-				self.prf = self.prf + opcost -- simple assign operation
-				copy[k] = lookup[v]
-			else
-				self.prf = self.prf + opcost * 3 -- creating new table
-				copy[k] = clone(self, v, lookup)
-			end
-		else
-			self.prf = self.prf + opcost -- simple assign operation
-			copy[k] = v
-		end
-	end
-
-	return copy
-end
-
 e2function table table:clone()
-	return clone(self, this)
+	return prf_clone(self, this)
 end
 
 __e2setcost(1)
@@ -588,30 +617,38 @@ end
 
 -- Adds rv2 to the end of 'this' (adds numerical indexes to the end of the array-part, and only inserts string indexes that don't exist on rv1)
 e2function table table:add( table rv2 )
-	local ret = table.Copy(this)
+	local ret = prf_clone(self, this)
 	local cost = this.size
 	local size = this.size
 
+	local ret_n, ret_ntypes = ret.n, ret.ntypes
+	local ret_s, ret_stypes = ret.s, ret.stypes
+
+	local rv2_n, rv2_ntypes = rv2.n, rv2.ntypes
+	local rv2_s, rv2_stypes = rv2.s, rv2.stypes
+
 	local count = #ret.n
-	for k,v in pairs( rv2.n ) do
+	for k, v in pairs( rv2_n ) do
 		cost = cost + 1
-		local id = rv2.ntypes[k]
-		if (!blocked_types[id]) then
+		local id = rv2_ntypes[k]
+		if not blocked_types[id] then
 			count = count + 1
 			size = size + 1
-			ret.n[count] = v
-			ret.ntypes[count] = id
+
+			ret_n[count] = v
+			ret_ntypes[count] = id
 		end
 	end
 
-	for k,v in pairs( rv2.s ) do
+	for k, v in pairs( rv2_s ) do
 		cost = cost + 1
-		if (!ret.s[k]) then
-			local id = rv2.stypes[k]
-			if (!blocked_types[id]) then
+		if not ret_s[k] then
+			local id = rv2_stypes[k]
+			if not blocked_types[id] then
 				size = size + 1
-				ret.s[k] = v
-				ret.stypes[k] = id
+
+				ret_s[k] = v
+				ret_stypes[k] = id
 			end
 		end
 	end
@@ -623,15 +660,15 @@ end
 
 -- Merges rv2 with 'this' (both numerical and string indexes are overwritten)
 e2function table table:merge( table rv2 )
-	local ret = table.Copy(this)
+	local ret = prf_clone(self, this)
 	local cost = this.size
 	local size = this.size
 
 	for k,v in pairs( rv2.n ) do
 		cost = cost + 1
 		local id = rv2.ntypes[k]
-		if (!blocked_types[id]) then
-			if (!ret.n[k]) then size = size + 1 end
+		if not blocked_types[id] then
+			if not ret.n[k] then size = size + 1 end
 			ret.n[k] = v
 			ret.ntypes[k] = id
 		end
@@ -640,8 +677,8 @@ e2function table table:merge( table rv2 )
 	for k,v in pairs( rv2.s ) do
 		cost = cost + 1
 		local id = rv2.stypes[k]
-		if (!blocked_types[id]) then
-			if (!ret.s[k]) then size = size + 1 end
+		if not blocked_types[id] then
+			if not ret.s[k] then size = size + 1 end
 			ret.s[k] = v
 			ret.stypes[k] = id
 		end
@@ -660,7 +697,7 @@ e2function table table:difference( table rv2 )
 
 	for k,v in pairs( this.n ) do
 		cost = cost + 1
-		if (!rv2.n[k]) then
+		if not rv2.n[k] then
 			size = size + 1
 			ret.n[size] = v
 			ret.ntypes[size] = this.ntypes[k]
@@ -669,7 +706,7 @@ e2function table table:difference( table rv2 )
 
 	for k,v in pairs( this.s ) do
 		cost = cost + 1
-		if (!rv2.s[k]) then
+		if not rv2.s[k] then
 			size = size + 1
 			ret.s[k] = v
 			ret.stypes[k] = this.stypes[k]
@@ -689,7 +726,7 @@ e2function table table:intersect( table rv2 )
 
 	for k,v in pairs( this.n ) do
 		cost = cost + 1
-		if (rv2.n[k]) then
+		if rv2.n[k] then
 			size = size + 1
 			ret.n[size] = v
 			ret.ntypes[size] = this.ntypes[k]
@@ -698,7 +735,7 @@ e2function table table:intersect( table rv2 )
 
 	for k,v in pairs( this.s ) do
 		cost = cost + 1
-		if (rv2.s[k]) then
+		if rv2.s[k] then
 			size = size + 1
 			ret.s[k] = v
 			ret.stypes[k] = this.stypes[k]
@@ -812,14 +849,14 @@ end
 
 -- Returns the types of the variables in the array-part
 e2function array table:typeidsArray()
-	if (IsEmpty(this.n)) then return {} end
+	if IsEmpty(this.n) then return {} end
 	self.prf = self.prf + table.Count(this.ntypes) * opcost
-	return table.Copy(this.ntypes)
+	return prf_clone(self, this.ntypes)
 end
 
 -- Converts the table into an array
 e2function array table:toArray()
-	if (IsEmpty(this.n)) then return {} end
+	if IsEmpty(this.n) then return {} end
 	local ret = {}
 	local cost = 0
 	for k,v in pairs( this.n ) do
@@ -868,22 +905,27 @@ e2function string table:concat()
 	self.prf = self.prf + #this * opcost
 	return concat(this.n)
 end
+
 e2function string table:concat(string delimiter)
 	self.prf = self.prf + #this * opcost
 	return concat(this.n,delimiter)
 end
+
 e2function string table:concat(string delimiter, startindex)
 	self.prf = self.prf + #this * opcost
 	return concat(this.n,delimiter,startindex)
 end
+
 e2function string table:concat(string delimiter, startindex, endindex)
 	self.prf = self.prf + #this * opcost
 	return concat(this.n,delimiter,startindex,endindex)
 end
+
 e2function string table:concat(startindex)
 	self.prf = self.prf + #this * opcost
 	return concat(this.n,"",startindex,endindex)
 end
+
 e2function string table:concat(startindex,endindex)
 	self.prf = self.prf + #this * opcost
 	return concat(this.n,"",startindex,endindex)
@@ -935,7 +977,7 @@ e2function table invert(table tbl)
 			ret.s[tostring_this(v)] = i
 			ret.stypes[tostring_this(v)] = "n"
 			size = size + 1
-		elseif (checkOwner(self)) then
+		elseif checkOwner(self) then
 			self.player:ChatPrint("E2: invert(T): Invalid type ("..typeid..") in table. Ignored.")
 		end
 	end
@@ -947,7 +989,7 @@ e2function table invert(table tbl)
 			ret.s[tostring_this(v)] = i
 			ret.stypes[tostring_this(v)] = "s"
 			size = size + 1
-		elseif (checkOwner(self)) then
+		elseif checkOwner(self) then
 			self.player:ChatPrint("E2: invert(T): Invalid type ("..typeid..") in table. Ignored.")
 		end
 	end


### PR DESCRIPTION
There already was a custom function for ``table:clone()`` that added ops (prf) based on the size of the table, etc.

However, most other functions like ``table:add(t)`` didn't even use this and just used ``table.Copy``, so people could lag/crash servers easily by spamming tables that add themselves to themselves or something.

* Renamed clone function to prf_clone and optimized a bit

* Replace all instances of table.Copy in table.lua with prf_clone

* Made some functions a bit more efficient with table index ops (table:add and table:clipToTypeId)

* As a bonus, added a runtime error (only on @strict ofc) if you try and put a gtable (or anything banned) inside of a table