### PR TITLE
Add `@strict` compat for remaining E2 Libraries

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/constraint.lua
+++ b/lua/entities/gmod_wire_expression2/core/constraint.lua
@@ -181,7 +181,7 @@ __e2setcost(20)
 
 --- Returns an '''array''' containing all entities directly or indirectly constrained to <this>, except <this> itself.
 e2function array entity:getConstraints()
-	if not IsValid(this) then return {} end
+	if not IsValid(this) then return self:throw("Invalid entity!", {}) end
 	if not constraint.HasConstraints(this) then return {} end
 
 	local result = getConnectedEntities(this)
@@ -196,7 +196,7 @@ end
 	supports filtering, see buildFilter above
 ]]
 e2function array entity:getConnectedEntities(...)
-	if not IsValid(this) then return {} end
+	if not IsValid(this) then return self:throw("Invalid entity!", {}) end
 	local result = getConnectedEntities(this,buildFilter({...}))
 	self.prf = self.prf + #result * 30
 	return result
@@ -212,7 +212,7 @@ __e2setcost(5)
 
 --- Returns the number of constraints on <this>.
 e2function number entity:hasConstraints()
-	if not IsValid(this) then return 0 end
+	if not IsValid(this) then return self:throw("Invalid entity!", 0) end
 
 	return #constraint_GetTable(this)
 end
@@ -226,7 +226,7 @@ end
 
 --- Returns 1 if <this> is constrained to anything, 0 otherwise.
 e2function number entity:isConstrained()
-	if not IsValid(this) then return 0 end
+	if not IsValid(this) then return self:throw("Invalid entity!", 0) end
 	if not constraint.HasConstraints(this) then return 0 end
 
 	return 1
@@ -234,7 +234,7 @@ end
 
 --- Returns the first entity <this> was welded to.
 e2function entity entity:isWeldedTo()
-	if not IsValid(this) then return nil end
+	if not IsValid(this) then return self:throw("Invalid entity!", nil) end
 	if not constraint.HasConstraints(this) then return nil end
 
 	local filter = {Weld=true} -- create filter directly, no need to call buildFilter here, since it's static
@@ -243,7 +243,7 @@ end
 
 --- Returns the <index>th entity <this> was welded to.
 e2function entity entity:isWeldedTo(index)
-	if not IsValid(this) then return nil end
+	if not IsValid(this) then return self:throw("Invalid entity!", nil) end
 	if not constraint.HasConstraints(this) then return nil end
 
 	local filter = {Weld=true} -- create filter directly, no need to call buildFilter here, since it's static
@@ -252,7 +252,7 @@ end
 
 --- Returns the first entity <this> was constrained to.
 e2function entity entity:isConstrainedTo()
-	if not IsValid(this) then return nil end
+	if not IsValid(this) then return self:throw("Invalid entity!", nil) end
 	if not constraint.HasConstraints(this) then return nil end
 
 	return ent1or2(this,constraint_GetTable(this),1)
@@ -260,7 +260,7 @@ end
 
 --- Returns the <index>th entity <this> was constrained to.
 e2function entity entity:isConstrainedTo(index)
-	if not IsValid(this) then return nil end
+	if not IsValid(this) then return self:throw("Invalid entity!", nil) end
 	if not constraint.HasConstraints(this) then return nil end
 
 	return ent1or2(this,constraint_GetTable(this), math.floor(index))
@@ -268,7 +268,7 @@ end
 
 --- Returns the first entity <this> was constrained to with the given constraint type <constraintType>.
 e2function entity entity:isConstrainedTo(string constraintType)
-	if not IsValid(this) then return nil end
+	if not IsValid(this) then return self:throw("Invalid entity!", nil) end
 	if not constraint.HasConstraints(this) then return nil end
 
 	return ent1or2(this,constraint_FindConstraint(this, buildFilter({constraintType})))
@@ -276,7 +276,7 @@ end
 
 --- Returns the <index>th entity <this> was constrained to with the given constraint type <constraintType>.
 e2function entity entity:isConstrainedTo(string constraintType, index)
-	if not IsValid(this) then return nil end
+	if not IsValid(this) then return self:throw("Invalid entity!", nil) end
 	if not constraint.HasConstraints(this) then return nil end
 
 	return ent1or2(this,constraint_FindConstraints(this, buildFilter({constraintType})), math.floor(index))

--- a/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
@@ -10,8 +10,14 @@ e2function void enableConstraintUndo(state)
 end
 
 local function checkEnts(self, ent1, ent2)
-	if !ent1 || (!ent1:IsValid() && !ent1:IsWorld()) || !ent2 || (!ent2:IsValid() && !ent2:IsWorld()) || ent1 == ent2 then return false end
-	if !isOwner(self, ent1) || !isOwner(self, ent2) || ent1:IsPlayer() || ent2:IsPlayer() then return false end
+	if not IsValid(ent1) and not ent1:IsWorld() then return self:throw("Invalid entity!", false) end
+	if not IsValid(ent2) and not ent2:IsWorld() then return self:throw("Invalid target entity!", false) end
+	if ent1 == ent2 then return self:throw("Cannot constrain an entity to itself!", false) end
+
+	if not isOwner(self, ent1) then return self:throw("You are not the owner of the entity!", false) end
+	if not isOwner(self, ent2) then return self:throw("You are not the owner of the target entity!", false) end
+
+	if ent1:IsPlayer() or ent2:IsPlayer() then return self:throw("Cannot constrain players!", false) end
 	return true
 end
 local function addundo(self, prop, message)
@@ -56,35 +62,35 @@ end
 
 --- Creates a ballsocket between <ent1> and <ent2> at <v>, which is local to <ent1>
 e2function void ballsocket(entity ent1, vector v, entity ent2)
-	if !checkEnts(self, ent1, ent2) then return end
+	if not checkEnts(self, ent1, ent2) then return end
 	local vec = Vector(v[1], v[2], v[3])
 	addundo(self, constraint.Ballsocket(ent1, ent2, 0, 0, vec, 0, 0, 0), "ballsocket")
 end
 
 --- Creates a ballsocket between <ent1> and <ent2> at <v>, which is local to <ent1>, with friction <friction>
 e2function void ballsocket(entity ent1, vector v, entity ent2, friction)
-	if !checkEnts(self, ent1, ent2) then return end
+	if not checkEnts(self, ent1, ent2) then return end
 	local vec = Vector(v[1], v[2], v[3])
 	addundo(self, constraint.AdvBallsocket(ent1, ent2, 0, 0, Vector(), vec, 0, 0, -180, -180, -180, 180, 180, 180, friction, friction, friction, 0, 0), "ballsocket")
 end
 
 --- Creates an adv ballsocket between <ent1> and <ent2> at <v>, which is local to <ent1>, with many settings
 e2function void ballsocket(entity ent1, vector v, entity ent2, vector mins, vector maxs, vector frictions)
-	if !checkEnts(self, ent1, ent2) then return end
+	if not checkEnts(self, ent1, ent2) then return end
 	local vec = Vector(v[1], v[2], v[3])
 	addundo(self, constraint.AdvBallsocket(ent1, ent2, 0, 0, Vector(), vec, 0, 0, mins[1], mins[2], mins[3], maxs[1], maxs[2], maxs[3], frictions[1], frictions[2], frictions[3], 0, 0), "ballsocket")
 end
 
 --- Creates an adv ballsocket between <ent1> and <ent2> at <v>, which is local to <ent1>, with many settings
 e2function void ballsocket(entity ent1, vector v, entity ent2, vector mins, vector maxs, vector frictions, rotateonly)
-	if !checkEnts(self, ent1, ent2) then return end
+	if not checkEnts(self, ent1, ent2) then return end
 	local vec = Vector(v[1], v[2], v[3])
 	addundo(self, constraint.AdvBallsocket(ent1, ent2, 0, 0, Vector(), vec, 0, 0, mins[1], mins[2], mins[3], maxs[1], maxs[2], maxs[3], frictions[1], frictions[2], frictions[3], rotateonly, 0), "ballsocket")
 end
 
 --- Creates an angular weld (angles are fixed, position isn't) between <ent1> and <ent2> at <v>, which is local to <ent1>
 e2function void weldAng(entity ent1, vector v, entity ent2)
-	if !checkEnts(self, ent1, ent2) then return end
+	if not checkEnts(self, ent1, ent2) then return end
 	local vec = Vector(v[1], v[2], v[3])
 	addundo(self, constraint.AdvBallsocket(ent1, ent2, 0, 0, Vector(), vec, 0, 0, 0, -0, 0, 0, 0, 0, 0, 0, 0, 1, 0), "ballsocket")
 end
@@ -109,7 +115,7 @@ end
 // Note: Winch is just a rename of Hydraulic with the last parameter True.
 --- Makes a winch constraint (stored at index <index>) between <ent1> and <ent2>, at vectors local to their respective ents, with <width> width.
 e2function void winch(index, entity ent1, vector v1, entity ent2, vector v2, width)
-	if !checkEnts(self, ent1, ent2) then return end
+	if not checkEnts(self, ent1, ent2) then return end
 	if !ent1.data then ent1.data = {} end
 	if !ent1.data.Ropes then ent1.data.Ropes = {} end
 	local vec1, vec2 = Vector(v1[1],v1[2],v1[3]), Vector(v2[1],v2[2],v2[3])
@@ -126,11 +132,11 @@ end
 
 --- Makes a hydraulic constraint (stored at index <index>) between <ent1> and <ent2>, at vectors local to their respective ents, with <width> width.
 e2function void hydraulic(index, entity ent1, vector v1, entity ent2, vector v2, width)
-	if !checkEnts(self, ent1, ent2) then return end
+	if not checkEnts(self, ent1, ent2) then return end
 	if !ent1.data then ent1.data = {} end
 	if !ent1.data.Ropes then ent1.data.Ropes = {} end
 	local vec1, vec2 = Vector(v1[1],v1[2],v1[3]), Vector(v2[1],v2[2],v2[3])
-	if width < 0 || width > 50 then width = 1 end
+	if width < 0 or width > 50 then width = 1 end
 
 	if IsValid(ent1.data.Ropes[index]) then
 		ent1.data.Ropes[index]:Remove()
@@ -285,29 +291,29 @@ __e2setcost(30)
 
 --- Creates a slider between <ent1> and <ent2> at vector positions local to each ent.
 e2function void slider(entity ent1, vector v1, entity ent2, vector v2)
-	if !checkEnts(self, ent1, ent2) then return end
+	if not checkEnts(self, ent1, ent2) then return end
 	local vec1, vec2 = Vector(v1[1], v1[2], v1[3]), Vector(v2[1], v2[2], v2[3])
 	addundo(self, constraint.Slider(ent1, ent2, 0, 0, vec1, vec2, 1), "slider")
 end
 
 --- Creates a slider between <ent1> and <ent2> at vector positions local to each ent, with <width> width.
 e2function void slider(entity ent1, vector v1, entity ent2, vector v2, width)
-	if !checkEnts(self, ent1, ent2) then return end
+	if not checkEnts(self, ent1, ent2) then return end
 	local vec1, vec2 = Vector(v1[1], v1[2], v1[3]), Vector(v2[1], v2[2], v2[3])
 	addundo(self, constraint.Slider(ent1, ent2, 0, 0, vec1, vec2, width), "slider")
 end
 
 --- Nocollides <ent1> to <ent2>
 e2function void noCollide(entity ent1, entity ent2)
-	if !checkEnts(self, ent1, ent2) then return end
+	if not checkEnts(self, ent1, ent2) then return end
 	addundo(self, constraint.NoCollide(ent1, ent2, 0, 0), "nocollide")
 end
 
 --- Nocollides <ent> to entities/players, just like Right Click of No-Collide Stool
 e2function void noCollideAll(entity ent, state)
-	if !IsValid(ent) then return end
-	if !isOwner(self, ent) then return false end
-	if state != 0 then
+	if not IsValid(ent) then return self:throw("Invalid entity!", nil) end
+	if not isOwner(self, ent) then return self:throw("You do not own this prop!", nil) end
+	if state ~= 0 then
 		ent:SetCollisionGroup( COLLISION_GROUP_WORLD )
 	else
 		ent:SetCollisionGroup( COLLISION_GROUP_NONE )
@@ -316,7 +322,7 @@ end
 
 --- Welds <ent1> to <ent2>
 e2function void weld(entity ent1, entity ent2)
-	if !checkEnts(self, ent1, ent2) then return end
+	if not checkEnts(self, ent1, ent2) then return end
 	addundo(self, constraint.Weld(ent1, ent2, 0, 0, 0, true), "weld")
 end
 
@@ -324,14 +330,14 @@ __e2setcost(5)
 
 --- Breaks EVERY CONSTRAINT on <this>
 e2function void entity:constraintBreak()
-	if !IsValid(this) then return end
-	if !isOwner(self, this) then return false end
+	if not IsValid(this) then return self:throw("Invalid entity!", nil) end
+	if not isOwner(self, this) then return self:throw("You do not own this prop!", nil) end
 	constraint.RemoveAll(this)
 end
 
 --- Breaks all constraints between <this> and <ent2>
 e2function void entity:constraintBreak(entity ent2)
-	if !checkEnts(self, this, ent2) then return end
+	if not checkEnts(self, this, ent2) then return end
 	local consts = this.Constraints
 	local consts2 = ent2.Constraints
 	if !consts then
@@ -341,7 +347,7 @@ e2function void entity:constraintBreak(entity ent2)
 	for _,v in pairs( consts ) do
 		if IsValid(v) then
 			local CTab = v:GetTable()
-			if ( CTab.Ent1 == this && CTab.Ent2 == ent2 ) ||  ( CTab.Ent1 == ent2 && CTab.Ent2 == this ) then
+			if ( CTab.Ent1 == this and CTab.Ent2 == ent2 ) or  ( CTab.Ent1 == ent2 and CTab.Ent2 == this ) then
 				v:Remove()
 			end
 	 	end
@@ -350,24 +356,24 @@ end
 
 --- Breaks all constraints of type <type> on <this>
 e2function void entity:constraintBreak(string type)
-	if !IsValid(this) then return end
-	if !isOwner(self, this) then return false end
+	if !IsValid(this) then return self:throw("Invalid entity!", nil) end
+	if !isOwner(self, this) then return self:throw("You do not own this prop!", nil) end
 	constraint.RemoveConstraints(this, caps(type))
 end
 
 --- Breaks a constraint of type <type> between <this> and <ent2>
 e2function void entity:constraintBreak(string type, entity ent2)
-	if !checkEnts(self, this, ent2) then return end
+	if not checkEnts(self, this, ent2) then return end
 	local consts = this.Constraints
 	local consts2 = ent2.Constraints
-	if !consts then
-		if !consts2 then return end
+	if not consts then
+		if not consts2 then return end
 		consts = consts2
 	end
 	for _,v in pairs( consts ) do
 		if IsValid(v) then
 			local CTab = v:GetTable()
-			if CTab.Type == caps(type) && ( CTab.Ent1 == this && CTab.Ent2 == ent2 ) ||  ( CTab.Ent1 == ent2 && CTab.Ent2 == this ) then
+			if CTab.Type == caps(type) and ( CTab.Ent1 == this and CTab.Ent2 == ent2 ) or ( CTab.Ent1 == ent2 and CTab.Ent2 == this ) then
 				v:Remove()
 				break
 			end

--- a/lua/entities/gmod_wire_expression2/core/custom/effects.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/effects.lua
@@ -62,123 +62,123 @@ e2function effect effect()
 end
 
 e2function effect effect:setOrigin(vector pos)
-	if not this then return end
+	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetOrigin(Vector( pos[1], pos[2], pos[3] ))
 	return this
 end
 
 e2function effect effect:setStart(vector pos)
-	if not this then return end
+	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetStart(Vector( pos[1], pos[2], pos[3] ))
 	return this
 end
 
 e2function effect effect:setMagnitude(number mag)
-	if not this then return end
+	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetMagnitude(mag)
 	return this
 end
 
 e2function effect effect:setAngles(angle ang)
-	if not this then return end
+	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetAngles( Angle( ang[1] ,ang[2] ,ang[3] ))
 	return this
 end
 
 e2function effect effect:setScale(number scale)
-	if not this then return end
+	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetScale(scale)
 	return this
 end
 
 e2function effect effect:setEntity(entity ent)
-	if not this then return end
-	if not IsValid(ent) then return end
+	if not this then return self:throw("Invalid effect!", nil) end
+	if not IsValid(ent) then return self:throw("Invalid entity!", nil) end
 
 	this:SetEntity(ent)
 	return this
 end
 
 e2function effect effect:setNormal(vector norm)
-	if not this then return end
+	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetNormal(Vector( norm[1], norm[2], norm[3] ))
 	return this
 end
 
 e2function effect effect:setSurfaceProp(number prop)
-	if not this then return end
+	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetSurfaceProp(prop)
 	return this
 end
 
 e2function effect effect:setRadius(number radius)
-	if not this then return end
+	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetRadius(radius)
 	return this
 end
 
 e2function effect effect:setMaterialIndex(number index)
-	if not this then return end
+	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetMaterialIndex(index)
 	return this
 end
 
 e2function effect effect:setHitBox(number index)
-	if not this then return end
+	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetHitBox(index)
 	return this
 end
 
 e2function effect effect:setFlags(number flags)
-	if not this then return end
+	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetFlags(flags)
 	return this
 end
 
 e2function effect effect:setEntIndex(number index)
-	if not this then return end
+	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetEntIndex(index)
 	return this
 end
 
 e2function effect effect:setDamageType(number index)
-	if not this then return end
+	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetDamageType(index)
 	return this
 end
 
 e2function effect effect:setColor(number index)
-	if not this then return end
+	if not this then return self:throw("Invalid effect!", nil) end
 	index = math.Clamp(index,0,255)
 	this:SetColor(index)
 	return this
 end
 
 e2function effect effect:setAttachment(number index)
-	if not this then return end
+	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetAttachment(index)
 	return this
 end
 
 e2function void effect:play(string name)
-	if not this then return end
-	if not isAllowed(self) then return end
-	if effect_blacklist[name] then return end
-	if hook.Run( "Expression2_CanEffect", name:lower(), self ) == false then return end
+	if not this then return self:throw("Invalid effect!", nil) end
+	if not isAllowed(self) then return self:throw("Effect play() burst limit reached!", nil) end
+	if effect_blacklist[name] then return self:throw("This effect is blacklisted!", nil) end
+	if hook.Run( "Expression2_CanEffect", name:lower(), self ) == false then return self:throw("A hook prevented this function from running", nil) end
 
 	util.Effect(name,this)
 end

--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -52,10 +52,10 @@ local canHaveInvalidPhysics = {
 }
 function PropCore.ValidAction(self, entity, cmd)
 	if(cmd=="spawn" or cmd=="Tdelete") then return true end
-	if(!IsValid(entity)) then return false end
-	if(!canHaveInvalidPhysics[cmd] and !validPhysics(entity)) then return false end
-	if(!isOwner(self, entity)) then return false end
-	if entity:IsPlayer() then return false end
+	if(!IsValid(entity)) then return self:throw("Invalid entity!", false) end
+	if(!canHaveInvalidPhysics[cmd] and !validPhysics(entity)) then return self:throw("Invalid physics object!", false) end
+	if(!isOwner(self, entity)) then return self:throw("You do not own this entity!", false) end
+	if entity:IsPlayer() then return self:throw("You cannot modify players", false) end
 
 	-- make sure we can only perform the same action on this prop once per tick
 	-- to prevent spam abuse
@@ -63,7 +63,7 @@ function PropCore.ValidAction(self, entity, cmd)
 		entity.e2_propcore_last_action = {}
 	end
 	if 	entity.e2_propcore_last_action[cmd] and
-		entity.e2_propcore_last_action[cmd] == CurTime() then return false end
+		entity.e2_propcore_last_action[cmd] == CurTime() then return self:throw("You can only perform one type of action per tick!", false) end
 	entity.e2_propcore_last_action[cmd] = CurTime()
 
 	local ply = self.player

--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -31,9 +31,7 @@ function PropCore.ValidSpawn(ply, model, isVehicle)
 	local limithit = playerMeta.LimitHit
 	playerMeta.LimitHit = function() end
 
-	if not PropCore.WithinPropcoreLimits() then
-		ret = false
-	elseif not (util.IsValidProp( model ) and WireLib.CanModel(ply, model)) then
+	if not (util.IsValidProp( model ) and WireLib.CanModel(ply, model)) then
 		ret = false
 	elseif isVehicle then
 		ret = gamemode.Call( "PlayerSpawnVehicle", ply, model, "Seat_Airboat", list.Get( "Vehicles" ).Seat_Airboat ) ~= false
@@ -79,6 +77,7 @@ local function MakePropNoEffect(...)
 end
 
 function PropCore.CreateProp(self,model,pos,angles,freeze,isVehicle)
+	if not PropCore.WithinPropcoreLimits() then return self:throw("Prop limit reached! (cooldown or max)", NULL) end
 	if not PropCore.ValidSpawn(self.player, model, isVehicle) then return NULL end
 
 	pos = WireLib.clampPos( pos )

--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -31,7 +31,9 @@ function PropCore.ValidSpawn(ply, model, isVehicle)
 	local limithit = playerMeta.LimitHit
 	playerMeta.LimitHit = function() end
 
-	if not (util.IsValidProp( model ) and WireLib.CanModel(ply, model)) then
+	if not PropCore.WithinPropcoreLimits() then
+		ret = false
+	elseif not (util.IsValidProp( model ) and WireLib.CanModel(ply, model)) then
 		ret = false
 	elseif isVehicle then
 		ret = gamemode.Call( "PlayerSpawnVehicle", ply, model, "Seat_Airboat", list.Get( "Vehicles" ).Seat_Airboat ) ~= false

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -328,7 +328,7 @@ hook.Add("PlayerBindUp", "Exp2KeyReceivingUp", function(player, binding, button)
 end)
 
 local function toggleRunOnKeys(self,ply,on,filter)
-	if not IsValid(ply) or not ply:IsPlayer() then return end
+	if not IsValid(ply) or not ply:IsPlayer() then return self:throw("Invalid player for runOnKeys!", nil) end
 
 	local ent = self.entity
 	local uid = ply:UniqueID()
@@ -600,8 +600,8 @@ end
 --------------------------------------------------------------------------------
 
 e2function entity entity:aimEntity()
-	if not IsValid(this) then return nil end
-	if not this:IsPlayer() then return nil end
+	if not IsValid(this) then return self:throw("Invalid entity!", nil) end
+	if not this:IsPlayer() then return self:throw("Expected a Player, got Entity", nil) end
 
 	local ent = this:GetEyeTraceNoCursor().Entity
 	if not ent:IsValid() then return nil end
@@ -767,24 +767,24 @@ e2function number lastDeathTime()
 end
 
 -- To avoid a lot of repeated checks
-local function getDeathEntry(ply,key)
-	if not IsValid(ply) then return end
-	if not ply:IsPlayer() then return end
+local function getDeathEntry(self, ply, key)
+	if not IsValid(ply) then return self:throw("Invalid player!", nil) end
+	if not ply:IsPlayer() then return self:throw("Expected a Player, got Entity", nil) end
 	local entry = DeathList[ply]
 	if not entry then return end -- Player has never died.
 	return entry[key]
 end
 
-local function getRespawnEntry(ply,key)
-	if not IsValid(ply) then return end
-	if not ply:IsPlayer() then return end
+local function getRespawnEntry(self, ply, key)
+	if not IsValid(ply) then return self:throw("Invalid player!", nil) end
+	if not ply:IsPlayer() then return self:throw("Expected a Player, got Entity", nil) end
 	local entry = RespawnList[ply]
 	if not entry then return end -- Player has never respawned.
 	return entry[key]
 end
 
 e2function number lastDeathTime(entity ply) -- When the player provided last died.
-	return getDeathEntry(ply,"timestamp") or 0
+	return getDeathEntry(self, ply,"timestamp") or 0
 end
 
 e2function entity lastDeathVictim()
@@ -796,7 +796,7 @@ e2function entity lastDeathInflictor()
 end
 
 e2function entity lastDeathInflictor(entity ply)
-	return getDeathEntry(ply,"inflictor") or NULL
+	return getDeathEntry(self, ply,"inflictor") or NULL
 end
 
 e2function entity lastDeathAttacker()
@@ -804,7 +804,7 @@ e2function entity lastDeathAttacker()
 end
 
 e2function entity lastDeathAttacker(entity ply)
-	return getDeathEntry(ply,"attacker") or NULL
+	return getDeathEntry(self, ply,"attacker") or NULL
 end
 
 -- Respawn Functions
@@ -821,7 +821,7 @@ e2function number lastSpawnTime()
 end
 
 e2function number lastSpawnTime(entity ply)
-	return getRespawnEntry(ply,"timestamp") or 0
+	return getRespawnEntry(self, ply,"timestamp") or 0
 end
 
 e2function entity lastSpawnedPlayer()

--- a/lua/entities/gmod_wire_expression2/core/selfaware.lua
+++ b/lua/entities/gmod_wire_expression2/core/selfaware.lua
@@ -135,7 +135,7 @@ end
 
 -- Get the name of another E2 or compatible entity or component name of wiremod components
 e2function string entity:getName()
-	if not IsValid(this) then return "" end
+	if not IsValid(this) then return self:throw("Invalid entity!", "") end
 	if this.GetGateName then
 		return this:GetGateName() or ""
 	end

--- a/lua/entities/gmod_wire_expression2/core/sound.lua
+++ b/lua/entities/gmod_wire_expression2/core/sound.lua
@@ -129,7 +129,8 @@ e2function void soundPlay( index, duration, string path )
 end
 
 e2function void entity:soundPlay( index, duration, string path)
-	if not IsValid(this) or not isOwner(self, this) then return end
+	if not IsValid(this) then return self:throw("Invalid entity!", nil) end
+	if not isOwner(self, this) then return self:throw("You do not own this entity!", nil) end
 	soundCreate(self,this,index,duration,path,0)
 end
 
@@ -138,7 +139,8 @@ e2function void soundPlay( index, duration, string path, fade )
 end
 
 e2function void entity:soundPlay( index, duration, string path, fade )
-	if not IsValid(this) or not isOwner(self, this) then return end
+	if not IsValid(this) then return self:throw("Invalid entity!", nil) end
+	if not isOwner(self, this) then return self:throw("You do not own this entity!", nil) end
 	soundCreate(self,this,index,duration,path,fade)
 end
 
@@ -163,14 +165,14 @@ end
 
 e2function void soundVolume( index, volume )
 	local sound = getSound( self, index )
-	if not sound then return end
+	if not sound then return self:throw("Invalid sound: " .. index, nil) end
 
 	sound:ChangeVolume( math.Clamp( volume, 0, 1 ), 0 )
 end
 
 e2function void soundVolume( index, volume, fadetime )
 	local sound = getSound( self, index )
-	if not sound then return end
+	if not sound then return self:throw("Invalid sound: " .. index, nil) end
 
 	sound:ChangeVolume( math.Clamp( volume, 0, 1 ), math.abs( fadetime ) )
 end
@@ -178,14 +180,14 @@ end
 
 e2function void soundPitch( index, pitch )
 	local sound = getSound( self, index )
-	if not sound then return end
+	if not sound then return self:throw("Invalid sound: " .. index, nil) end
 
 	sound:ChangePitch( math.Clamp( pitch, 0, 255 ), 0 )
 end
 
 e2function void soundPitch( index, pitch, fadetime )
 	local sound = getSound( self, index )
-	if not sound then return end
+	if not sound then return self:throw("Invalid sound: " .. index, nil) end
 
 	sound:ChangePitch( math.Clamp( pitch, 0, 255 ), math.abs( fadetime ) )
 end

--- a/lua/entities/gmod_wire_expression2/core/table.lua
+++ b/lua/entities/gmod_wire_expression2/core/table.lua
@@ -1165,8 +1165,8 @@ registerCallback( "postinit", function()
 			local op1, op2, op3 = args[2], args[3], args[4]
 			local rv1, rv2, rv3 = op1[1](self, op1), op2[1](self, op2), op3[1](self,op3)
 			if rv3 == nil then return end
-			if rv2 < 0 then return end
-			if rv2 > 2^31 then return end -- too large, possibility of crashing gmod
+			if rv2 < 0 then return self:throw("Insert key cannot be negative!") end
+			if rv2 > 2^31 then return self:throw("Insert key too large!") end -- too large, possibility of crashing gmod
 			rv1.size = rv1.size + 1
 			table.insert( rv1.n, rv2, rv3 )
 			table.insert( rv1.ntypes, rv2, id )


### PR DESCRIPTION
Just missing all of the egp draw functions, which I don't think would be worth doing anyway

Added strict compat to:
* Constraint library
* Constraint core
* Propcore
* Effects
* Player (runOnDeath, runOnKeys)
* Sounds
* T:insert(X, N)