### PR TITLE
making shell script POSIX

### DIFF
--- a/generate-luacheck.sh
+++ b/generate-luacheck.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 


### PR DESCRIPTION
Making script POSIX compliant.
This will use the shell that the user have set.
If you installed fx 'dash' witch is allegedly 4x faster than bash, it will use that.