### PR TITLE
Fix wirelinks getting removed by WireLib.AdjustOutputs

### DIFF
--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -234,7 +234,16 @@ end
 function WireLib.AdjustSpecialOutputs(ent, names, types, descs)
 	types = types or {}
 	descs = descs or {}
+
 	local ent_ports = ent.Outputs or {}
+
+	if ent_ports.wirelink then
+		local n = #names+1
+
+		names[n] = "wirelink"
+		types[n] = "WIRELINK"
+	end
+
 	for n,v in ipairs(names) do
 		local name, desc, tp = ParsePortName(v, types[n] or "NORMAL", descs and descs[n])
 


### PR DESCRIPTION
Behavior is inconsistent as existing wires are preserved through an adjustment, but wirelinks are not.

When calling `WireLib.AdjustOutputs(entity, nameList)`, `wirelink` is not passed. If it were, it'd show up whether an actual wirelink existed or not. It would also be created as `NORMAL` and not `WIRELINK`, blocking any attempts to create an actual wirelink.

Proposed fix here just adds `wirelink` and `WIRELINK` to `names` and `types` if one exists to preserve the wirelink.