### PR TITLE
Update gmod_wire_socket.lua

### DIFF
--- a/lua/entities/gmod_wire_socket.lua
+++ b/lua/entities/gmod_wire_socket.lua
@@ -54,7 +54,7 @@ function ENT:GetClosestPlug()
 	local ClosestDist
 	local Closest
 
-	for k,v in pairs( plugs ) do
+	for k,v in ipairs( plugs ) do
 		if (v:GetClass() == self:GetPlugClass() and not v:GetLinked()) then
 			local Dist = v:GetPos():Distance( Pos )
 			if (ClosestDist == nil or ClosestDist > Dist) then


### PR DESCRIPTION
ents.FindInSphere will always return a sequential table, so ipairs should be used here.