### PR TITLE
Added cl_hologram owner display culling

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/cl_hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_hologram.lua
@@ -1,40 +1,42 @@
-local HoloDisplayCVar = GetConVar("wire_holograms_display_owners_maxdist")
+-- Replicated from serverside, same function as the one below except this takes precedence
+local holoDisplayCVar = GetConVar("wire_holograms_display_owners_maxdist")
 
-local HoloDisplayCVarCL = CreateClientConVar("wire_holograms_display_owners_maxdist_cl","-1",true,false,
-"The maximum distance that wire_holograms_display_owners will allow names to be seen. -1 for original function.",-1,32768)
+local holoDisplayCVarCL = CreateClientConVar( "wire_holograms_display_owners_maxdist_cl" , "-1", true, false,
+"The maximum distance that wire_holograms_display_owners will allow names to be seen. -1 for original function.", -1, 32768)
 
 local function WireHologramsShowOwners()
-	local Eye = EyePos()
-	local EntList = ents.FindByClass( "gmod_wire_hologram" )
-	local FinalEntList = {}
+	local eye = EyePos()
+	local entList = ents.FindByClass( "gmod_wire_hologram" )
+	local finalEntList = {}
 
-	local FinalCVar = 0
-	local CVA = HoloDisplayCVar:GetInt()
-	local CVB = HoloDisplayCVarCL:GetInt()
+	local finalCVar = 0
+	-- Both cvars, server-replicated and clientside
+	local cva = holoDisplayCVar:GetInt()
+	local cvb = holoDisplayCVarCL:GetInt()
 
-	if CVA == -1 then -- Server allows mapwide visibility for display, default to the client's setting
-		FinalCVar = CVB
+	if cva == -1 then -- Server allows mapwide visibility for display, default to the client's setting
+		finalCVar = cvb
 	else
-		if CVB >= 0 then -- Use whichever value is lower, as long as the client isn't trying to get mapwide visibility of names while the server prevents it
-			FinalCVar = math.min(CVA,CVB)
+		if cvb >= 0 then -- Use whichever value is lower, as long as the client isn't trying to get mapwide visibility of names while the server prevents it
+			finalCVar = math.min( cva, cvb)
 		else -- If all else fails, settle with what the server is using
-			FinalCVar = CVA
+			finalCVar = cva
 		end
 	end
 
-	local HoloDisplayDist = FinalCVar ^ 2
+	local holoDisplayDist = finalCVar ^ 2
 
-	if FinalCVar > 0 then -- Can't check for -1 from the above variable since it is squared, and it needs to be squared for performance reasons comparing distances
-		for _,ent in pairs(EntList) do
-			local DistToEye = Eye:DistToSqr(ent:GetPos())
-			if DistToEye < HoloDisplayDist then FinalEntList[#FinalEntList + 1] = ent end
+	if finalCVar > 0 then -- Can't check for -1 from the above variable since it is squared, and it needs to be squared for performance reasons comparing distances
+		for _,ent in pairs( entList ) do
+			local distToEye = eye:DistToSqr( ent:GetPos() )
+			if distToEye < holoDisplayDist then finalEntList[ #finalEntList + 1 ] = ent end
 		end
 	else -- Default to the original function of showing ALL holograms
 		-- if, in the end, both are 0, why even bother trying to do it at all (and why is this running?)
-		if FinalCVar == -1 then FinalEntList = EntList end
+		if finalCVar == -1 then finalEntList = entList end
 	end
 
-	for _,ent in pairs( FinalEntList ) do
+	for _,ent in pairs( finalEntList ) do
 		local id = ent:GetNWInt( "ownerid" )
 
 		for _,ply in pairs( player.GetAll() ) do

--- a/lua/entities/gmod_wire_expression2/core/cl_hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_hologram.lua
@@ -8,7 +8,7 @@ local function WireHologramsShowOwners()
 	local EntList = ents.FindByClass( "gmod_wire_hologram" )
 	local FinalEntList = {}
 
-	local FinalCVar = HoloDisplayCVar:GetInt()
+	local FinalCVar = 0
 	local CVA = HoloDisplayCVar:GetInt()
 	local CVB = HoloDisplayCVarCL:GetInt()
 

--- a/lua/entities/gmod_wire_expression2/core/cl_hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_hologram.lua
@@ -24,12 +24,13 @@ local function WireHologramsShowOwners()
 
 	local HoloDisplayDist = FinalCVar ^ 2
 
-	if FinalCVar >= 0 then -- Can't check for -1 from the above variable since it is squared, and it needs to be squared for performance reasons comparing distances
+	if FinalCVar > 0 then -- Can't check for -1 from the above variable since it is squared, and it needs to be squared for performance reasons comparing distances
 		for _,ent in pairs(EntList) do
 			local DistToEye = Eye:DistToSqr(ent:GetPos())
 			if DistToEye < HoloDisplayDist then FinalEntList[#FinalEntList + 1] = ent end
 		end
 	else -- Default to the original function of showing ALL holograms
+		-- if, in the end, both are 0, why even bother trying to do it at all (and why is this running?)
 		if FinalCVar == -1 then FinalEntList = EntList end
 	end
 

--- a/lua/entities/gmod_wire_expression2/core/hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/hologram.lua
@@ -17,7 +17,7 @@ local wire_holograms_modelany = CreateConVar( "wire_holograms_modelany", "0", {F
 	"1: Allow holograms to use models besides the official hologram models." ..
 	"2: Allow holograms to additionally use models not present on the server." )
 local wire_holograms_size_max = CreateConVar( "wire_holograms_size_max", "50", {FCVAR_ARCHIVE} )
-local wire_holograms_max_show_owner_dist = CreateConVar( "wire_holograms_display_owners_maxdist", "-1", {FCVAR_ARCHIVE + FCVAR_REPLICATED},
+CreateConVar( "wire_holograms_display_owners_maxdist", "-1", {FCVAR_ARCHIVE + FCVAR_REPLICATED},
 	"The maximum distance that wire_holograms_display_owners will allow names to be seen. -1 for original function. Server-side and has priority over clients.", -1, 32768)
 util.AddNetworkString("wire_holograms_set_visible")
 util.AddNetworkString("wire_holograms_clip")

--- a/lua/entities/gmod_wire_expression2/core/hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/hologram.lua
@@ -17,8 +17,8 @@ local wire_holograms_modelany = CreateConVar( "wire_holograms_modelany", "0", {F
 	"1: Allow holograms to use models besides the official hologram models." ..
 	"2: Allow holograms to additionally use models not present on the server." )
 local wire_holograms_size_max = CreateConVar( "wire_holograms_size_max", "50", {FCVAR_ARCHIVE} )
-local wire_holograms_max_show_owner_dist = CreateConVar("wire_holograms_display_owners_maxdist","-1",{FCVAR_ARCHIVE + FCVAR_REPLICATED},
-	"The maximum distance that wire_holograms_display_owners will allow names to be seen. -1 for original function. Server-side and has priority over clients.",-1,32768)
+local wire_holograms_max_show_owner_dist = CreateConVar( "wire_holograms_display_owners_maxdist", "-1", {FCVAR_ARCHIVE + FCVAR_REPLICATED},
+	"The maximum distance that wire_holograms_display_owners will allow names to be seen. -1 for original function. Server-side and has priority over clients.", -1, 32768)
 util.AddNetworkString("wire_holograms_set_visible")
 util.AddNetworkString("wire_holograms_clip")
 util.AddNetworkString("wire_holograms_set_scale")

--- a/lua/entities/gmod_wire_expression2/core/hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/hologram.lua
@@ -17,6 +17,8 @@ local wire_holograms_modelany = CreateConVar( "wire_holograms_modelany", "0", {F
 	"1: Allow holograms to use models besides the official hologram models." ..
 	"2: Allow holograms to additionally use models not present on the server." )
 local wire_holograms_size_max = CreateConVar( "wire_holograms_size_max", "50", {FCVAR_ARCHIVE} )
+local wire_holograms_max_show_owner_dist = CreateConVar("wire_holograms_display_owners_maxdist","-1",{FCVAR_ARCHIVE + FCVAR_REPLICATED},
+	"The maximum distance that wire_holograms_display_owners will allow names to be seen. -1 for original function. Server-side and has priority over clients.",-1,32768)
 util.AddNetworkString("wire_holograms_set_visible")
 util.AddNetworkString("wire_holograms_clip")
 util.AddNetworkString("wire_holograms_set_scale")
@@ -176,8 +178,8 @@ local clip_queue = {}
 local vis_queue = {}
 local player_color_queue = {}
 
---[[ helper function to add items to a queue 
-	parameters: 
+--[[ helper function to add items to a queue
+	parameters:
 		queue - the queue to add to
 		ply - the player who ran the command
 		holo - holo table entry
@@ -368,7 +370,7 @@ local function rescale(Holo, scale, bone)
 			local y = math.Clamp( b_scale[2], minval, maxval )
 			local z = math.Clamp( b_scale[3], minval, maxval )
 			local scale = Vector(x, y, z)
-			
+
 			add_queue( bone_scale_queue, Holo.e2owner, Holo, bidx, scale )
 			Holo.bone_scale[bidx] =  scale
 		else  -- reset holo bone scale


### PR DESCRIPTION
Added a new convar (wire_holograms_display_owners_maxdist) for serverside usage which sets a maximum distance that clients can render the names of the owners of holograms.

Also a clientside convar (wire_holograms_display_owners_maxdist_cl), and the lowest value is used in the end (except for -1)

Default value is -1 for both, in which case it falls back to the original function of displaying ALL of the holograms.

This was partly done for servers where being able to see where holograms are would put other players at a disadvantage, for example in combat gamemodes where holograms may be allowed, but this also revealed being a performance increase when culled reasonably (who would have thought cutting down on text draws would do that?)

This only affects the "wire_holograms_display_owners" command when it is running.