### PR TITLE
Fix for server cvar not replicating

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/cl_hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_hologram.lua
@@ -1,5 +1,5 @@
 -- Replicated from serverside, same function as the one below except this takes precedence
-local holoDisplayCVar = GetConVar("wire_holograms_display_owners_maxdist")
+local holoDisplayCVar = CreateConVar("wire_holograms_display_owners_maxdist", "-1", {FCVAR_REPLICATED})
 
 local holoDisplayCVarCL = CreateClientConVar( "wire_holograms_display_owners_maxdist_cl" , "-1", true, false,
 "The maximum distance that wire_holograms_display_owners will allow names to be seen. -1 for original function.", -1, 32768)


### PR DESCRIPTION
Made the required cvar actually get created on the clientside so it has something to replicate to
Should fix #2273, but I can't test from a proper server perspective as I can't get my test server running correctly, so this needs testing from that point