### PR TITLE
Update wiring.lua

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/wiring.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/wiring.lua
@@ -119,10 +119,8 @@ __e2setcost(10)
 
 --- Links <this> to <ent2> if applicable
 e2function number entity:linkTo(entity ent2)
-	if not IsValid(this) then return self:throw("Invalid Entity!", 0) end
-	if not IsValid(ent2) then return self:throw("Invalid Entity!", 0) end
-	if not isOwner(self, this) then return self:throw("You do not own this entity", 0) end
-	if not isOwner(self, ent2) then return self:throw("You do not own this entity", 0) end
+	if not IsValid(this) or not IsValid(ent2) then return self:throw("Invalid Entity!", 0) end
+	if not isOwner(self, this) or not isOwner(self, ent2) then return self:throw("You do not own this entity", 0) end
 	
 	if not this.LinkEnt then return self:throw("Entity can't be linked", 0) end
 	return this:LinkEnt(ent2) and 1 or 0
@@ -130,10 +128,8 @@ end
 
 --- Unlinks <this> from <ent2> if applicable
 e2function number entity:unlinkFrom(entity ent2)
-	if not IsValid(this) then return self:throw("Invalid Entity!", 0) end
-	if not IsValid(ent2) then return self:throw("Invalid Entity!", 0) end
-	if not isOwner(self, this) then return self:throw("You do not own this entity", 0) end
-	if not isOwner(self, ent2) then return self:throw("You do not own this entity", 0) end
+	if not IsValid(this) or not IsValid(ent2) then return self:throw("Invalid Entity!", 0) end
+	if not isOwner(self, this) or not isOwner(self, ent2) then return self:throw("You do not own this entity", 0) end
 
 	if not this.UnlinkEnt then return self:throw("Entity can't be unlinked", 0) end
 	return this:UnlinkEnt(ent2) and 1 or 0

--- a/lua/entities/gmod_wire_expression2/core/custom/wiring.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/wiring.lua
@@ -138,3 +138,17 @@ e2function number entity:unlinkFrom(entity ent2)
 	if not this.UnlinkEnt then return self:throw("Entity can't be unlinked", 0) end
 	return this:UnlinkEnt(ent2) and 1 or 0
 end
+
+--- Clears <this>'s links if applicable 
+e2function void entity:clearLinks()
+	if not IsValid(this) then return self:throw("Invalid Entity!", nil) end
+	if not isOwner(self, this) then return self:throw("You do not own this entity!", nil) end
+
+	if this.ClearEntities then
+		this:ClearEntities()
+	elseif this.UnlinkEnt then
+		this:UnlinkEnt()
+	else 
+		self:throw("Entity links cannot be cleared!")
+	end
+end

--- a/lua/entities/gmod_wire_expression2/core/custom/wiring.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/wiring.lua
@@ -119,28 +119,22 @@ __e2setcost(10)
 
 --- Links <this> to <ent2> if applicable
 e2function number entity:linkTo(entity ent2)
-	if not IsValid(this) then return self:throw("Invalid Entity!", nil) end
-	if not IsValid(ent2) then return self:throw("Invalid Entity!", nil) end
-	if not isOwner(self, this) then return self:throw("You do not own this entity", nil) end
-	if not isOwner(self, ent2) then return self:throw("You do not own this entity", nil) end
+	if not IsValid(this) then return self:throw("Invalid Entity!", 0) end
+	if not IsValid(ent2) then return self:throw("Invalid Entity!", 0) end
+	if not isOwner(self, this) then return self:throw("You do not own this entity", 0) end
+	if not isOwner(self, ent2) then return self:throw("You do not own this entity", 0) end
 	
-	if ent2.LinkEnt then
-		local bool = ent2:LinkEnt(this)	
-		if bool == true then return 1 end
-	end
-	return 0
+	if not this.LinkEnt then return self:throw("Entity can't be linked", 0) end
+	return this:LinkEnt(ent2) and 1 or 0
 end
 
 --- Unlinks <this> from <ent2> if applicable
 e2function number entity:unlinkFrom(entity ent2)
-	if not IsValid(this) then return self:throw("Invalid Entity!", nil) end
-	if not IsValid(ent2) then return self:throw("Invalid Entity!", nil) end
-	if not isOwner(self, this) then return self:throw("You do not own this entity", nil) end
-	if not isOwner(self, ent2) then return self:throw("You do not own this entity", nil) end
+	if not IsValid(this) then return self:throw("Invalid Entity!", 0) end
+	if not IsValid(ent2) then return self:throw("Invalid Entity!", 0) end
+	if not isOwner(self, this) then return self:throw("You do not own this entity", 0) end
+	if not isOwner(self, ent2) then return self:throw("You do not own this entity", 0) end
 
-	if ent2.UnlinkEnt then
-		local bool = ent2:UnlinkEnt(this)
-		if bool == true then return 1 end
-	end
-	return 0
+	if not this.UnlinkEnt then return self:throw("Entity can't be unlinked", 0) end
+	return this:UnlinkEnt(ent2) and 1 or 0
 end

--- a/lua/entities/gmod_wire_expression2/core/custom/wiring.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/wiring.lua
@@ -123,9 +123,11 @@ e2function number entity:linkTo(entity ent2)
 	if not IsValid(ent2) then return self:throw("Invalid Entity!", nil) end
 	if not isOwner(self, this) then return self:throw("You do not own this entity", nil) end
 	if not isOwner(self, ent2) then return self:throw("You do not own this entity", nil) end
-
-	local error, result = pcall(function() ent2:LinkEnt(this) end)
-	if error == true then return 1 end
+	
+	if ent2.LinkEnt then
+		local bool = ent2:LinkEnt(this)	
+		if bool == true then return 1 end
+	end
 	return 0
 end
 
@@ -136,7 +138,9 @@ e2function number entity:unlinkFrom(entity ent2)
 	if not isOwner(self, this) then return self:throw("You do not own this entity", nil) end
 	if not isOwner(self, ent2) then return self:throw("You do not own this entity", nil) end
 
-	local error, result = pcall(function() ent2:UnlinkEnt(this) end)
-	if error == true then return 1 end
+	if ent2.UnlinkEnt then
+		local bool = ent2:UnlinkEnt(this)
+		if bool == true then return 1 end
+	end
 	return 0
 end

--- a/lua/entities/gmod_wire_expression2/core/custom/wiring.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/wiring.lua
@@ -114,3 +114,29 @@ e2function wirelink entity:wirelink()
 	end
 	return this
 end
+
+__e2setcost(10)
+
+--- Links <this> to <ent2> if applicable
+e2function number entity:linkTo(entity ent2)
+	if not IsValid(this) then return self:throw("Invalid Entity!", nil) end
+	if not IsValid(ent2) then return self:throw("Invalid Entity!", nil) end
+	if not isOwner(self, this) then return self:throw("You do not own this entity", nil) end
+	if not isOwner(self, ent2) then return self:throw("You do not own this entity", nil) end
+
+	local error, result = pcall(function() ent2:LinkEnt(this) end)
+	if error == true then return 1 end
+	return 0
+end
+
+--- Unlinks <this> from <ent2> if applicable
+e2function number entity:unlinkFrom(entity ent2)
+	if not IsValid(this) then return self:throw("Invalid Entity!", nil) end
+	if not IsValid(ent2) then return self:throw("Invalid Entity!", nil) end
+	if not isOwner(self, this) then return self:throw("You do not own this entity", nil) end
+	if not isOwner(self, ent2) then return self:throw("You do not own this entity", nil) end
+
+	local error, result = pcall(function() ent2:UnlinkEnt(this) end)
+	if error == true then return 1 end
+	return 0
+end


### PR DESCRIPTION
Added `e:linkTo(e)` and `e:unlinkFrom(e)` for entities with 'marks' such as the pod and cam controllers, freezer, adv entity marker etc.