### PR TITLE
Fix bootleg detonator damaging method

### DIFF
--- a/lua/entities/gmod_wire_detonator.lua
+++ b/lua/entities/gmod_wire_detonator.lua
@@ -38,13 +38,7 @@ end
 
 function ENT:DoDamage()
 	if self.target and self.target:IsValid() then
-		local dmg = DamageInfo()
-		dmg:SetDamage(self.damage)
-		dmg:SetDamageType(DMG_GENERIC)
-		dmg:SetAttacker(self:GetPlayer())
-		dmg:SetInflictor(self)
-		
-		self.target:TakeDamageInfo(dmg)
+		self.target:TakeDamage(self.damage, self:GetPlayer(), self)
 	end
 
 	local effectdata = EffectData()

--- a/lua/entities/gmod_wire_detonator.lua
+++ b/lua/entities/gmod_wire_detonator.lua
@@ -40,7 +40,7 @@ function ENT:DoDamage()
 	if self.target and self.target:IsValid() then
 		local dmg = DamageInfo()
 		dmg:SetDamage(self.damage)
-		dmg:SetDamageType(DMG_BLAST)
+		dmg:SetDamageType(DMG_GENERIC)
 		dmg:SetAttacker(self:GetPlayer())
 		dmg:SetInflictor(self)
 		

--- a/lua/entities/gmod_wire_detonator.lua
+++ b/lua/entities/gmod_wire_detonator.lua
@@ -37,14 +37,14 @@ function ENT:ShowOutput( Trigger )
 end
 
 function ENT:DoDamage()
-	if self.target and self.target:IsValid() and self.target:Health() > 0 then
-		if self.target:Health() <= self.damage then
-			self.target:SetHealth(0)
-			self.target:Fire( "break", "", 0 )
-			self.target:Fire( "kill", "", 0.2 )
-		else
-			self.target:SetHealth( self.target:Health() - self.damage )
-		end
+	if self.target and self.target:IsValid() then
+		local dmg = DamageInfo()
+		dmg:SetDamage(self.damage)
+		dmg:SetDamageType(DMG_BLAST)
+		dmg:SetAttacker(self:GetPlayer())
+		dmg:SetInflictor(self)
+		
+		self.target:TakeDamageInfo(dmg)
 	end
 
 	local effectdata = EffectData()


### PR DESCRIPTION
replaced the input-fire-based prop breaking with TakeDamageInfo, no cons as far as i know given that Detonator is meant for breakable props

the old method doesn't account for stuff like prop damage addons, which happens to be something i'm working on