### PR TITLE
Fix Wired CD Reporting Wrong Number of Tracks

### DIFF
--- a/lua/entities/gmod_wire_cd_disk.lua
+++ b/lua/entities/gmod_wire_cd_disk.lua
@@ -72,12 +72,12 @@ function ENT:Setup(precision, iradius, skin)
 	self.StackStartHeight = -min.z
 
 	self.DiskStacks = math.max(1,math.floor((max.z - min.z) / self.Precision)+1)
-	self.DiskTracks = math.floor(0.5*math.min(max.x - min.x,max.y - min.y) / self.Precision)
+	self.DiskTracks = math.floor(0.5*math.min(max.x - min.x,max.y - min.y) / self.Precision) - 1
 
 	self.DiskSectors = 0
 	self.TrackSectors = {}
 	self.FirstTrack = math.floor((self.IRadius) / self.Precision)
-	for i=self.FirstTrack,self.DiskTracks-1 do
+	for i=self.FirstTrack,self.DiskTracks do
 		self.TrackSectors[i] = self.DiskSectors
 		self.DiskSectors = self.DiskSectors + math.floor(2*3.1415926*i) + 1
 	end


### PR DESCRIPTION
The Wire CD reports the wrong number of usable tracks. At the moment, the medium CD model (models/venompapa/wirecd_medium.mdl) reports 8 tracks and 172 total sectors. There is no entry for track 8 in the entity's TrackSectors table which causes the CD Ray to give an erroneous sector index when attempting to read from it.

This change corrects this problem by reducing the total number of tracks on the disk by 1.