### PR TITLE
Add ``@strict`` to the default E2 text

### DIFF
--- a/lua/wire/client/text_editor/wire_expression2_editor.lua
+++ b/lua/wire/client/text_editor/wire_expression2_editor.lua
@@ -932,7 +932,7 @@ function Editor:InitComponents()
 end
 
 -- code1 contains the code that is not to be marked
-local code1 = "@name \n@inputs \n@outputs \n@persist \n@trigger \n@strict \n\n"
+local code1 = "@name \n@inputs \n@outputs \n@persist \n@trigger \n@strict\n\n"
 -- code2 contains the code that is to be marked, so it can simply be overwritten or deleted.
 local code2 = [[#[
     Documentation and examples are available at:

--- a/lua/wire/client/text_editor/wire_expression2_editor.lua
+++ b/lua/wire/client/text_editor/wire_expression2_editor.lua
@@ -937,6 +937,7 @@ local code1 = "@name \n@inputs \n@outputs \n@persist \n@trigger \n@strict\n\n"
 local code2 = [[#[
     Documentation and examples are available at:
     https://github.com/wiremod/wire/wiki/Expression-2
+    ^ Read what @strict and other directives do here ^
 
     Discord is available at https://discord.gg/H8UKY3Y
     Reddit is available at https://www.reddit.com/r/wiremod

--- a/lua/wire/client/text_editor/wire_expression2_editor.lua
+++ b/lua/wire/client/text_editor/wire_expression2_editor.lua
@@ -932,7 +932,7 @@ function Editor:InitComponents()
 end
 
 -- code1 contains the code that is not to be marked
-local code1 = "@name \n@inputs \n@outputs \n@persist \n@trigger \n\n"
+local code1 = "@name \n@inputs \n@outputs \n@persist \n@trigger \n@strict \n\n"
 -- code2 contains the code that is to be marked, so it can simply be overwritten or deleted.
 local code2 = [[#[
     Documentation and examples are available at:


### PR DESCRIPTION
Pretty sure the feature has been out for long enough to know it won't cause errors and people can just remove it from the top anyway.