### PR TITLE
Assert array contents are valid at compile time

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -455,14 +455,13 @@ function Compiler:InstrCALL(args)
 			if BLOCKED_ARRAY_TYPES[tp] then
 				self:Error("Cannot have type " .. tps_pretty(tp) .. " in array creation argument #" .. i, args[4][i])
 			end
-			tps[#tps + 1] = tp
-			exprs[#exprs + 1] = ex
+
+			exprs[i + 1] = ex
+			tps[i] = tp
 		end
 	else
 		for i = 1, #args[4] do
-			local ex, tp = self:Evaluate(args[4], i - 2)
-			tps[#tps + 1] = tp
-			exprs[#exprs + 1] = ex
+			exprs[i + 1], tps[i] = self:Evaluate(args[4], i - 2)
 		end
 	end
 

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -447,10 +447,23 @@ function Compiler:InstrCALL(args)
 	local exprs = { false }
 
 	local tps = {}
-	for i = 1, #args[4] do
-		local ex, tp = self:Evaluate(args[4], i - 2)
-		tps[#tps + 1] = tp
-		exprs[#exprs + 1] = ex
+	if args[3] == "array" then
+		-- Hack for array creation.
+		-- Check if illegal arguments are passed
+		for i = 1, #args[4] do
+			local ex, tp = self:Evaluate(args[4], i - 2)
+			if BLOCKED_ARRAY_TYPES[tp] then
+				self:Error("Cannot have type " .. tps_pretty(tp) .. " in array creation argument #" .. i, args[4][i])
+			end
+			tps[#tps + 1] = tp
+			exprs[#exprs + 1] = ex
+		end
+	else
+		for i = 1, #args[4] do
+			local ex, tp = self:Evaluate(args[4], i - 2)
+			tps[#tps + 1] = tp
+			exprs[#exprs + 1] = ex
+		end
 	end
 
 	local rt = self:GetFunction(args, args[3], tps)
@@ -977,6 +990,10 @@ function Compiler:InstrKVARRAY(args)
 		local key, type = self:CallInstruction(k[1], k)
 		if type == "n" then
 			local value, type = self:CallInstruction(v[1], v)
+			if BLOCKED_ARRAY_TYPES[type] then
+				self:Error("Cannot have type " .. tps_pretty(type) .. " in array creation for keyvalue", v)
+			end
+
 			values[key] = value
 			types[key] = type
 		else

--- a/lua/entities/gmod_wire_expression2/core/array.lua
+++ b/lua/entities/gmod_wire_expression2/core/array.lua
@@ -49,11 +49,14 @@ registerType("array", "r", {},
 __e2setcost(1)
 e2function array array(...)
 	local ret = {...}
-	if (#ret == 0) then return {} end -- This is in place of the old "array()" function (now deleted because array(...) overwrote it)
-	for k,v in pairs( ret ) do
+	if #ret == 0 then return {} end -- This is in place of the old "array()" function (now deleted because array(...) overwrote it)
+
+	-- Assume the arguments passed to the array do not contain illegal array types,
+	-- from the compile time checks.
+	for _ in pairs( ret ) do
 		self.prf = self.prf + 1/3
-		if (blocked_types[typeids[k]]) then ret[k] = nil end
 	end
+
 	return ret
 end
 
@@ -64,14 +67,12 @@ registerOperator( "kvarray", "", "r", function( self, args )
 	local types = args[3]
 
 	for k,v in pairs( values ) do
-		if not blocked_types[types[k]] then
-			local key = k[1]( self, k )
-			local value = v[1]( self, v )
+		local key = k[1]( self, k )
+		local value = v[1]( self, v )
 
-			ret[key] = value
+		ret[key] = value
 
-			self.prf = self.prf + 1/3
-		end
+		self.prf = self.prf + 1/3
 	end
 
 	return ret

--- a/lua/entities/gmod_wire_expression2/core/array.lua
+++ b/lua/entities/gmod_wire_expression2/core/array.lua
@@ -48,25 +48,21 @@ registerType("array", "r", {},
 --------------------------------------------------------------------------------
 __e2setcost(1)
 e2function array array(...)
-	local ret = {...}
-	if #ret == 0 then return {} end -- This is in place of the old "array()" function (now deleted because array(...) overwrote it)
+	local len = select("#", ...)
+	if len == 0 then return {} end -- This is in place of the old "array()" function (now deleted because array(...) overwrote it)
 
 	-- Assume the arguments passed to the array do not contain illegal array types,
 	-- from the compile time checks.
-	for _ in pairs( ret ) do
-		self.prf = self.prf + 1/3
-	end
+	self.prf = self.prf + len * (1 / 4)
 
-	return ret
+	return {...}
 end
 
 registerOperator( "kvarray", "", "r", function( self, args )
 	local ret = {}
-
 	local values = args[2]
-	local types = args[3]
 
-	for k,v in pairs( values ) do
+	for k, v in pairs( values ) do
 		local key = k[1]( self, k )
 		local value = v[1]( self, v )
 

--- a/lua/entities/gmod_wire_expression2/core/strfunc.lua
+++ b/lua/entities/gmod_wire_expression2/core/strfunc.lua
@@ -116,6 +116,8 @@ end
 
 __e2setcost(5)
 
+local BLOCKED_ARRAY_TYPES = E2Lib.blocked_array_types
+
 registerOperator( "stringcall", "", "", function(self, args)
 	local op1, funcargs, typeids, typeids_str, returntype = args[2], args[3], args[4], args[5], args[6]
 	local funcname = op1[1](self,op1)
@@ -129,6 +131,25 @@ registerOperator( "stringcall", "", "", function(self, args)
 	end
 
 	if returntype ~= "" then
+		if funcname == "array" then
+			local types = funcargs[#funcargs]
+
+			local k = 1
+
+			local ty = types[k]
+			while ty do
+				if BLOCKED_ARRAY_TYPES[ty] then
+					table.remove(types, k)
+					table.remove(funcargs, k + 1)
+
+					self:throw("Cannot use type " .. tps_pretty(ty) .. " for argument #" .. k .. " in stringcall array creation")
+				else
+					k = k + 1
+				end
+
+				ty = types[k]
+			end
+		end
 		local ret = func( self, funcargs )
 		return ret
 	else


### PR DESCRIPTION
Now arrays will be checked if they contain types they are not allowed to hold at compile time. Runtime checks have been removed so this should optimize array creation a bit. This affects base E2 (does not need ``@strict``) since you shouldn't have been making arrays like that anyways.

(Actually) resolves https://github.com/wiremod/wire/issues/1181 a bit nicer

![image](https://user-images.githubusercontent.com/56230599/178590296-cdf52e72-a19d-41dd-a842-01be763973d7.png)
![image](https://user-images.githubusercontent.com/56230599/178590362-050a7975-a04f-4c0d-b06e-d6db679e2966.png)
