### PR TITLE
Add variadic user functions

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -262,6 +262,16 @@ function Compiler:GetMethod(instr, Name, Meta, Args)
 
 	if not Func then
 		Func = self:UDFunction(Name .. "(" .. Params .. ")")
+
+		if not Func then
+			for I = #Params, 0, -1 do
+				local sig = Name .. "(" .. Params:sub(1, I) .. "..r)"
+				if self.funcs_ret[sig] then
+					Func = self:UDFunction(sig)
+					break
+				end
+			end
+		end
 	end
 
 	if not Func then

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -824,7 +824,7 @@ function Compiler:InstrFUNCTION(args)
 		if VariadicType then
 			local nargs = #Args
 			-- There's 100% a better way to structure this mess but this works fine for now...
-			local offset = methodType and 1 or 0
+			local offset = methodType ~= "" and 1 or 0
 
 			for parameterIndex = 2, nargs do
 				local parameterExpression = runtimeArgs[parameterIndex]
@@ -848,6 +848,7 @@ function Compiler:InstrFUNCTION(args)
 					len = len + 1
 				end
 
+				tbl.size = len - 1
 				parameterValues[nargs] = tbl
 			else
 				-- Array

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -229,9 +229,13 @@ function Compiler:GetFunction(instr, Name, Args)
 
 		if not Func then
 			for I = #Params, 0, -1 do
-				local sig = Name .. "(" .. Params:sub(1, I) .. "..r)"
-				if self.funcs_ret[sig] then
-					Func = self:UDFunction(sig)
+				local sig = Name .. "(" .. Params:sub(1, I)
+				local arrsig, tblsig = sig .. "..r)", sig .. "..t)"
+				if self.funcs_ret[arrsig] then
+					Func = self:UDFunction(arrsig)
+					break
+				elseif self.funcs_ret[tblsig] then
+					Func = self:UDFunction(tblsig)
 					break
 				end
 			end
@@ -265,9 +269,13 @@ function Compiler:GetMethod(instr, Name, Meta, Args)
 
 		if not Func then
 			for I = #Params, 0, -1 do
-				local sig = Name .. "(" .. Params:sub(1, I) .. "..r)"
-				if self.funcs_ret[sig] then
-					Func = self:UDFunction(sig)
+				local sig = Name .. "(" .. Params:sub(1, I)
+				local arrsig, tblsig = sig .. "..r)", sig .. "..t)"
+				if self.funcs_ret[arrsig] then
+					Func = self:UDFunction(arrsig)
+					break
+				elseif self.funcs_ret[tblsig] then
+					Func = self:UDFunction(tblsig)
 					break
 				end
 			end
@@ -772,11 +780,20 @@ function Compiler:InstrFUNCTION(args)
 	self:InitScope() -- Create a new Scope Enviroment
 	self:PushScope()
 
-	local IsVariadic
+	local VariadicType
 	for _, D in pairs(Args) do
 		local Name, Type, Variadic = D[1], wire_expression_types[D[2]][1], D[3]
-		IsVariadic = Variadic -- Variadic param will be last (so no need to check if false)
+		VariadicType = Variadic and Type
 		self:SetLocalVariableType(Name, Type, args)
+	end
+
+	if VariadicType then
+		-- Don't allow users to define two functions with different variadic types
+		-- Because that'd cause ambiguity.
+		local opposite = VariadicType == "r" and "t" or "r"
+		if self.funcs_ret[Sig:gsub("%.%." .. VariadicType, ".." .. opposite)] then
+			self:Error("Cannot override variadic " .. tps_pretty(opposite) .. " function with variadic " .. tps_pretty(VariadicType) .. " function to avoid ambiguity.", args)
+		end
 	end
 
 	if self.funcs_ret[Sig] and self.funcs_ret[Sig] ~= Return then
@@ -795,7 +812,7 @@ function Compiler:InstrFUNCTION(args)
 	self:PopScope()
 	self:LoadScopes(OldScopes) -- Reload the old enviroment
 
-	self.prfcounter = self.prfcounter + (IsVariadic and 80 or 40)
+	self.prfcounter = self.prfcounter + (VariadicType and 80 or 40)
 
 	-- This is the function that will be bound to to the function name, ie. the
 	-- one that's called at runtime when code calls the function
@@ -804,8 +821,10 @@ function Compiler:InstrFUNCTION(args)
 		-- we need to evaluate the arguments before switching to the new scope
 
 		local parameterValues = {}
-		if IsVariadic then
+		if VariadicType then
 			local nargs = #Args
+			-- There's 100% a better way to structure this mess but this works fine for now...
+			local offset = methodType and 1 or 0
 
 			for parameterIndex = 2, nargs do
 				local parameterExpression = runtimeArgs[parameterIndex]
@@ -813,26 +832,45 @@ function Compiler:InstrFUNCTION(args)
 				parameterValues[parameterIndex - 1] = parameterValue
 			end
 
-			-- Construct array here w/ dynamic values
-			local arr, len = {}, 1
 			local types = runtimeArgs[#runtimeArgs]
+			if VariadicType == "t" then
+				-- Table argument.
+				local tbl, len = E2Lib.newE2Table(), 1
+				local n, ntypes = tbl.n, tbl.ntypes
 
-			for parameterIndex = nargs + 1, #runtimeArgs - 1 do
-				local ty = types[nargs - 1 + len]
-				if BLOCKED_ARRAY_TYPES[ty] then
-					self:throw("Cannot use type " .. tps_pretty(ty) .. " as an argument for variadic array function", nil)
-					break
+				for parameterIndex = nargs + 1, #runtimeArgs - 1 do
+					local ty = types[nargs - 1 - offset + len]
+
+					local parameterExpression = runtimeArgs[parameterIndex]
+					local parameterValue = parameterExpression[1](self, parameterExpression)
+
+					n[len], ntypes[len] = parameterValue, ty
+					len = len + 1
 				end
 
-				local parameterExpression = runtimeArgs[parameterIndex]
-				local parameterValue = parameterExpression[1](self, parameterExpression)
+				parameterValues[nargs] = tbl
+			else
+				-- Array
+				-- Construct array here w/ dynamic values
+				local arr, len = {}, 1
 
-				arr[len] = parameterValue
-				len = len + 1
+				for parameterIndex = nargs + 1, #runtimeArgs - 1 do
+					local ty = types[nargs - 1 - offset + len]
+
+					if BLOCKED_ARRAY_TYPES[ty] then
+						self:throw("Cannot use type " .. tps_pretty(ty) .. " as an argument for variadic array function", nil)
+						break
+					end
+
+					local parameterExpression = runtimeArgs[parameterIndex]
+					local parameterValue = parameterExpression[1](self, parameterExpression)
+
+					arr[len] = parameterValue
+					len = len + 1
+				end
+
+				parameterValues[nargs] = arr
 			end
-
-			-- Final value is an array for variadic functions
-			parameterValues[nargs] = arr
 		else
 			for parameterIndex = 2, #Args + 1 do
 				local parameterExpression = runtimeArgs[parameterIndex]

--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -666,6 +666,11 @@ function Parser:Stmt10()
 
 		if wire_expression2_funcs[Sig] then self:Error("Function '" .. Sig .. "' already exists") end
 
+		-- Variadic signatures for lua created functions are ..., while user defined ones use ..<t>.
+		-- Check if ... functions exist as to not essentially override them
+		local lua_variadic_sig = string.gsub(Sig, "%.%.[rt]", "...")
+		if wire_expression2_funcs[lua_variadic_sig] then self:Error("Can't override function " .. lua_variadic_sig .. " with user defined variadic function " .. Sig) end
+
 		local Inst = self:Instruction(Trace, "function", Sig, Return, Type, Args, self:Block("function declaration"))
 
 		return Inst

--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -804,9 +804,8 @@ function Parser:FunctionArgs(Temp, Args)
 					self:Error("Invalid type specified")
 				end
 
-				if type ~= "ARRAY" then
-					-- in the future might want to support table for named arguments like in python or something.
-					self:Error("Only array type is supported for spread arguments")
+				if type ~= "ARRAY" and type ~= "TABLE" then
+					self:Error("Only array or table type is supported for spread arguments")
 				end
 
 				if self:AcceptRoamingToken("com") then

--- a/lua/entities/gmod_wire_expression2/core/array.lua
+++ b/lua/entities/gmod_wire_expression2/core/array.lua
@@ -12,11 +12,7 @@ local table_insert = table.insert
 local table_remove = table.remove
 local floor = math.floor
 
-local blocked_types = {
-	["t"] = true,
-	["r"] = true,
-	["xgt"] = true
-}
+local blocked_types = E2Lib.blocked_array_types
 
 -- Fix return values
 local fixDefault = E2Lib.fixDefault

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -346,6 +346,7 @@ E2Lib.optable_inv = {
 	dlt = "$",
 	trg = "~",
 	imp = "->",
+	spread = "..."
 }
 
 E2Lib.optable = {}

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -101,8 +101,9 @@ function E2Lib.splitType(args)
 			thistype = ret[1]
 			ret = {}
 		elseif letter == "." then
-			if args:sub(i) ~= "..." then error("Misplaced '.' in args", 2) end
-			table.insert(ret, "...")
+			local slice = args:sub(i)
+			if slice ~= "..." and slice ~= "..r" then error("Misplaced '.' in args", 2) end
+			table.insert(ret, slice)
 			i = i + 2
 		elseif letter == "=" then
 			if #ret ~= 1 then error("Misplaced '=' in args", 2) end

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -385,6 +385,12 @@ function E2Lib.printops()
 	print("}")
 end
 
+E2Lib.blocked_array_types = {
+	["t"] = true,
+	["r"] = true,
+	["xgt"] = true
+}
+
 -- ------------------------------ string stuff ---------------------------------
 
 -- limits the given string to the given length and adds "..." to the end if too long.

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -102,7 +102,7 @@ function E2Lib.splitType(args)
 			ret = {}
 		elseif letter == "." then
 			local slice = args:sub(i)
-			if slice ~= "..." and slice ~= "..r" then error("Misplaced '.' in args", 2) end
+			if slice ~= "..." and slice ~= "..r" and slice ~= "..t" then error("Misplaced '.' in args", 2) end
 			table.insert(ret, slice)
 			i = i + 2
 		elseif letter == "=" then

--- a/lua/wire/client/text_editor/modes/e2.lua
+++ b/lua/wire/client/text_editor/modes/e2.lua
@@ -81,7 +81,6 @@ end
 local cols = {}
 local lastcol
 local function addToken(tokenname, tokendata)
-	if tokendata == "+" or tokendata == "..." then print(tokendata) debug.Trace() end
 	local color = colors[tokenname]
 	if lastcol and color == lastcol[2] then
 		lastcol[1] = lastcol[1] .. tokendata

--- a/lua/wire/client/text_editor/modes/e2.lua
+++ b/lua/wire/client/text_editor/modes/e2.lua
@@ -81,6 +81,7 @@ end
 local cols = {}
 local lastcol
 local function addToken(tokenname, tokendata)
+	if tokendata == "+" or tokendata == "..." then print(tokendata) debug.Trace() end
 	local color = colors[tokenname]
 	if lastcol and color == lastcol[2] then
 		lastcol[1] = lastcol[1] .. tokendata
@@ -341,6 +342,10 @@ function EDITOR:SyntaxColorLine(row)
 
 				local spaces = self:SkipPattern( " *" )
 				if spaces then addToken( "comment", spaces ) end
+
+				-- Exception for the spread "..." operator
+				local dots = self:SkipPattern( "%.%.%." )
+				if dots then addToken( "operator", dots ) end
 
 				local invalidInput = self:SkipPattern( "[^A-Z:%[]*" )
 				if invalidInput then addToken( "notfound", invalidInput ) end


### PR DESCRIPTION
Resolves #1735 

This adds variadic/rest parameters to E2 that just desugars to an array.
In the future we could also give access to key value pairs for user defined functions like python's kwargs that would desugar to a table, but I don't want to make this PR too big so this just provides the array part.

If you give values that aren't allowed in arrays (e.g. table or arrays) then it will throw a runtime error (on ``@strict`` at least. Maybe it should be forced, or be done at compile time).

![image](https://user-images.githubusercontent.com/56230599/174423419-d76846c5-32b9-4278-983f-c71473bff4b1.png)

```golo
local MSG_PREFIX = array(vec(0, 172, 0), "[neat] ", vec(255))

function void printMessage(...Args:array) {
	printColor(MSG_PREFIX:add(Args))
}

printMessage("Cool! Here's a number: ", randint(1, 27), ".")
```

```golo
function void entity:applyForces(...Forces:table) {
	foreach (K:number, Force:vector = Forces) {
		This:applyForce(Force)
	}
}
```