### PR TITLE
Add warnings & attributes system

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -332,7 +332,7 @@ function Compiler:InstrSEQ(args)
 		else
 			local stmt, _, instr, extra = self:EvaluateStatement(args, i)
 			if instr == "CALL" or instr == "METHODCALL" then
-				if extra.nodiscard then
+				if extra and extra.nodiscard then
 					self:Warning("The return value of this function cannot be discarded", args[i + 2])
 				end
 			elseif instr == "GET" then

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -480,7 +480,7 @@ function Compiler:InstrCALL(args)
 			elseif instr == "VAR" then
 				local varname = args[4][i][3]
 				if self.inputs[varname] then
-					self:Warning("Using changed on an input is bad, use the ~ operator instead", args[4][i])
+					self:Warning("Using changed on an input is bad, use the ~ or -> operators instead", args[4][i])
 				end
 			end
 			exprs[i + 1], tps[i] = ex, tp

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -1136,7 +1136,7 @@ function Compiler:InstrINCLU(args)
 
 			local nwarnings = #self.warnings[file]
 			if nwarnings ~= 0 then
-				self:Warning("include '" .. file .. "' has " .. nwarnings .. " warnings.", args)
+				self:Warning("include '" .. file .. "' has " .. nwarnings .. " warning(s).", args)
 			end
 		end
 

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -504,7 +504,7 @@ function Compiler:InstrCALL(args)
 	exprs[#exprs + 1] = tps
 
 	if rt[4] and rt[4].deprecated then
-		self:Warning("Use of deprecated function: " .. rt[3], args)
+		self:Warning("Use of deprecated function: " .. args[3] .. "(" .. tps_pretty(tps) .. ")", args)
 	end
 
 	return exprs, rt[2], rt[4]
@@ -556,7 +556,7 @@ function Compiler:InstrMETHODCALL(args)
 	exprs[#exprs + 1] = tps
 
 	if rt[4] and rt[4].deprecated then
-		self:Warning("Use of deprecated function: " .. rt[3], args)
+		self:Warning("Use of deprecated method: " .. tps_pretty(tp) .. ":" .. args[3] .. "(" .. tps_pretty(tps) .. ")", args)
 	end
 
 	return exprs, rt[2], rt[4]

--- a/lua/entities/gmod_wire_expression2/cl_init.lua
+++ b/lua/entities/gmod_wire_expression2/cl_init.lua
@@ -40,8 +40,6 @@ local function Include(e2, directives, includes, scripts)
 end
 
 function wire_expression2_validate(buffer)
-	-- removed CLIENT as this is client file
-	-- if CLIENT and
 	if not e2_function_data_received then return "Loading extensions. Please try again in a few seconds..." end
 
 	-- invoke preprocessor
@@ -50,10 +48,7 @@ function wire_expression2_validate(buffer)
 
 	-- decompose directives
 	local inports, outports, persists = directives.inputs, directives.outputs, directives.persist
-	-- removed CLIENT as this is client file
-	-- if CLIENT then
 	RunConsoleCommand("wire_expression2_scriptmodel", directives.model or "")
-	-- end
 
 	-- invoke tokenizer (=lexer)
 	local status, tokens = E2Lib.Tokenizer.Execute(buffer)
@@ -74,7 +69,7 @@ function wire_expression2_validate(buffer)
 	local status, script, instance = E2Lib.Compiler.Execute(tree, inports[3], outports[3], persists[3], dvars, scripts)
 	if not status then return script end
 
-	return nil, includes
+	return nil, includes, #instance.warnings ~= 0 and instance.warnings
 end
 
 -- string.GetTextSize shits itself if the string is both wide and tall,

--- a/lua/entities/gmod_wire_expression2/core/array.lua
+++ b/lua/entities/gmod_wire_expression2/core/array.lua
@@ -141,7 +141,7 @@ registerCallback( "postinit", function()
 				local op1, op2 = args[2], args[3]
 				local array, index = op1[1](self,op1), op2[1](self,op2)
 				return getter( self, array, index )
-			end)
+			end, nil, nil, { deprecated = true })
 
 			--------------------------------------------------------------------------------
 			-- Set functions
@@ -171,7 +171,7 @@ registerCallback( "postinit", function()
 				local op1, op2, op3 = args[2], args[3], args[4]
 				local array, index, value = op1[1](self,op1), op2[1](self,op2), op3[1](self,op3)
 				return setter( self, array, index, value )
-			end)
+			end, nil, nil, { deprecated = true })
 
 
 			--------------------------------------------------------------------------------

--- a/lua/entities/gmod_wire_expression2/core/color.lua
+++ b/lua/entities/gmod_wire_expression2/core/color.lua
@@ -248,14 +248,16 @@ converters[3] = function(r, g, b)
 end
 
 --- Converts an RGB vector <rgb> to a number in digital screen format. <mode> Specifies a mode, either 0, 2 or 3, corresponding to Digital Screen color modes.
-e2function(nodiscard) number rgb2digi(vector rgb, mode)
+[nodiscard]
+e2function number rgb2digi(vector rgb, mode)
 	local conv = converters[mode]
 	if not conv then return self:throw("Mode " .. mode .. " does not exist!", 0) end
 	return conv(rgb[1], rgb[2], rgb[3])
 end
 
 --- Converts the RGB color (<r>,<g>,<b>) to a number in digital screen format. <mode> Specifies a mode, either 0, 2 or 3, corresponding to Digital Screen color modes.
-e2function(nodiscard) number rgb2digi(r, g, b, mode)
+[nodiscard]
+e2function number rgb2digi(r, g, b, mode)
 	local conv = converters[mode]
 	if not conv then return self:throw("Mode " .. mode .. " does not exist!", 0) end
 	return conv(r, g, b)

--- a/lua/entities/gmod_wire_expression2/core/color.lua
+++ b/lua/entities/gmod_wire_expression2/core/color.lua
@@ -248,14 +248,14 @@ converters[3] = function(r, g, b)
 end
 
 --- Converts an RGB vector <rgb> to a number in digital screen format. <mode> Specifies a mode, either 0, 2 or 3, corresponding to Digital Screen color modes.
-e2function number rgb2digi(vector rgb, mode)
+e2function(nodiscard) number rgb2digi(vector rgb, mode)
 	local conv = converters[mode]
 	if not conv then return self:throw("Mode " .. mode .. " does not exist!", 0) end
 	return conv(rgb[1], rgb[2], rgb[3])
 end
 
 --- Converts the RGB color (<r>,<g>,<b>) to a number in digital screen format. <mode> Specifies a mode, either 0, 2 or 3, corresponding to Digital Screen color modes.
-e2function number rgb2digi(r, g, b, mode)
+e2function(nodiscard) number rgb2digi(r, g, b, mode)
 	local conv = converters[mode]
 	if not conv then return self:throw("Mode " .. mode .. " does not exist!", 0) end
 	return conv(r, g, b)

--- a/lua/entities/gmod_wire_expression2/core/constraint.lua
+++ b/lua/entities/gmod_wire_expression2/core/constraint.lua
@@ -180,7 +180,8 @@ end
 __e2setcost(20)
 
 --- Returns an '''array''' containing all entities directly or indirectly constrained to <this>, except <this> itself.
-e2function(deprecated) array entity:getConstraints()
+[deprecated, nodiscard]
+e2function array entity:getConstraints()
 	if not IsValid(this) then return self:throw("Invalid entity!", {}) end
 	if not constraint.HasConstraints(this) then return {} end
 
@@ -195,6 +196,7 @@ end
 	Returns an '''array''' constaining all entities directly or indirectly connected to <this>
 	supports filtering, see buildFilter above
 ]]
+[nodiscard]
 e2function array entity:getConnectedEntities(...filters)
 	if not IsValid(this) then return self:throw("Invalid entity!", {}) end
 	local result = getConnectedEntities(this,buildFilter(filters))

--- a/lua/entities/gmod_wire_expression2/core/constraint.lua
+++ b/lua/entities/gmod_wire_expression2/core/constraint.lua
@@ -180,7 +180,7 @@ end
 __e2setcost(20)
 
 --- Returns an '''array''' containing all entities directly or indirectly constrained to <this>, except <this> itself.
-e2function array entity:getConstraints()
+e2function(deprecated) array entity:getConstraints()
 	if not IsValid(this) then return self:throw("Invalid entity!", {}) end
 	if not constraint.HasConstraints(this) then return {} end
 

--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -444,14 +444,14 @@ e2function void entity:setPos(vector pos)
 	PropCore.PhysManipulate(this, pos, nil, nil, nil, nil)
 end
 
-e2function void entity:reposition(vector pos) = e2function void entity:setPos(vector pos)
+e2function(deprecated) void entity:reposition(vector pos) = e2function void entity:setPos(vector pos)
 
 e2function void entity:setAng(angle rot)
 	if not PropCore.ValidAction(self, this, "ang") then return end
 	PropCore.PhysManipulate(this, nil, rot, nil, nil, nil)
 end
 
-e2function void entity:rerotate(angle rot) = e2function void entity:setAng(angle rot)
+e2function(deprecated) void entity:rerotate(angle rot) = e2function void entity:setAng(angle rot)
 
 --------------------------------------------------------------------------------
 

--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -444,14 +444,16 @@ e2function void entity:setPos(vector pos)
 	PropCore.PhysManipulate(this, pos, nil, nil, nil, nil)
 end
 
-e2function(deprecated) void entity:reposition(vector pos) = e2function void entity:setPos(vector pos)
+[deprecated]
+e2function void entity:reposition(vector pos) = e2function void entity:setPos(vector pos)
 
 e2function void entity:setAng(angle rot)
 	if not PropCore.ValidAction(self, this, "ang") then return end
 	PropCore.PhysManipulate(this, nil, rot, nil, nil, nil)
 end
 
-e2function(deprecated) void entity:rerotate(angle rot) = e2function void entity:setAng(angle rot)
+[deprecated]
+e2function void entity:rerotate(angle rot) = e2function void entity:setAng(angle rot)
 
 --------------------------------------------------------------------------------
 

--- a/lua/entities/gmod_wire_expression2/core/extpp.lua
+++ b/lua/entities/gmod_wire_expression2/core/extpp.lua
@@ -221,16 +221,15 @@ function E2Lib.ExtPP.Pass2(contents)
 
 	-- This flag helps determine whether the preprocessor changed, so we can tell the environment about it.
 	local changed = false
-	for h_begin, attributes, ret, thistype, colon, name, args, whitespace, equals, h_end in contents:gmatch("()e2function%(?([%w,]*)%)?%s+(" .. p_typename .. ")%s+([a-z0-9]-)%s*(:?)%s*(" .. p_func_operator .. ")%(([^)]*)%)(%s*)(=?)()") do
+	for h_begin, attributes, ret, thistype, colon, name, args, whitespace, equals, h_end in contents:gmatch("()e2function%(?([%w, ]*)%)?%s+(" .. p_typename .. ")%s+([a-z0-9]-)%s*(:?)%s*(" .. p_func_operator .. ")%(([^)]*)%)(%s*)(=?)()") do
 		-- Convert attributes to a lookup table passed to registerFunction
 		if attributes ~= "" then
-			-- e2function(deprecated,nodiscard) void test()
-			-- Note nodiscard isn't a real attribute right now.
+			-- e2function(deprecated, nodiscard) void test()
 			attributes = attributes:Split(",")
 
 			local lookup = {}
 			for _, tag in ipairs(attributes) do
-				lookup[ tag:lower() ] = true
+				lookup[ tag:lower():Trim() ] = true
 			end
 
 			local buf = "{"

--- a/lua/entities/gmod_wire_expression2/core/globalvars.lua
+++ b/lua/entities/gmod_wire_expression2/core/globalvars.lua
@@ -269,23 +269,28 @@ end) -- postinit
 ------------------------------------------------
 __e2setcost(1)
 
-e2function(deprecated) void gSetGroup( string groupname )
+[deprecated]
+e2function void gSetGroup( string groupname )
 	self.data.gvars.group = groupname
 end
 
-e2function(deprecated) string gGetGroup()
+[deprecated]
+e2function string gGetGroup()
 	return self.data.gvars.group or ""
 end
 
-e2function(deprecated) void gShare( number share )
+[deprecated]
+e2function void gShare( number share )
 	self.data.gvars.shared = math.Clamp(share,0,1)
 end
 
-e2function(deprecated) number gGetShare()
+[deprecated]
+e2function number gGetShare()
 	return self.data.gvars.shared or 0
 end
 
-e2function(deprecated) void gResetGroup()
+[deprecated]
+e2function void gResetGroup()
 	self.data.gvars.group = "default"
 end
 

--- a/lua/entities/gmod_wire_expression2/core/globalvars.lua
+++ b/lua/entities/gmod_wire_expression2/core/globalvars.lua
@@ -261,7 +261,6 @@ registerCallback("postinit",function()
 	end -- loop
 end) -- postinit
 
-
 ------------------------------------------------------------------------------------------------
 -- ALL BELOW FUNCTIONS ARE DEPRECATED (Only for compability)
 ------------------------------------------------------------------------------------------------
@@ -270,23 +269,23 @@ end) -- postinit
 ------------------------------------------------
 __e2setcost(1)
 
-e2function void gSetGroup( string groupname )
+e2function(deprecated) void gSetGroup( string groupname )
 	self.data.gvars.group = groupname
 end
 
-e2function string gGetGroup()
+e2function(deprecated) string gGetGroup()
 	return self.data.gvars.group or ""
 end
 
-e2function void gShare( number share )
+e2function(deprecated) void gShare( number share )
 	self.data.gvars.shared = math.Clamp(share,0,1)
 end
 
-e2function number gGetShare()
+e2function(deprecated) number gGetShare()
 	return self.data.gvars.shared or 0
 end
 
-e2function void gResetGroup()
+e2function(deprecated) void gResetGroup()
 	self.data.gvars.group = "default"
 end
 

--- a/lua/entities/gmod_wire_expression2/core/wirelink.lua
+++ b/lua/entities/gmod_wire_expression2/core/wirelink.lua
@@ -396,7 +396,7 @@ e2function(deprecated) number wirelink:writeCell(address, value)
 	if this:WriteCell(address, value) then return 1 else return 0 end
 end
 
-e2function(deprecated) number wirelink:readCell(address)
+e2function(deprecated, nodiscard) number wirelink:readCell(address)
 	if not validWirelink(self, this) then return 0 end
 
 	if not this.ReadCell then return 0 end

--- a/lua/entities/gmod_wire_expression2/core/wirelink.lua
+++ b/lua/entities/gmod_wire_expression2/core/wirelink.lua
@@ -389,14 +389,16 @@ end
 
 __e2setcost(5) -- temporary
 
-e2function(deprecated) number wirelink:writeCell(address, value)
+[deprecated]
+e2function number wirelink:writeCell(address, value)
 	if not validWirelink(self, this) then return 0 end
 
 	if not this.WriteCell then return 0 end
 	if this:WriteCell(address, value) then return 1 else return 0 end
 end
 
-e2function(deprecated, nodiscard) number wirelink:readCell(address)
+[deprecated, nodiscard]
+e2function number wirelink:readCell(address)
 	if not validWirelink(self, this) then return 0 end
 
 	if not this.ReadCell then return 0 end

--- a/lua/entities/gmod_wire_expression2/core/wirelink.lua
+++ b/lua/entities/gmod_wire_expression2/core/wirelink.lua
@@ -389,14 +389,14 @@ end
 
 __e2setcost(5) -- temporary
 
-e2function number wirelink:writeCell(address, value)
+e2function(deprecated) number wirelink:writeCell(address, value)
 	if not validWirelink(self, this) then return 0 end
 
 	if not this.WriteCell then return 0 end
 	if this:WriteCell(address, value) then return 1 else return 0 end
 end
 
-e2function number wirelink:readCell(address)
+e2function(deprecated) number wirelink:readCell(address)
 	if not validWirelink(self, this) then return 0 end
 
 	if not this.ReadCell then return 0 end

--- a/lua/wire/client/text_editor/wire_expression2_editor.lua
+++ b/lua/wire/client/text_editor/wire_expression2_editor.lua
@@ -1612,11 +1612,27 @@ end
 
 function Editor:Validate(gotoerror)
 	if self.EditorType == "E2" then
-		local errors = wire_expression2_validate(self:GetCode())
+		local errors, _, warnings = wire_expression2_validate(self:GetCode())
 		if not errors then
-			self.C.Val:SetBGColor(0, 110, 20, 255)
-			self.C.Val:SetText("   Validation successful")
-			return true
+			if warnings then
+				self.C.Val:SetBGColor(150, 150, 0, 255)
+
+				local nwarnings = #warnings
+				local warning = table.remove(warnings, 1)
+
+				if gotoerror then
+					self.C.Val:SetText("   Warning (1/" .. nwarnings .. "): " .. warning.message)
+					self:GetCurrentEditor():SetCaret { warning.line, warning.char  }
+				else
+					self.C.Val:SetText("   Validated with " .. nwarnings .. " warning(s).")
+				end
+
+				return true
+			else
+				self.C.Val:SetBGColor(0, 110, 20, 255)
+				self.C.Val:SetText("   Validation successful")
+				return true
+			end
 		end
 		if gotoerror then
 			local row, col = errors:match("at line ([0-9]+), char ([0-9]+)$")

--- a/lua/wire/stools/expression2.lua
+++ b/lua/wire/stools/expression2.lua
@@ -709,10 +709,10 @@ elseif CLIENT then
 		if not code and not wire_expression2_editor then return end -- If the player leftclicks without opening the editor or cpanel (first spawn)
 		code = code or wire_expression2_editor:GetCode()
 		filepath = filepath or wire_expression2_editor:GetChosenFile()
-		local err, includes
+		local err, includes, warnings
 
 		if e2_function_data_received then
-			err, includes = wire_expression2_validate(code)
+			err, includes, warnings = wire_expression2_validate(code)
 			if err then
 				WireLib.AddNotify(err, NOTIFY_ERROR, 7, NOTIFYSOUND_ERROR1)
 				return


### PR DESCRIPTION
# Warnings
This PR adds warnings to the E2 Compiler, which are shown in the editor. This is a way to provide soft errors rather than backwards-incompatible changes, for deprecation, lints, etc.

When you first load the editor it will show you how many warnings were found (if any), and if you press the bar, or use ctrl+space, it will show you the first warning.  

In the future maybe the editor could be changed to underline where the warning is, or hover for the reason, but it isn't completely *necessary* here (and would be a lot of work) so I opted not to do it.

![image](https://user-images.githubusercontent.com/56230599/185822022-1d49ad77-a332-43fd-ad87-70e828df1a07.png)


## Implemented Warnings
### Unreachable Code
I reimplemented the unreachable code implementation from #2388, except now it throws a warning rather than an error. If unreachable code is detected additionally the compiler will ignore any statements in the sequence (``InstrSEQ``) to not waste compile time.

![image](https://user-images.githubusercontent.com/56230599/185822428-00f4985c-f3dd-4c90-b04d-33991642be0b.png)

### ``changed()`` on an input
The ``~`` operator exists for a reason, and not many people know about it, so now using changed on an input creates a warning.
![image](https://user-images.githubusercontent.com/56230599/185822507-d2f9cca9-5ea8-47c2-b0c3-f23bc700261f.png)

### ``changed()`` on a literal
If for some reason you do this, it will warn you.
![image](https://user-images.githubusercontent.com/56230599/185822628-402bec55-2262-4ed4-b849-f27bd0bd7176.png)

### Deprecated Functions
The biggest change here is adding warnings for deprecated functions.  
E2 for the longest time has been plagued by backwards compatibility, but hopefully this will be a step in the right direction toward making progress.

![image](https://user-images.githubusercontent.com/56230599/185822741-ef7fcf11-26b4-4361-a3da-7b4856770cc6.png)


# Attributes
The ``e2function`` preprocessor now also scans for attributes after the label, which allow you to mark a function as ``deprecated``, or stuff like ``nodiscard`` (if it is implemented in the future).

## Implemented Attributes

### ``deprecated``
This is necessary to signal to the compiler what is and isn't deprecated, since there isn't a solid documentation format like what starfall has to signal stuff.

### ``nodiscard``
* Annotates that a function's return value must be used (otherwise the function call would be pointless).
* Also implemented this for the GET instruction (aka XWL[K] or Tbl[K, T]). 

### Example (Outdated)
```lua
e2function(deprecated, nodiscard) array entity:getConstraints()
    ...
end
```

### New example
```lua
[deprecated, nodiscard, xyz = "zyx"]
e2function array entity:getConstraints()
    ...
end
```