### PR TITLE
string foreach operators

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -36,6 +36,7 @@ end)
 
 /******************************************************************************/
 
+local string_sub = string.sub
 registerOperator("fea", "nss", "", function(self, args)
 	local keyname, valname = args[2], args[3]
 	local str = args[4]
@@ -44,7 +45,7 @@ registerOperator("fea", "nss", "", function(self, args)
 	local statement = args[5]
 
 	for key=1, #str do
-		local value = str[key]
+		local value = string_sub(str, key, key)
 		self:PushScope()
 
 		self.prf = self.prf + 1

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -38,14 +38,14 @@ end)
 
 registerOperator("fea", "nss", "", function(self, args)
 	local keyname, valname = args[2], args[3]
-
+	local sub = utf8.sub
 	local str = args[4]
 	str = str[1](self, str)
 
 	local statement = args[5]
 
 	for key=1, #str do
-		local value = str[key]
+		local value = sub(str,key,key)
 		if type(value) == 'string' then
 			self:PushScope()
 

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -38,69 +38,63 @@ end)
 
 registerOperator("fea", "nss", "", function(self, args)
 	local keyname, valname = args[2], args[3]
-	local sub = utf8.sub
 	local str = args[4]
 	str = str[1](self, str)
 
 	local statement = args[5]
 
 	for key=1, #str do
-		local value = sub(str,key,key)
-		if type(value) == 'string' then
-			self:PushScope()
+		local value = str[key]
+		self:PushScope()
 
-			self.prf = self.prf + 1
+		self.prf = self.prf + 1
 
-			self.Scope.vclk[keyname] = true
-			self.Scope.vclk[valname] = true
+		self.Scope.vclk[keyname] = true
+		self.Scope.vclk[valname] = true
 
-			self.Scope[keyname] = key
-			self.Scope[valname] = value
+		self.Scope[keyname] = key
+		self.Scope[valname] = value
 
-			local ok, msg = pcall(statement[1], self, statement)
+		local ok, msg = pcall(statement[1], self, statement)
 
-			if not ok then
-				if msg == "break" then	self:PopScope() break
-				elseif msg ~= "continue" then self:PopScope() error(msg, 0) end
-			end
-
-			self:PopScope()
+		if not ok then
+			if msg == "break" then	self:PopScope() break
+			elseif msg ~= "continue" then self:PopScope() error(msg, 0) end
 		end
+
+		self:PopScope()
 	end
 end)
 
+local string_byte = string.byte
 registerOperator("fea", "nns", "", function(self, args)
 	local keyname, valname = args[2], args[3]
-	local byte = string.byte
 
 	local str = args[4]
 	str = str[1](self, str)
 
 	local statement = args[5]
-	PrintTable(args)
 
 	for key=1, #str do
-		local value = byte(str,key,key)
-		if type(value) == 'number' then
-			self:PushScope()
+		local value = string_byte(str,key,key)
+		self:PushScope()
 
-			self.prf = self.prf + 1
+		self.prf = self.prf + 1
 
-			self.Scope.vclk[keyname] = true
-			self.Scope.vclk[valname] = true
+		self.Scope.vclk[keyname] = true
+		self.Scope.vclk[valname] = true
 
-			self.Scope[keyname] = key
-			self.Scope[valname] = value
+		self.Scope[keyname] = key
+		self.Scope[valname] = value
 
-			local ok, msg = pcall(statement[1], self, statement)
+		local ok, msg = pcall(statement[1], self, statement)
 
-			if not ok then
-				if msg == "break" then	self:PopScope() break
-				elseif msg ~= "continue" then self:PopScope() error(msg, 0) end
-			end
-
-			self:PopScope()
+		if not ok then
+			if msg == "break" then	self:PopScope() break
+			elseif msg ~= "continue" then self:PopScope() error(msg, 0) end
 		end
+
+		self:PopScope()
 	end
 end)
 

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -69,6 +69,41 @@ registerOperator("fea", "nss", "", function(self, args)
 	end
 end)
 
+registerOperator("fea", "nns", "", function(self, args)
+	local keyname, valname = args[2], args[3]
+	local byte = string.byte
+
+	local str = args[4]
+	str = str[1](self, str)
+
+	local statement = args[5]
+	PrintTable(args)
+
+	for key=1, #str do
+		local value = byte(str,key,key)
+		if type(value) == 'number' then
+			self:PushScope()
+
+			self.prf = self.prf + 1
+
+			self.Scope.vclk[keyname] = true
+			self.Scope.vclk[valname] = true
+
+			self.Scope[keyname] = key
+			self.Scope[valname] = value
+
+			local ok, msg = pcall(statement[1], self, statement)
+
+			if not ok then
+				if msg == "break" then	self:PopScope() break
+				elseif msg ~= "continue" then self:PopScope() error(msg, 0) end
+			end
+
+			self:PopScope()
+		end
+	end
+end)
+
 /******************************************************************************/
 
 registerOperator("is", "s", "n", function(self, args)

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -40,7 +40,7 @@ registerOperator("fea", "nss", "", function(self, args)
 	local keyname, valname = args[2], args[3]
 
 	local str = args[4]
-	str = str[1](self, tbl)
+	str = str[1](self, str)
 
 	local statement = args[5]
 

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -36,6 +36,41 @@ end)
 
 /******************************************************************************/
 
+registerOperator("fea", "nss", "", function(self, args)
+	local keyname, valname = args[2], args[3]
+
+	local str = args[4]
+	str = str[1](self, tbl)
+
+	local statement = args[5]
+
+	for key=1, #str do
+		local value = str[key]
+		if type(value) == 'string' then
+			self:PushScope()
+
+			self.prf = self.prf + 1
+
+			self.Scope.vclk[keyname] = true
+			self.Scope.vclk[valname] = true
+
+			self.Scope[keyname] = key
+			self.Scope[valname] = value
+
+			local ok, msg = pcall(statement[1], self, statement)
+
+			if not ok then
+				if msg == "break" then	self:PopScope() break
+				elseif msg ~= "continue" then self:PopScope() error(msg, 0) end
+			end
+
+			self:PopScope()
+		end
+	end
+end)
+
+/******************************************************************************/
+
 registerOperator("is", "s", "n", function(self, args)
 	local op1 = args[2]
 	local rv1 = op1[1](self, op1)


### PR DESCRIPTION
#### This introduces two foreach operators for strings: one for characters and one for bytes.
```golo
### Test 1
Buffer = ""
foreach(N,Char:string = "wtf string foreach??"){
    Buffer = Buffer + Char
}
print(Buffer) # "wtf string foreach??"

### Test 2
Buffer = ""
foreach(N,Char:number = "bytes too!?"){
    Buffer = Buffer + Char + ", "
}
print(Buffer + "0") # "98, 121, 116, 101, 115, 32, 116, 111, 111, 33, 63, 0"


### Example 1
Lol = "You're mocking me, aren't you?"
Buffer = ""
foreach(N,Char:string = Lol){
    if(N%2){ Buffer = Buffer + Char:upper() }
    else{ Buffer = Buffer + Char:lower() }
}
print(Buffer)

### Example 2
Checksum = 0
foreach(N,Byte:number = "I really hope nobody tampers with this string!"){
    Checksum += Byte
}
if(Checksum != 4369){ print("someone modified example 2!") }
```
I mean like, strings are basically arrays anyway, so why not let foreach work on them too?