### PR TITLE
Better checks for forcers

### DIFF
--- a/lua/entities/gmod_wire_forcer.lua
+++ b/lua/entities/gmod_wire_forcer.lua
@@ -71,9 +71,10 @@ function ENT:Think()
 
 	if not IsValid(trace.Entity) then return end
 	local convar_value = wire_forcer_permissions:GetInt()
-	if IsValid(self:GetPlayer()) and convar_value > 0 then
-		if convar_value == 2 and not gamemode.Call( "GravGunPickupAllowed", self:GetPlayer(), trace.Entity ) then return end
-		if convar_value == 1 and not gamemode.Call( "GravGunPunt", self:GetPlayer(), trace.Entity ) then return end
+	if convar_value==1 then
+		if not IsValid(self:GetPlayer()) or gamemode.Call( "GravGunPunt", self:GetPlayer(), trace.Entity )==false then return end
+	elseif convar_value==2 then
+		if not IsValid(self:GetPlayer()) or gamemode.Call( "GravGunPickupAllowed", self:GetPlayer(), trace.Entity )==false then return end
 	end
 
 	if trace.Entity:GetMoveType() == MOVETYPE_VPHYSICS then

--- a/lua/entities/gmod_wire_forcer.lua
+++ b/lua/entities/gmod_wire_forcer.lua
@@ -12,6 +12,8 @@ end
 
 if CLIENT then return end -- No more client
 
+local wire_forcer_permissions = CreateConVar( "wire_forcer_permissions", 1, FCVAR_ARCHIVE, "0 = no check for forcers, 1 = GravGunPunt, 2 = GravGunPickupAllowed", 0, 2)
+
 function ENT:Initialize()
 	self:PhysicsInit( SOLID_VPHYSICS )
 	self:SetMoveType( MOVETYPE_VPHYSICS )
@@ -68,7 +70,10 @@ function ENT:Think()
 	}
 
 	if not IsValid(trace.Entity) then return end
-	if IsValid(self:GetPlayer()) and not gamemode.Call( "GravGunPickupAllowed", self:GetPlayer(), trace.Entity ) then return end
+	local convar_value = wire_forcer_permissions:GetInt()
+	if IsValid(self:GetPlayer()) and convar_value > 0 then
+		if convar_value == 2 and not gamemode.Call( "GravGunPickupAllowed", self:GetPlayer(), trace.Entity ) or convar_value == 1 and not gamemode.Call( "GravGunPunt", self:GetPlayer(), trace.Entity ) then return end
+	end
 
 	if trace.Entity:GetMoveType() == MOVETYPE_VPHYSICS then
 		local phys = trace.Entity:GetPhysicsObject()

--- a/lua/entities/gmod_wire_forcer.lua
+++ b/lua/entities/gmod_wire_forcer.lua
@@ -68,7 +68,7 @@ function ENT:Think()
 	}
 
 	if not IsValid(trace.Entity) then return end
-	if IsValid(self:GetPlayer()) and not gamemode.Call( "GravGunPunt", self:GetPlayer(), trace.Entity ) then return end
+	if IsValid(self:GetPlayer()) and not gamemode.Call( "GravGunPickupAllowed", self:GetPlayer(), trace.Entity ) then return end
 
 	if trace.Entity:GetMoveType() == MOVETYPE_VPHYSICS then
 		local phys = trace.Entity:GetPhysicsObject()

--- a/lua/entities/gmod_wire_forcer.lua
+++ b/lua/entities/gmod_wire_forcer.lua
@@ -72,7 +72,8 @@ function ENT:Think()
 	if not IsValid(trace.Entity) then return end
 	local convar_value = wire_forcer_permissions:GetInt()
 	if IsValid(self:GetPlayer()) and convar_value > 0 then
-		if convar_value == 2 and not gamemode.Call( "GravGunPickupAllowed", self:GetPlayer(), trace.Entity ) or convar_value == 1 and not gamemode.Call( "GravGunPunt", self:GetPlayer(), trace.Entity ) then return end
+		if convar_value == 2 and not gamemode.Call( "GravGunPickupAllowed", self:GetPlayer(), trace.Entity ) then return end
+		if convar_value == 1 and not gamemode.Call( "GravGunPunt", self:GetPlayer(), trace.Entity ) then return end
 	end
 
 	if trace.Entity:GetMoveType() == MOVETYPE_VPHYSICS then


### PR DESCRIPTION
GravGunPunt usually returns true for most entities, but GravGunPickupAllowed is usually more restrictive and I think it makes more sense for this case.