### PR TITLE
Switched string function cache to use a lookup table

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/functions.lua
+++ b/lua/entities/gmod_wire_expression2/core/functions.lua
@@ -9,7 +9,12 @@ __e2setcost(1)
 registerOperator("function", "", "", function(self, args)
 	local sig, body = args[2], args[3]
 	self.funcs[sig] = body
-	self.strfunc_cache = {}
+
+	local cached = self.strfunc_cache[1][sig]
+	if cached then
+		self.strfunc_cache[2][ cached[3] ] = nil
+		self.strfunc_cache[1][sig] = nil
+	end
 end)
 
 __e2setcost(2)

--- a/lua/entities/gmod_wire_expression2/core/strfunc.lua
+++ b/lua/entities/gmod_wire_expression2/core/strfunc.lua
@@ -62,7 +62,7 @@ local function findFunc( self, funcname, typeids, typeids_str )
 		func, func_return_type = checkFuncName( self, funcname .. "()" )
 	end
 
-	if func and not self.strfunc_cache[1][str] then
+  if func and not self.strfunc_cache[1][str] then
     self.strfunc_cache[1][str] = { func, func_return_type }
     insert( self.strfunc_cache[2], 1, str )
     

--- a/lua/entities/gmod_wire_expression2/core/strfunc.lua
+++ b/lua/entities/gmod_wire_expression2/core/strfunc.lua
@@ -1,3 +1,5 @@
+PrintMessage(3, "Loaded strFuncOptimizations Test")
+
 local function nicename( word )
 	local ret = word:lower()
 	if ret == "normal" then return "number" end
@@ -18,17 +20,16 @@ local insert = table.insert
 local concat = table.concat
 local function findFunc( self, funcname, typeids, typeids_str )
 	local func, func_return_type
-	local cache, limiter = self.strfunc_cache[1], self.strfunc_cache[2]
+	local cache = self.strfunc_cache[1]
 
 	local str = funcname .. "(" .. typeids_str .. ")"
-
-	local cached = cache[str]
-	if cached then
-		return cached[1], cached[2]
+	
+	if cache[str] then
+		return cache[str][1], cache[str][2]
 	end
 
 	local typeIDsLength = #typeids
-	self.prf = self.prf + 20
+	self.prf = self.prf + 10
 
 	if typeIDsLength > 0 then
 		if not func then
@@ -64,8 +65,10 @@ local function findFunc( self, funcname, typeids, typeids_str )
 		func, func_return_type = checkFuncName( self, funcname .. "()" )
 	end
 
-	if func and not cache[str] then
+	if func then
+		local limiter = self.strfunc_cache[2]
 		local limiterLength = #limiter + 1
+
 		cache[str] = { func, func_return_type, limiterLength }
 		insert( limiter, 1, str )
 
@@ -78,7 +81,7 @@ local function findFunc( self, funcname, typeids, typeids_str )
 	return func, func_return_type
 end
 
-__e2setcost(20)
+__e2setcost(5)
 
 registerOperator( "stringcall", "", "", function(self, args)
 	local op1, funcargs, typeids, typeids_str, returntype = args[2], args[3], args[4], args[5], args[6]

--- a/lua/entities/gmod_wire_expression2/core/strfunc.lua
+++ b/lua/entities/gmod_wire_expression2/core/strfunc.lua
@@ -83,7 +83,7 @@ registerOperator( "stringcall", "", "", function(self, args)
 
 	local func, func_return_type = findFunc( self, funcname, typeids, typeids_str )
 
-	if not func then E2Lib.raiseException( "No  such function: " .. funcname .. "(" .. tps_pretty( typeids_str ) .. ")", 0 ) end
+	if not func then E2Lib.raiseException( "No such function: " .. funcname .. "(" .. tps_pretty( typeids_str ) .. ")", 0 ) end
 
 	if returntype ~= "" and func_return_type ~= returntype then
 		error( "Mismatching return types. Got " .. nicename(wire_expression_types2[returntype][1]) .. ", expected " .. nicename(wire_expression_types2[func_return_type][1] ), 0 )

--- a/lua/entities/gmod_wire_expression2/core/strfunc.lua
+++ b/lua/entities/gmod_wire_expression2/core/strfunc.lua
@@ -18,10 +18,11 @@ local insert = table.insert
 local concat = table.concat
 local function findFunc( self, funcname, typeids, typeids_str )
 	local func, func_return_type
+	local cache, limiter = self.strfunc_cache[1], self.strfunc_cache[2]
 
 	local str = funcname .. "(" .. typeids_str .. ")"
 
-  local cached = self.strfunc_cache[1][str]
+	local cached = self.strfunc_cache[1][str]
 	if cached then
 		return cached[1], cached[2]
 	end
@@ -62,14 +63,14 @@ local function findFunc( self, funcname, typeids, typeids_str )
 		func, func_return_type = checkFuncName( self, funcname .. "()" )
 	end
 
-  if func and not self.strfunc_cache[1][str] then
-    self.strfunc_cache[1][str] = { func, func_return_type }
-    insert( self.strfunc_cache[2], 1, str )
-    
-    if #self.strfunc_cache[2] == 101 then
-      self.strfunc_cache[1][self.strfunc_cache[2][101]] = nil
-      self.strfunc_cache[2][101] = nil
-    end
+	if func and not self.strfunc_cache[1][str] then
+		self.strfunc_cache[1][str] = { func, func_return_type }
+		insert( self.strfunc_cache[2], 1, str )
+
+		if #self.strfunc_cache[2] == 101 then
+			self.strfunc_cache[1][self.strfunc_cache[2][101]] = nil
+			self.strfunc_cache[2][101] = nil
+		end
 	end
 
 	return func, func_return_type

--- a/lua/entities/gmod_wire_expression2/core/strfunc.lua
+++ b/lua/entities/gmod_wire_expression2/core/strfunc.lua
@@ -22,7 +22,7 @@ local function findFunc( self, funcname, typeids, typeids_str )
 
 	local str = funcname .. "(" .. typeids_str .. ")"
 
-	local cached = self.strfunc_cache[1][str]
+	local cached = cache[str]
 	if cached then
 		return cached[1], cached[2]
 	end
@@ -63,13 +63,13 @@ local function findFunc( self, funcname, typeids, typeids_str )
 		func, func_return_type = checkFuncName( self, funcname .. "()" )
 	end
 
-	if func and not self.strfunc_cache[1][str] then
-		self.strfunc_cache[1][str] = { func, func_return_type }
-		insert( self.strfunc_cache[2], 1, str )
+	if func and not cache[str] then
+		cache[str] = { func, func_return_type }
+		insert( limiter, 1, str )
 
-		if #self.strfunc_cache[2] == 101 then
-			self.strfunc_cache[1][self.strfunc_cache[2][101]] = nil
-			self.strfunc_cache[2][101] = nil
+		if #limiter == 101 then
+			cache[ limiter[101] ] = nil
+			limiter[101] = nil
 		end
 	end
 

--- a/lua/entities/gmod_wire_expression2/core/strfunc.lua
+++ b/lua/entities/gmod_wire_expression2/core/strfunc.lua
@@ -6,7 +6,6 @@ end
 
 local function checkFuncName( self, funcname )
 	if self.funcs[funcname] then
-		self.prf = self.prf + 15
 		return self.funcs[funcname], self.funcs_ret[funcname], true
 	elseif wire_expression2_funcs[funcname] then
 		return wire_expression2_funcs[funcname][3], wire_expression2_funcs[funcname][2]

--- a/lua/entities/gmod_wire_expression2/core/strfunc.lua
+++ b/lua/entities/gmod_wire_expression2/core/strfunc.lua
@@ -27,9 +27,10 @@ local function findFunc( self, funcname, typeids, typeids_str )
 		return cached[1], cached[2]
 	end
 
+	local typeIDsLength = #typeids
 	self.prf = self.prf + 20
 
-	if #typeids > 0 then
+	if typeIDsLength > 0 then
 		if not func then
 			func, func_return_type = checkFuncName( self, str )
 		end
@@ -39,7 +40,7 @@ local function findFunc( self, funcname, typeids, typeids_str )
 		end
 
 		if not func then
-			for i=#typeids,1,-1 do
+			for i = typeIDsLength, 1, -1 do
 				func, func_return_type = checkFuncName( self, funcname .. "(" .. concat(typeids,"",1,i) .. "...)" )
 				if func then break end
 			end
@@ -50,7 +51,7 @@ local function findFunc( self, funcname, typeids, typeids_str )
 		end
 
 		if not func then
-			for i=#typeids,2,-1 do
+			for i = typeIDsLength, 2, -1 do
 				func, func_return_type = checkFuncName( self, funcname .. "(" .. typeids[1] .. ":" ..  concat(typeids,"",2,i) .. "...)" )
 				if func then break end
 			end

--- a/lua/entities/gmod_wire_expression2/core/strfunc.lua
+++ b/lua/entities/gmod_wire_expression2/core/strfunc.lua
@@ -66,9 +66,9 @@ local function findFunc( self, funcname, typeids, typeids_str )
     self.strfunc_cache[1][str] = { func, func_return_type }
     insert( self.strfunc_cache[2], 1, str )
     
-    if #self.strfunc_cache[2] == 151 then
-      self.strfunc_cache[1][self.strfunc_cache[2][151]] = nil
-      self.strfunc_cache[2][151] = nil
+    if #self.strfunc_cache[2] == 101 then
+      self.strfunc_cache[1][self.strfunc_cache[2][101]] = nil
+      self.strfunc_cache[2][101] = nil
     end
 	end
 

--- a/lua/entities/gmod_wire_expression2/core/strfunc.lua
+++ b/lua/entities/gmod_wire_expression2/core/strfunc.lua
@@ -1,5 +1,3 @@
-PrintMessage(3, "Loaded strFuncOptimizations Test")
-
 local function nicename( word )
 	local ret = word:lower()
 	if ret == "normal" then return "number" end
@@ -29,7 +27,7 @@ local function findFunc( self, funcname, typeids, typeids_str )
 	end
 
 	local typeIDsLength = #typeids
-	self.prf = self.prf + 10
+	self.prf = self.prf + 5
 
 	if typeIDsLength > 0 then
 		if not func then
@@ -66,6 +64,8 @@ local function findFunc( self, funcname, typeids, typeids_str )
 	end
 
 	if func then
+		self.prf = self.prf + 20
+
 		local limiter = self.strfunc_cache[2]
 		local limiterLength = #limiter + 1
 

--- a/lua/entities/gmod_wire_expression2/core/strfunc.lua
+++ b/lua/entities/gmod_wire_expression2/core/strfunc.lua
@@ -65,12 +65,13 @@ local function findFunc( self, funcname, typeids, typeids_str )
 	end
 
 	if func and not cache[str] then
-		cache[str] = { func, func_return_type }
+		local limiterLength = #limiter + 1
+		cache[str] = { func, func_return_type, limiterLength }
 		insert( limiter, 1, str )
 
-		if #limiter == 101 then
-			cache[ limiter[101] ] = nil
-			limiter[101] = nil
+		if limiterLength == 101 then
+			self.strfunc_cache[1][ limiter[101] ] = nil
+			self.strfunc_cache[2][101] = nil
 		end
 	end
 

--- a/lua/entities/gmod_wire_expression2/core/strfunc.lua
+++ b/lua/entities/gmod_wire_expression2/core/strfunc.lua
@@ -21,7 +21,7 @@ local function findFunc( self, funcname, typeids, typeids_str )
 	local cache = self.strfunc_cache[1]
 
 	local str = funcname .. "(" .. typeids_str .. ")"
-	
+
 	if cache[str] then
 		return cache[str][1], cache[str][2]
 	end


### PR DESCRIPTION
Finally remembered to make this

Cache now uses a lookup table and has a separate numerically indexed table for size limiting
Removed vararg mentions because they weren't being used anywhere
Lowered opcost to 20 flat, additional 20 if function needs to be looked up

Closes #2222 