### PR TITLE
Fix view requests window indexing a `nil` value under certain circumstances

### DIFF
--- a/lua/wire/client/e2_viewrequest_menu.lua
+++ b/lua/wire/client/e2_viewrequest_menu.lua
@@ -81,7 +81,7 @@ list.Set("DesktopWindows", "WireExpression2_ViewRequestMenu", {
 
 			for initiator, requests in pairs(viewRequests) do
 				for chip, request in pairs(requests) do
-					if not displayed[initiator][chip] and ValidateRequest(initiator, chip) then
+					if (not displayed[initiator] or not displayed[initiator][chip]) and ValidateRequest(initiator, chip) then
 						local line = self:AddLine(tostring(chip:EntIndex()), initiator:Nick(), request.name, tostring(math.ceil(request.expiry - CurTime())))
 						line.initiator = initiator
 						line.chip = chip

--- a/lua/wire/stools/expression2.lua
+++ b/lua/wire/stools/expression2.lua
@@ -499,7 +499,6 @@ if SERVER then
 					)
 				end
 				WireLib.Expression2Download(player, E2)
-				
 			end
 		else
 			RequestView(E2, player)


### PR DESCRIPTION
Somehow didn't crop up until now, but if a new request initiator makes their first request while the person they're requesting from has the view requests window open, it'll try to index a `nil` value for already displayed requests.  

*Also removed a trailing newline in `expression2.lua`*