### PR TITLE
Better(er) FLIR rendering

### DIFF
--- a/lua/wire/flir.lua
+++ b/lua/wire/flir.lua
@@ -26,14 +26,14 @@ if CLIENT then
 	FLIR.RenderStack = {}
 	FLIR.enabled = false
 
-	FLIR.gcvar = CreateClientConVar("wire_flir_gain", 2, true, false, "Brightness of FLIR ents. Higher = less detail, more visible.", 0, 10)
+	FLIR.gcvar = CreateClientConVar("wire_flir_gain", 2.2, true, false, "Brightness of FLIR ents. Higher = less detail, more visible.", 0, 10)
 	cvars.AddChangeCallback("wire_flir_gain", function(_,_,v) 
 		FLIR.gain = v
 	end)
 
 	FLIR.gain = FLIR.gcvar:GetInt()
 	FLIR.mat = Material("phoenix_storms/concrete0")
-	FLIR.transmat = Material("models/props_combine/metal_combinebridge001")
+	FLIR.transmat = Material("models/props/cs_assault/metal_stairs1")
 	FLIR.hide = false
 
 	function FLIR.Render(self)

--- a/lua/wire/flir.lua
+++ b/lua/wire/flir.lua
@@ -25,7 +25,7 @@ if CLIENT then
 
 	FLIR.RenderStack = {}
 	FLIR.enabled = false
-	FLIR.col = Color(1, 1, 1) --the multipliers for each color channel
+	--FLIR.col = Color(1, 1, 1) --the multipliers for each color channel
 	FLIR.mat = Material("phoenix_storms/concrete0")
 	FLIR.transmat = Material("models/props_combine/metal_combinebridge001")
 	FLIR.hide = false
@@ -102,7 +102,8 @@ if CLIENT then
 
 			render.MaterialOverride(FLIR.mat)
 			render.SuppressEngineLighting(true)
-			render.SetColorModulation(FLIR.col.r, FLIR.col.g, FLIR.col.b)			--this works?? I could not for the life of me make it work in renderoverride. Well.
+			--currently set to 1
+			--render.SetColorModulation(FLIR.col.r, FLIR.col.g, FLIR.col.b)			--this works?? I could not for the life of me make it work in renderoverride. Well.
 																					--It's a much better solution than the stencil I spent hours on...
 			for ent, valid in pairs(FLIR.RenderStack) do
 				if not IsValid(ent) or not valid or ent:GetNoDraw() then

--- a/lua/wire/flir.lua
+++ b/lua/wire/flir.lua
@@ -27,6 +27,7 @@ if CLIENT then
 	FLIR.enabled = false
 	FLIR.col = Color(2, 2, 2) --the multipliers for each color channel
 	FLIR.mat = Material("phoenix_storms/concrete0")
+	FLIR.transmat = Material("models/props_combine/metal_combinebridge001")
 	FLIR.hide = false
 
 	function FLIR.Render(self)
@@ -56,7 +57,7 @@ if CLIENT then
 		if not IsValid(ent) then return end
 		local c = ent:GetClass()
 
-		if (string.match(c, "^prop_") or ent:GetMoveType() == MOVETYPE_VPHYSICS or (ent:IsPlayer() and ent != ply) or ent:IsNPC() or ent:IsRagdoll() or c == "gmod_wire_hologram") and ent:GetColor().a > 0 then
+		if (c == "prop_physics" or ent:GetMoveType() == MOVETYPE_VPHYSICS or (ent:IsPlayer() and ent != ply) or ent:IsNPC() or ent:IsRagdoll() or c == "gmod_wire_hologram") and ent:GetColor().a > 0 then
 			if ent:GetColor().a > 0 then
 				FLIR.RenderStack[ent] = true
 				ent.RenderOverride = FLIR.Render	--we're already rendering later, so don't bother beforehand
@@ -116,12 +117,18 @@ if CLIENT then
 				::next::
 			end
 
-			render.MaterialOverride(nil)
-			render.SuppressEngineLighting(false)
+			
 			render.SetColorModulation(1,1,1)
+			render.SuppressEngineLighting(false)
+			render.MaterialOverride(FLIR.transmat)
 
 		end)
 
+		hook.Add("PostDrawTranslucentRenderables", "wire_flir", function()
+		render.SuppressEngineLighting(false)
+		
+		render.MaterialOverride(nil)
+		end)
 
 
 		hook.Add("RenderScreenspaceEffects", "wire_flir", function()
@@ -156,6 +163,7 @@ if CLIENT then
 		render.SetLightingMode(0)
 
 		hook.Remove("PostDrawOpaqueRenderables", "wire_flir")
+		hook.Remove("PostDrawTranslucentRenderables", "wire_flir")
 		hook.Remove("RenderScreenspaceEffects", "wire_flir")
 		hook.Remove("PostDraw2DSkyBox", "wire_flir")
 		hook.Remove("PreRender", "wire_flir")

--- a/lua/wire/flir.lua
+++ b/lua/wire/flir.lua
@@ -56,9 +56,19 @@ if CLIENT then
 		["$pp_colour_brightness"] = 0
 	}
 
-
-
 	--add and remove entities from the FLIR rendering stack
+
+	local function RemoveFLIR(ent)
+		FLIR.RenderStack[ent] = nil
+		if IsValid(ent) then ent.RenderOverride = nil end
+	end
+
+	local function RemoveCheck(ent)		--make sure entity has actually been removed, not weird call
+		timer.Create(tostring(ent).."rmcheck", 0, 1, function()
+			if not IsValid(ent) then RemoveFLIR(ent) end
+		end)
+	end
+
 	local function SetFLIR(ent)
 		if not IsValid(ent) then return end
 		local c = ent:GetClass()
@@ -67,17 +77,12 @@ if CLIENT then
 			if ent:GetColor().a > 0 then
 				FLIR.RenderStack[ent] = true
 				ent.RenderOverride = FLIR.Render	--we're already rendering later, so don't bother beforehand
-				ent:CallOnRemove("RemoveFLIR", RemoveFLIR)
+				ent:CallOnRemove("rmcheck", RemoveCheck(ent))
 			end
 		end
 	end
 
-	local function RemoveFLIR(ent)
-		if not IsValid(ent) then return end
 
-		FLIR.RenderStack[ent] = nil
-		ent.RenderOverride = nil
-	end
 
 
 

--- a/lua/wire/flir.lua
+++ b/lua/wire/flir.lua
@@ -33,7 +33,7 @@ if CLIENT then
 
 	FLIR.gain = FLIR.gcvar:GetInt()
 	FLIR.mat = Material("phoenix_storms/concrete0")
-	FLIR.transmat = Material("models/props/cs_assault/metal_stairs1")
+	FLIR.transmat = Material("phoenix_storms/iron_rails")
 	FLIR.hide = false
 
 	function FLIR.Render(self)

--- a/lua/wire/flir.lua
+++ b/lua/wire/flir.lua
@@ -176,7 +176,7 @@ if CLIENT then
 		hook.Remove("OnEntityCreated", "wire_flir")
 		hook.Remove("CreateClientsideRagdoll", "wire_flir")
 
-		for _, v in pairs(ents.GetAll()) do
+		for _, v in ipairs(ents.GetAll()) do
 			RemoveFLIR(v)
 		end
 	end

--- a/lua/wire/flir.lua
+++ b/lua/wire/flir.lua
@@ -116,16 +116,13 @@ if CLIENT then
 			render.SetColorModulation(FLIR.gain, FLIR.gain, FLIR.gain)  			--this works?? I could not for the life of me make it work in renderoverride. Well.
 																					--It's a much better solution than the stencil I spent hours on...
 			for ent, valid in pairs(FLIR.RenderStack) do
-				if not IsValid(ent) or not valid or ent:GetNoDraw() then
+				if valid and ent:IsValid() and not ent:GetNoDraw() then
+					FLIR.hide = false
+					ent:DrawModel()
+					FLIR.hide = true
+				else
 					RemoveFLIR(ent)
-					goto next
 				end
-
-				FLIR.hide = false
-				ent:DrawModel()
-				FLIR.hide = true
-
-				::next::
 			end
 
 			render.SuppressEngineLighting(false)

--- a/lua/wire/flir.lua
+++ b/lua/wire/flir.lua
@@ -26,14 +26,12 @@ if CLIENT then
 	FLIR.RenderStack = {}
 	FLIR.enabled = false
 
-	FLIR.gain = CreateClientConVar("wire_flir_gain", 2, true, false, "Brightness of FLIR ents. Higher = less detail, more visible.", 0, 10)
+	FLIR.gcvar = CreateClientConVar("wire_flir_gain", 2, true, false, "Brightness of FLIR ents. Higher = less detail, more visible.", 0, 10)
 	cvars.AddChangeCallback("wire_flir_gain", function(_,_,v) 
-		FLIR.col = Color(v,v,v)
+		FLIR.gain = v
 	end)
 
-	local g = FLIR.gain:GetInt()
-	FLIR.col = Color(g, g, g) --the multipliers for each color channel
-	
+	FLIR.gain = FLIR.gcvar:GetInt()
 	FLIR.mat = Material("phoenix_storms/concrete0")
 	FLIR.transmat = Material("models/props_combine/metal_combinebridge001")
 	FLIR.hide = false
@@ -110,7 +108,7 @@ if CLIENT then
 
 			render.MaterialOverride(FLIR.mat)
 			render.SuppressEngineLighting(true)
-			render.SetColorModulation(FLIR.col.r, FLIR.col.g, FLIR.col.b)			--this works?? I could not for the life of me make it work in renderoverride. Well.
+			render.SetColorModulation(FLIR.gain, FLIR.gain, FLIR.gain)  			--this works?? I could not for the life of me make it work in renderoverride. Well.
 																					--It's a much better solution than the stencil I spent hours on...
 			for ent, valid in pairs(FLIR.RenderStack) do
 				if not IsValid(ent) or not valid or ent:GetNoDraw() then

--- a/lua/wire/flir.lua
+++ b/lua/wire/flir.lua
@@ -8,11 +8,12 @@
 	* IR sensors often have auto gain control that we might simulate with auto-exposure
 
 
-	TODO:
+	To Fix:
 	* Find a way to make fog work. With rendermode 1 or 2, fog is disabled. mat_fullbright would be
 		perfect except that it causes a big stutter on being disabled.
 	* Add entities to the list as they are parented. If something is parented while FLIR is enabled, it doesn't
 		add itself until it's switched off and back on.
+	* Sun pops in and out of full brightness when looking around it
 	
 --]]
 

--- a/lua/wire/flir.lua
+++ b/lua/wire/flir.lua
@@ -25,7 +25,15 @@ if CLIENT then
 
 	FLIR.RenderStack = {}
 	FLIR.enabled = false
-	--FLIR.col = Color(1, 1, 1) --the multipliers for each color channel
+
+	FLIR.gain = CreateClientConVar("wire_flir_gain", 2, true, false, "Brightness of FLIR ents. Higher = less detail, more visible.", 0, 10)
+	cvars.AddChangeCallback("wire_flir_gain", function(_,_,v) 
+		FLIR.col = Color(v,v,v)
+	end)
+
+	local g = FLIR.gain:GetInt()
+	FLIR.col = Color(g, g, g) --the multipliers for each color channel
+	
 	FLIR.mat = Material("phoenix_storms/concrete0")
 	FLIR.transmat = Material("models/props_combine/metal_combinebridge001")
 	FLIR.hide = false
@@ -102,8 +110,7 @@ if CLIENT then
 
 			render.MaterialOverride(FLIR.mat)
 			render.SuppressEngineLighting(true)
-			--currently set to 1
-			--render.SetColorModulation(FLIR.col.r, FLIR.col.g, FLIR.col.b)			--this works?? I could not for the life of me make it work in renderoverride. Well.
+			render.SetColorModulation(FLIR.col.r, FLIR.col.g, FLIR.col.b)			--this works?? I could not for the life of me make it work in renderoverride. Well.
 																					--It's a much better solution than the stencil I spent hours on...
 			for ent, valid in pairs(FLIR.RenderStack) do
 				if not IsValid(ent) or not valid or ent:GetNoDraw() then
@@ -183,6 +190,7 @@ if CLIENT then
 	concommand.Add("flir_toggle", function()
 		FLIR.toggle()
 	end)
+
 
 	function FLIR.enable(enabled)
 		if enabled then FLIR.start() else FLIR.stop() end

--- a/lua/wire/flir.lua
+++ b/lua/wire/flir.lua
@@ -25,7 +25,7 @@ if CLIENT then
 
 	FLIR.RenderStack = {}
 	FLIR.enabled = false
-	FLIR.col = Color(0.9, 0.9, 0.9) --the multipliers for each color channel
+	FLIR.col = Color(1, 1, 1) --the multipliers for each color channel
 	FLIR.mat = Material("phoenix_storms/concrete0")
 	FLIR.transmat = Material("models/props_combine/metal_combinebridge001")
 	FLIR.hide = false
@@ -105,7 +105,7 @@ if CLIENT then
 			render.SetColorModulation(FLIR.col.r, FLIR.col.g, FLIR.col.b)			--this works?? I could not for the life of me make it work in renderoverride. Well.
 																					--It's a much better solution than the stencil I spent hours on...
 			for ent, valid in pairs(FLIR.RenderStack) do
-				if not IsValid(ent) or not valid then
+				if not IsValid(ent) or not valid or ent:GetNoDraw() then
 					RemoveFLIR(ent)
 					goto next
 				end

--- a/lua/wire/flir.lua
+++ b/lua/wire/flir.lua
@@ -60,24 +60,17 @@ if CLIENT then
 
 	local function RemoveFLIR(ent)
 		FLIR.RenderStack[ent] = nil
-		if IsValid(ent) then ent.RenderOverride = nil end
-	end
-
-	local function RemoveCheck(ent)		--make sure entity has actually been removed, not weird call
-		timer.Create(tostring(ent).."rmcheck", 0, 1, function()
-			if not IsValid(ent) then RemoveFLIR(ent) end
-		end)
+		if ent:IsValid() then ent.RenderOverride = nil end
 	end
 
 	local function SetFLIR(ent)
-		if not IsValid(ent) then return end
+		if not ent:IsValid() then return end
 		local c = ent:GetClass()
 
 		if (c == "prop_physics" or ent:GetMoveType() == MOVETYPE_VPHYSICS or (ent:IsPlayer() and ent != ply) or ent:IsNPC() or ent:IsRagdoll() or c == "gmod_wire_hologram") and ent:GetColor().a > 0 then
 			if ent:GetColor().a > 0 then
 				FLIR.RenderStack[ent] = true
 				ent.RenderOverride = FLIR.Render	--we're already rendering later, so don't bother beforehand
-				ent:CallOnRemove("rmcheck", RemoveCheck(ent))
 			end
 		end
 	end

--- a/lua/wire/flir.lua
+++ b/lua/wire/flir.lua
@@ -25,7 +25,7 @@ if CLIENT then
 
 	FLIR.RenderStack = {}
 	FLIR.enabled = false
-	FLIR.col = Color(2, 2, 2) --the multipliers for each color channel
+	FLIR.col = Color(0.9, 0.9, 0.9) --the multipliers for each color channel
 	FLIR.mat = Material("phoenix_storms/concrete0")
 	FLIR.transmat = Material("models/props_combine/metal_combinebridge001")
 	FLIR.hide = false
@@ -117,8 +117,6 @@ if CLIENT then
 				::next::
 			end
 
-			
-			render.SetColorModulation(1,1,1)
 			render.SuppressEngineLighting(false)
 			render.MaterialOverride(FLIR.transmat)
 


### PR DESCRIPTION
The FLIR redo I did had a lot of graphical and performance issues. I cut down all the unnecessary fat, redid the rendering process and massively improved performance. 

The gist of it: 
*Color() and Material() calls moved out of hooks (big performance draw)
*Material and Color parameters adjusted - you can now see some level of detail instead of being a white haze
*Outdated umsg() functions updated to net standard
*Several unnecessary hooks removed and packaged into others
*Sun is still a little odd, but doesn't freak out like before
*Particles and tools now render properly without flashing (render.setlightingmode 1 -> 2)
*Huge performance gain with lots of props (no stutter, max 5-10fps loss for me as opposed to 20-30)

Problems:
*Still no fog rendering. I would use mat_fullbright but that has a big stutter when switching back on.
*Since DrawColorModify() applies to everything retroactively and drawing props after translucent entities gives you pseudo-wallhacks through particles some props, bright translucent entities also glow.

These issues were also in the previous version, to be clear. 
Of course, test this all for yourself. I only spent a few days on this, but I think I exhausted my options.