### PR TITLE
Switch vector and angle types to use userdata types

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/angle.lua
+++ b/lua/entities/gmod_wire_expression2/core/angle.lua
@@ -112,7 +112,7 @@ end
 __e2setcost(2)
 
 e2function angle operator_neg(angle rv1)
-	return Angle(-rv1[1], -rv1[2], -rv1[3])
+	return -rv1
 end
 
 e2function angle operator+(rv1, angle rv2)
@@ -124,7 +124,7 @@ e2function angle operator+(angle rv1, rv2)
 end
 
 e2function angle operator+(angle rv1, angle rv2)
-	return Angle(rv1[1] + rv2[1], rv1[2] + rv2[2], rv1[3] + rv2[3])
+	return rv1 + rv2
 end
 
 e2function angle operator-(rv1, angle rv2)
@@ -136,11 +136,11 @@ e2function angle operator-(angle rv1, rv2)
 end
 
 e2function angle operator-(angle rv1, angle rv2)
-	return Angle(rv1[1] - rv2[1], rv1[2] - rv2[2], rv1[3] - rv2[3])
+	return rv1 - rv2
 end
 
 e2function angle operator*(angle rv1, angle rv2)
-	return Angle(rv1[1] * rv2[1], rv1[2] * rv2[2], rv1[3] * rv2[3])
+	return rv1 * rv2
 end
 
 e2function angle operator*(rv1, angle rv2)
@@ -160,7 +160,7 @@ e2function angle operator/(angle rv1, rv2)
 end
 
 e2function angle operator/(angle rv1, angle rv2)
-	return Angle(rv1[1] / rv2[1], rv1[2] / rv2[2], rv1[3] / rv2[3])
+	return rv1 / rv2
 end
 
 e2function number angle:operator[](index)
@@ -219,54 +219,54 @@ end
 __e2setcost(5)
 
 e2function angle round(angle rv1)
-	return {
+	return Angle(
 		floor(rv1[1] + 0.5),
 		floor(rv1[2] + 0.5),
 		floor(rv1[3] + 0.5)
-	}
+	)
 end
 
 e2function angle round(angle rv1, decimals)
 	local shf = 10 ^ decimals
-	return {
+	return Angle(
 		floor(rv1[1] * shf + 0.5) / shf,
 		floor(rv1[2] * shf + 0.5) / shf,
 		floor(rv1[3] * shf + 0.5) / shf
-	}
+	)
 end
 
 e2function angle ceil(angle rv1)
-	return {
+	return Angle(
 		ceil(rv1[1]),
 		ceil(rv1[2]),
 		ceil(rv1[3])
-	}
+	)
 end
 
 e2function angle ceil(angle rv1, decimals)
 	local shf = 10 ^ decimals
-	return {
+	return Angle(
 		ceil(rv1[1] * shf) / shf,
 		ceil(rv1[2] * shf) / shf,
 		ceil(rv1[3] * shf) / shf
-	}
+	)
 end
 
 e2function angle floor(angle rv1)
-	return {
+	return Angle(
 		floor(rv1[1]),
 		floor(rv1[2]),
 		floor(rv1[3])
-	}
+	)
 end
 
 e2function angle floor(angle rv1, decimals)
 	local shf = 10 ^ decimals
-	return {
+	return Angle(
 		floor(rv1[1] * shf) / shf,
 		floor(rv1[2] * shf) / shf,
 		floor(rv1[3] * shf) / shf
-	}
+	)
 end
 
 // Performs modulo on p,y,r separately

--- a/lua/entities/gmod_wire_expression2/core/angle.lua
+++ b/lua/entities/gmod_wire_expression2/core/angle.lua
@@ -2,16 +2,15 @@
 Angle support
 \******************************************************************************/
 
-registerType("angle", "a", { 0, 0, 0 },
-	function(self, input) return { input.p or input[1], input.y or input[2], input.r or input[3] } end,
-	function(self, output) return Angle(output[1], output[2], output[3]) end,
+registerType("angle", "a", Angle(0, 0, 0),
+	nil,
+	function(self, output) return Angle(output:Unpack()) end,
 	function(retval)
 		if isangle(retval) then return end
-		if !istable(retval) then error("Return value is not a table, but a "..type(retval).."!",0) end
-		if #retval ~= 3 then error("Return value does not have exactly 3 entries!",0) end
+		error("Return value is not an Angle, but a "..type(retval).."!", 0)
 	end,
 	function(v)
-		return not isangle(v) and (not istable(v) or #v ~= 3)
+		return not isangle(v)
 	end
 )
 
@@ -23,22 +22,22 @@ local floor, ceil = math.floor, math.ceil
 __e2setcost(1) -- approximated
 
 e2function angle ang()
-	return { 0, 0, 0 }
+	return Angle(0, 0, 0)
 end
 
 __e2setcost(2)
 
 e2function angle ang(rv1)
-	return { rv1, rv1, rv1 }
+	return Angle(rv1, rv1, rv1)
 end
 
 e2function angle ang(rv1, rv2, rv3)
-	return { rv1, rv2, rv3 }
+	return Angle(rv1, rv2, rv3)
 end
 
 // Convert Vector -> Angle
 e2function angle ang(vector rv1)
-	return {rv1[1],rv1[2],rv1[3]}
+	return Angle(rv1[1], rv1[2], rv1[3])
 end
 
 /******************************************************************************/
@@ -113,55 +112,55 @@ end
 __e2setcost(2)
 
 e2function angle operator_neg(angle rv1)
-	return { -rv1[1], -rv1[2], -rv1[3] }
+	return Angle(-rv1[1], -rv1[2], -rv1[3])
 end
 
 e2function angle operator+(rv1, angle rv2)
-	return { rv1 + rv2[1], rv1 + rv2[2], rv1 + rv2[3] }
+	return Angle(rv1 + rv2[1], rv1 + rv2[2], rv1 + rv2[3])
 end
 
 e2function angle operator+(angle rv1, rv2)
-	return { rv1[1] + rv2, rv1[2] + rv2, rv1[3] + rv2 }
+	return Angle(rv1[1] + rv2, rv1[2] + rv2, rv1[3] + rv2)
 end
 
 e2function angle operator+(angle rv1, angle rv2)
-	return { rv1[1] + rv2[1], rv1[2] + rv2[2], rv1[3] + rv2[3] }
+	return Angle(rv1[1] + rv2[1], rv1[2] + rv2[2], rv1[3] + rv2[3])
 end
 
 e2function angle operator-(rv1, angle rv2)
-	return { rv1 - rv2[1], rv1 - rv2[2], rv1 - rv2[3] }
+	return Angle(rv1 - rv2[1], rv1 - rv2[2], rv1 - rv2[3])
 end
 
 e2function angle operator-(angle rv1, rv2)
-	return { rv1[1] - rv2, rv1[2] - rv2, rv1[3] - rv2 }
+	return Angle(rv1[1] - rv2, rv1[2] - rv2, rv1[3] - rv2)
 end
 
 e2function angle operator-(angle rv1, angle rv2)
-	return { rv1[1] - rv2[1], rv1[2] - rv2[2], rv1[3] - rv2[3] }
+	return Angle(rv1[1] - rv2[1], rv1[2] - rv2[2], rv1[3] - rv2[3])
 end
 
 e2function angle operator*(angle rv1, angle rv2)
-	return { rv1[1] * rv2[1], rv1[2] * rv2[2], rv1[3] * rv2[3] }
+	return Angle(rv1[1] * rv2[1], rv1[2] * rv2[2], rv1[3] * rv2[3])
 end
 
 e2function angle operator*(rv1, angle rv2)
-	return { rv1 * rv2[1], rv1 * rv2[2], rv1 * rv2[3] }
+	return Angle(rv1 * rv2[1], rv1 * rv2[2], rv1 * rv2[3])
 end
 
 e2function angle operator*(angle rv1, rv2)
-	return { rv1[1] * rv2, rv1[2] * rv2, rv1[3] * rv2 }
+	return Angle(rv1[1] * rv2, rv1[2] * rv2, rv1[3] * rv2)
 end
 
 e2function angle operator/(rv1, angle rv2)
-    return { rv1 / rv2[1], rv1 / rv2[2], rv1 / rv2[3] }
+    return Angle(rv1 / rv2[1], rv1 / rv2[2], rv1 / rv2[3])
 end
 
 e2function angle operator/(angle rv1, rv2)
-    return { rv1[1] / rv2, rv1[2] / rv2, rv1[3] / rv2 }
+    return Angle(rv1[1] / rv2, rv1[2] / rv2, rv1[3] / rv2)
 end
 
 e2function angle operator/(angle rv1, angle rv2)
-	return { rv1[1] / rv2[1], rv1[2] / rv2[2], rv1[3] / rv2[3] }
+	return Angle(rv1[1] / rv2[1], rv1[2] / rv2[2], rv1[3] / rv2[3])
 end
 
 e2function number angle:operator[](index)
@@ -179,7 +178,7 @@ end
 __e2setcost(5)
 
 e2function angle angnorm(angle rv1)
-	return {(rv1[1] + 180) % 360 - 180,(rv1[2] + 180) % 360 - 180,(rv1[3] + 180) % 360 - 180}
+	return Angle((rv1[1] + 180) % 360 - 180, (rv1[2] + 180) % 360 - 180, (rv1[3] + 180) % 360 - 180)
 end
 
 e2function number angnorm(rv1)
@@ -204,15 +203,15 @@ __e2setcost(2)
 
 // SET methods that returns angles
 e2function angle angle:setPitch(rv2)
-	return { rv2, this[2], this[3] }
+	return Angle(rv2, this[2], this[3])
 end
 
 e2function angle angle:setYaw(rv2)
-	return { this[1], rv2, this[3] }
+	return Angle(this[1], rv2, this[3])
 end
 
 e2function angle angle:setRoll(rv2)
-	return { this[1], this[2], rv2 }
+	return Angle(this[1], this[2], rv2)
 end
 
 /******************************************************************************/
@@ -282,7 +281,7 @@ e2function angle mod(angle rv1, rv2)
 	if rv1[3] >= 0 then
 		r = rv1[3] % rv2
 	else r = rv1[3] % -rv2 end
-	return {p, y, r}
+	return Angle(p, y, r)
 end
 
 // Modulo where divisors are defined as an angle
@@ -297,7 +296,7 @@ e2function angle mod(angle rv1, angle rv2)
 	if rv1[3] >= 0 then
 		y = rv1[3] % rv2[3]
 	else y = rv1[3] % -rv2[3] end
-	return {p, y, r}
+	return Angle(p, y, r)
 end
 
 // Clamp each p,y,r separately
@@ -316,7 +315,7 @@ e2function angle clamp(angle rv1, rv2, rv3)
 	elseif rv1[3] > rv3 then r = rv3
 	else r = rv1[3] end
 
-	return {p, y, r}
+	return Angle(p, y, r)
 end
 
 // Clamp according to limits defined by two min/max angles
@@ -335,7 +334,7 @@ e2function angle clamp(angle rv1, angle rv2, angle rv3)
 	elseif rv1[3] > rv3[3] then r = rv3[3]
 	else r = rv1[3] end
 
-	return {p, y, r}
+	return Angle(p, y, r)
 end
 
 // Mix two angles by a given proportion (between 0 and 1)
@@ -343,18 +342,18 @@ e2function angle mix(angle rv1, angle rv2, rv3)
 	local p = rv1[1] * rv3 + rv2[1] * (1-rv3)
 	local y = rv1[2] * rv3 + rv2[2] * (1-rv3)
 	local r = rv1[3] * rv3 + rv2[3] * (1-rv3)
-	return {p, y, r}
+	return Angle(p, y, r)
 end
 
 __e2setcost(2)
 
 // Circular shift function: shiftr(  p,y,r ) = ( r,p,y )
 e2function angle shiftR(angle rv1)
-	return {rv1[3], rv1[1], rv1[2]}
+	return Angle(rv1[3], rv1[1], rv1[2])
 end
 
 e2function angle shiftL(angle rv1)
-	return {rv1[2], rv1[3], rv1[1]}
+	return Angle(rv1[2], rv1[3], rv1[1])
 end
 
 __e2setcost(5)
@@ -374,21 +373,19 @@ end
 
 // Rotate an angle around a vector by the given number of degrees
 e2function angle angle:rotateAroundAxis(vector axis, degrees)
-	local ang = Angle(this[1], this[2], this[3])
-	local vec = Vector(axis[1], axis[2], axis[3]):GetNormal()
-
-	ang:RotateAroundAxis(vec, degrees)
-	return {ang.p, ang.y, ang.r}
+	local ang = Angle( this:Unpack() )
+	ang:RotateAroundAxis( axis:GetNormalized(), degrees )
+	return ang
 end
 
 // Convert the magnitude of the angle to radians
 e2function angle toRad(angle rv1)
-	return {rv1[1] * pi / 180, rv1[2] * pi / 180, rv1[3] * pi / 180}
+	return Angle(rv1[1] * pi / 180, rv1[2] * pi / 180, rv1[3] * pi / 180)
 end
 
 // Convert the magnitude of the angle to degrees
 e2function angle toDeg(angle rv1)
-	return {rv1[1] * 180 / pi, rv1[2] * 180 / pi, rv1[3] * 180 / pi}
+	return Angle(rv1[1] * 180 / pi, rv1[2] * 180 / pi, rv1[3] * 180 / pi)
 end
 
 /******************************************************************************/

--- a/lua/entities/gmod_wire_expression2/core/angle.lua
+++ b/lua/entities/gmod_wire_expression2/core/angle.lua
@@ -4,7 +4,7 @@ Angle support
 
 registerType("angle", "a", Angle(0, 0, 0),
 	nil,
-	function(self, output) return Angle(output:Unpack()) end,
+	function(self, output) return Angle(output) end,
 	function(retval)
 		if isangle(retval) then return end
 		error("Return value is not an Angle, but a "..type(retval).."!", 0)
@@ -373,7 +373,7 @@ end
 
 // Rotate an angle around a vector by the given number of degrees
 e2function angle angle:rotateAroundAxis(vector axis, degrees)
-	local ang = Angle( this:Unpack() )
+	local ang = Angle(this)
 	ang:RotateAroundAxis( axis:GetNormalized(), degrees )
 	return ang
 end

--- a/lua/entities/gmod_wire_expression2/core/bone.lua
+++ b/lua/entities/gmod_wire_expression2/core/bone.lua
@@ -164,7 +164,7 @@ end
 
 --- Returns <this>'s position.
 e2function vector bone:pos()
-	if not isValidBone(this) then return self:throw("Invalid bone!", {0, 0, 0}) end
+	if not isValidBone(this) then return self:throw("Invalid bone!", Vector(0, 0, 0)) end
 	return this:GetPos()
 end
 
@@ -173,32 +173,32 @@ do
 
 	--- Returns a vector describing <this>'s forward direction.
 	e2function vector bone:forward()
-		if not isValidBone(this) then return self:throw("Invalid bone!", {0, 0, 0}) end
+		if not isValidBone(this) then return self:throw("Invalid bone!", Vector(0, 0, 0)) end
 		return this:LocalToWorld(fwd)-this:GetPos()
 	end
 
 	--- Returns a vector describing <this>'s right direction.
 	e2function vector bone:right()
-		if not isValidBone(this) then return self:throw("Invalid bone!", {0, 0, 0}) end
+		if not isValidBone(this) then return self:throw("Invalid bone!", Vector(0, 0, 0)) end
 		return this:LocalToWorld(right)-this:GetPos() -- the y coordinate in local coords is left, not right. hence -1
 	end
 
 	--- Returns a vector describing <this>'s up direction.
 	e2function vector bone:up()
-		if not isValidBone(this) then return self:throw("Invalid bone!", {0, 0, 0}) end
+		if not isValidBone(this) then return self:throw("Invalid bone!", Vector(0, 0, 0)) end
 		return this:LocalToWorld(up)-this:GetPos()
 	end
 end
 
 --- Returns <this>'s velocity.
 e2function vector bone:vel()
-	if not isValidBone(this) then return self:throw("Invalid bone!", {0, 0, 0}) end
+	if not isValidBone(this) then return self:throw("Invalid bone!", Vector(0, 0, 0)) end
 	return this:GetVelocity()
 end
 
 --- Returns <this>'s velocity in local coordinates.
 e2function vector bone:velL()
-	if not isValidBone(this) then return self:throw("Invalid bone!", {0, 0, 0}) end
+	if not isValidBone(this) then return self:throw("Invalid bone!", Vector(0, 0, 0)) end
 	return this:WorldtoLocal(this:GetVelocity() + this:GetPos())
 end
 
@@ -206,13 +206,13 @@ end
 
 --- Transforms <pos> from local coordinates (as seen from <this>) to world coordinates.
 e2function vector bone:toWorld(vector pos)
-	if not isValidBone(this) then return self:throw("Invalid bone!", {0, 0, 0}) end
+	if not isValidBone(this) then return self:throw("Invalid bone!", Vector(0, 0, 0)) end
 	return this:LocalToWorld(Vector(pos[1],pos[2],pos[3]))
 end
 
 --- Transforms <pos> from world coordinates to local coordinates (as seen from <this>).
 e2function vector bone:toLocal(vector pos)
-	if not isValidBone(this) then return self:throw("Invalid bone!", {0, 0, 0}) end
+	if not isValidBone(this) then return self:throw("Invalid bone!", Vector(0, 0, 0)) end
 	return this:WorldToLocal(Vector(pos[1],pos[2],pos[3]))
 end
 
@@ -220,22 +220,22 @@ end
 
 --- Returns <this>'s angular velocity.
 e2function angle bone:angVel()
-	if not isValidBone(this) then return self:throw("Invalid bone!", {0, 0, 0}) end
+	if not isValidBone(this) then return self:throw("Invalid bone!", Angle(0, 0, 0)) end
 	local vec = this:GetAngleVelocity()
-	return { vec.y, vec.z, vec.x }
+	return Angle(vec.y, vec.z, vec.x)
 end
 
 --- Returns a vector describing rotation axis, magnitude and sense given as the vector's direction, magnitude and orientation.
 e2function vector bone:angVelVector()
-	if not isValidBone(this) then return self:throw("Invalid bone!", {0, 0, 0}) end
+	if not isValidBone(this) then return self:throw("Invalid bone!", Vector(0, 0, 0)) end
 	return this:GetAngleVelocity()
 end
 
 --- Returns <this>'s pitch, yaw and roll angles.
 e2function angle bone:angles()
-	if not isValidBone(this) then return self:throw("Invalid bone!", {0, 0, 0}) end
+	if not isValidBone(this) then return self:throw("Invalid bone!", Angle(0, 0, 0)) end
 	local ang = this:GetAngles()
-	return { ang.p, ang.y, ang.r }
+	return Angle(ang.p, ang.y, ang.r)
 end
 
 --[[************************************************************************]]--
@@ -261,7 +261,7 @@ end
 
 --- Returns the elevation (pitch) and bearing (yaw) from <this> to <pos>
 e2function angle bone:heading(vector pos)
-	if not isValidBone(this) then return self:throw("Invalid bone!", {0, 0, 0}) end
+	if not isValidBone(this) then return self:throw("Invalid bone!", Angle(0, 0, 0)) end
 
 	pos = this:WorldToLocal(Vector(pos[1],pos[2],pos[3]))
 
@@ -270,10 +270,10 @@ e2function angle bone:heading(vector pos)
 
 	-- elevation
 	local len = pos:Length()--sqrt(x*x + y*y + z*z)
-	if len < delta then return { 0, bearing, 0 } end
+	if len < delta then return Angle(0, bearing, 0) end
 	local elevation = rad2deg*asin(pos.z / len)
 
-	return { elevation, bearing, 0 }
+	return Angle(elevation, bearing, 0)
 end
 
 --- Returns <this>'s mass.
@@ -284,13 +284,13 @@ end
 
 --- Returns <this>'s Center of Mass.
 e2function vector bone:massCenter()
-	if not isValidBone(this) then return self:throw("Invalid bone!", {0, 0, 0}) end
+	if not isValidBone(this) then return self:throw("Invalid bone!", Vector(0, 0, 0)) end
 	return this:LocalToWorld(this:GetMassCenter())
 end
 
 --- Returns <this>'s Center of Mass in local coordinates.
 e2function vector bone:massCenterL()
-	if not isValidBone(this) then return self:throw("Invalid bone!", {0, 0, 0}) end
+	if not isValidBone(this) then return self:throw("Invalid bone!", Vector(0, 0, 0)) end
 	return this:GetMassCenter()
 end
 
@@ -305,7 +305,7 @@ end
 
 --- Gets the principal components of <this>'s inertia tensor in the form vec(Ixx, Iyy, Izz)
 e2function vector bone:inertia()
-	if not isValidBone(this) then return self:throw("Invalid bone!", {0, 0, 0}) end
+	if not isValidBone(this) then return self:throw("Invalid bone!", Vector(0, 0, 0)) end
 	return this:GetInertia()
 end
 

--- a/lua/entities/gmod_wire_expression2/core/color.lua
+++ b/lua/entities/gmod_wire_expression2/core/color.lua
@@ -15,10 +15,10 @@ end
 __e2setcost(2)
 
 e2function vector entity:getColor()
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
 
 	local c = this:GetColor()
-	return { c.r, c.g, c.b }
+	return Vector(c.r, c.g, c.b)
 end
 
 e2function vector4 entity:getColor4()
@@ -87,20 +87,20 @@ e2function void entity:setRenderMode(mode)
 end
 
 e2function vector entity:getPlayerColor()
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
-	if not this:IsPlayer() then return self:throw("Expected player but got an entity", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
+	if not this:IsPlayer() then return self:throw("Expected player but got an entity", Vector(0, 0, 0)) end
 
 	local c = this:GetPlayerColor()
 
-	return { RGBClamp(Round(c.r * 255), Round(c.g * 255), Round(c.b * 255)) }
+	return Vector(RGBClamp(Round(c.r * 255), Round(c.g * 255), Round(c.b * 255)))
 end
 
 e2function vector entity:getWeaponColor()
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
-	if not this:IsPlayer() then return self:throw("Expected player but got an entity", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
+	if not this:IsPlayer() then return self:throw("Expected player but got an entity", Vector(0, 0, 0)) end
 
 	local c = this:GetWeaponColor()
-	return { RGBClamp(Round(c.r * 255), Round(c.g * 255), Round(c.b * 255)) }
+	return Vector(RGBClamp(Round(c.r * 255), Round(c.g * 255), Round(c.b * 255)))
 end
 
 e2function void entity:setWeaponColor(vector c)
@@ -126,21 +126,21 @@ end
 --- Converts <hsv> from the [http://en.wikipedia.org/wiki/HSV_color_space HSV color space] to the [http://en.wikipedia.org/wiki/RGB_color_space RGB color space]
 e2function vector hsv2rgb(vector hsv)
 	local col = HSVToColor(math.Clamp(hsv[1] % 360, 0, 360), hsv[2], hsv[3])
-	return { col.r, col.g, col.b }
+	return Vector(col.r, col.g, col.b)
 end
 
 e2function vector hsv2rgb(h, s, v)
 	local col = HSVToColor(math.Clamp(h % 360, 0, 360), s, v)
-	return { col.r, col.g, col.b }
+	return Vector(col.r, col.g, col.b)
 end
 
 --- Converts <rgb> from the [http://en.wikipedia.org/wiki/RGB_color_space RGB color space] to the [http://en.wikipedia.org/wiki/HSV_color_space HSV color space]
 e2function vector rgb2hsv(vector rgb)
-	return { ColorToHSV(Color(rgb[1], rgb[2], rgb[3])) }
+	return Vector(ColorToHSV(Color(rgb[1], rgb[2], rgb[3])))
 end
 
 e2function vector rgb2hsv(r, g, b)
-	return { ColorToHSV(Color(r, g, b)) }
+	return Vector(ColorToHSV(Color(r, g, b)))
 end
 
 --- HSL
@@ -211,22 +211,22 @@ end
 
 --- Converts <hsl> HSL color space to RGB color space
 e2function vector hsl2rgb(vector hsl)
-	return { RGBClamp(Convert_hsl2rgb(hsl[1] / 360, hsl[2], hsl[3])) }
+	return Vector(RGBClamp(Convert_hsl2rgb(hsl[1] / 360, hsl[2], hsl[3])))
 end
 
 e2function vector hsl2rgb(h, s, l)
-	return { RGBClamp(Convert_hsl2rgb(h / 360, s, l)) }
+	return Vector(RGBClamp(Convert_hsl2rgb(h / 360, s, l)))
 end
 
 --- Converts <rgb> RGB color space to HSL color space
 e2function vector rgb2hsl(vector rgb)
 	local h,s,l = Convert_rgb2hsl(RGBClamp(rgb[1], rgb[2], rgb[3]))
-	return { floor(h * 360), s, l }
+	return Vector(floor(h * 360), s, l)
 end
 
 e2function vector rgb2hsl(r, g, b)
 	local h,s,l = Convert_rgb2hsl(RGBClamp(r, g, b))
-	return { floor(h * 360), s, l }
+	return Vector(floor(h * 360), s, l)
 end
 
 --- DIGI

--- a/lua/entities/gmod_wire_expression2/core/compat.lua
+++ b/lua/entities/gmod_wire_expression2/core/compat.lua
@@ -31,7 +31,7 @@ local clamp = WireLib.clampForce
 e2function void applyForce(vector force)
 	force = clamp(force)
 	local phys = self.entity:GetPhysicsObject()
-	phys:ApplyForceCenter(Vector(force[1],force[2],force[3]))
+	phys:ApplyForceCenter(force)
 end
 
 e2function void applyOffsetForce(vector force, vector position)

--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -149,8 +149,8 @@ function PropCore.PhysManipulate(this, pos, rot, freeze, gravity, notsolid)
 	local phys = this:GetPhysicsObject()
 	local physOrThis = IsValid(phys) and phys or this
 
-	if pos ~= nil then WireLib.setPos( physOrThis, Vector( pos[1],pos[2],pos[3] ) ) end
-	if rot ~= nil then WireLib.setAng( physOrThis, Angle( rot[1],rot[2],rot[3] ) ) end
+	if pos ~= nil then WireLib.setPos( physOrThis, pos ) end
+	if rot ~= nil then WireLib.setAng( physOrThis, rot ) end
 
 	if IsValid( phys ) then
 		if freeze ~= nil and this:GetUnFreezable() ~= true then phys:EnableMotion( freeze == 0 ) end

--- a/lua/entities/gmod_wire_expression2/core/debug.lua
+++ b/lua/entities/gmod_wire_expression2/core/debug.lua
@@ -106,7 +106,8 @@ e2function number playerCanPrint()
 end
 
 local function SpecialCase( arg )
-	if istable(arg) then
+	local t = type(arg)
+	if t == "table" then
 		if (arg.isfunction) then
 			return "function " .. arg[3] .. " = (" .. arg[2] .. ")"
 		elseif (seq(arg)) then -- A table with only numerical indexes
@@ -130,6 +131,10 @@ local function SpecialCase( arg )
 		else -- Else it's a table with string indexes (which this function can't handle)
 			return "[table]"
 		end
+	elseif t == "Vector" then
+		return string.format("vec(%.2f,%.2f,%.2f)", arg[1], arg[2], arg[3])
+	elseif t == "Angle" then
+		return string.format("ang(%d,%d,%d)", arg[1], arg[2], arg[3])
 	end
 end
 

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -45,10 +45,16 @@ function E2Lib.newE2Table()
 end
 
 -- Returns a cloned table of the variable given if it is a table.
+-- TODO: Ditch this system for instead having users provide a function that returns the default value.
+-- Would be much more efficient and avoid type checks.
 local istable = istable
 local table_Copy = table.Copy
 function E2Lib.fixDefault(var)
-	return istable(var) and table_Copy(var) or var
+	local t = type(var)
+	return t == "table" and table_Copy(var)
+		or t == "Vector" and Vector( var:Unpack() )
+		or t == "Angle" and Angle( var:Unpack() )
+		or var
 end
 
 -- getHash

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -52,8 +52,8 @@ local table_Copy = table.Copy
 function E2Lib.fixDefault(var)
 	local t = type(var)
 	return t == "table" and table_Copy(var)
-		or t == "Vector" and Vector( var:Unpack() )
-		or t == "Angle" and Angle( var:Unpack() )
+		or t == "Vector" and Vector(var)
+		or t == "Angle" and Angle(var)
 		or var
 end
 

--- a/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
@@ -816,9 +816,9 @@ __e2setcost(20)
 e2function vector wirelink:egpGlobalPos( number index )
 	local hasvertices, posang = EGP:GetGlobalPos( this, index )
 	if (!hasvertices) then
-		return { posang.x, posang.y, posang.angle }
+		return Vector( posang.x, posang.y, posang.angle )
 	end
-	return { 0,0,0 }
+	return Vector(0, 0, 0)
 end
 
 e2function array wirelink:egpGlobalVertices( number index )
@@ -840,7 +840,7 @@ e2function array wirelink:egpGlobalVertices( number index )
 			return {{data.x,data.y},{data.x2,data.y2}}
 		end
 	end
-	return { 0,0,0 }
+	return { 0, 0, 0 }
 end
 
 __e2setcost(5)
@@ -879,10 +879,10 @@ e2function vector wirelink:egpColor( number index )
 	local bool, k, v = EGP:HasObject( this, index )
 	if (bool) then
 		if (v.r and v.g and v.b) then
-			return {v.r,v.g,v.b}
+			return Vector(v.r, v.g, v.b)
 		end
 	end
-	return {-1,-1,-1}
+	return Vector(-1, -1, -1)
 end
 
 e2function number wirelink:egpAlpha( number index )

--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -159,52 +159,52 @@ __e2setcost(5) -- temporary
 /******************************************************************************/
 // Functions getting vector
 e2function vector entity:pos()
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
 	return this:GetPos()
 end
 
 e2function vector entity:forward()
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
 	return this:GetForward()
 end
 
 e2function vector entity:right()
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
 	return this:GetRight()
 end
 
 e2function vector entity:up()
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
 	return this:GetUp()
 end
 
 e2function vector entity:vel()
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
 	return this:GetVelocity()
 end
 
 e2function vector entity:velL()
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
 	return this:WorldToLocal(this:GetVelocity() + this:GetPos())
 end
 
 e2function angle entity:angVel()
-	if not validPhysics(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not validPhysics(this) then return self:throw("Invalid entity!", Angle(0, 0, 0)) end
 	local phys = this:GetPhysicsObject()
 	local vec = phys:GetAngleVelocity()
-	return { vec.y, vec.z, vec.x }
+	return Angle(vec.y, vec.z, vec.x)
 end
 
 --- Returns a vector describing rotation axis, magnitude and sense given as the vector's direction, magnitude and orientation.
 e2function vector entity:angVelVector()
-	if not validPhysics(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not validPhysics(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
 	local phys = this:GetPhysicsObject()
 	return phys:GetAngleVelocity()
 end
 
 --- Specific to env_sun because Source is dum. Use this to trace towards the sun or something.
 e2function vector sunDirection()
-	if not IsValid(sun) then return {0, 0, 0} end
+	if not IsValid(sun) then return Vector(0, 0, 0) end
 	return sun:GetKeyValues().sun_dir
 end
 
@@ -214,37 +214,37 @@ end
 __e2setcost(15)
 
 e2function vector entity:toWorld(vector localPosition)
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
 	return this:LocalToWorld(Vector(localPosition[1],localPosition[2],localPosition[3]))
 end
 
 e2function vector entity:toLocal(vector worldPosition)
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
 	return this:WorldToLocal(Vector(worldPosition[1],worldPosition[2],worldPosition[3]))
 end
 
 e2function vector entity:toWorldAxis(vector localAxis)
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
 	return this:LocalToWorld(Vector(localAxis[1],localAxis[2],localAxis[3]))-this:GetPos()
 end
 
 e2function vector entity:toLocalAxis(vector worldAxis)
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
 	return this:WorldToLocal(Vector(worldAxis[1],worldAxis[2],worldAxis[3])+this:GetPos())
 end
 
 --- Transforms from an angle local to <this> to a world angle.
 e2function angle entity:toWorld(angle localAngle)
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Angle(0, 0, 0)) end
 	local worldAngle = this:LocalToWorldAngles(Angle(localAngle[1],localAngle[2],localAngle[3]))
-	return { worldAngle.p, worldAngle.y, worldAngle.r }
+	return Angle(worldAngle.p, worldAngle.y, worldAngle.r)
 end
 
 --- Transforms from a world angle to an angle local to <this>.
 e2function angle entity:toLocal(angle worldAngle)
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Angle(0, 0, 0)) end
 	local localAngle = this:WorldToLocalAngles(Angle(worldAngle[1],worldAngle[2],worldAngle[3]))
-	return { localAngle.p, localAngle.y, localAngle.r }
+	return Angle(localAngle.p, localAngle.y, localAngle.r)
 end
 
 /******************************************************************************/
@@ -293,7 +293,7 @@ end
 
 --- Returns the elevation (pitch) and bearing (yaw) from <this> to <pos>
 e2function angle entity:heading(vector pos)
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Angle(0, 0, 0)) end
 
 	pos = this:WorldToLocal(Vector(pos[1],pos[2],pos[3]))
 
@@ -302,10 +302,10 @@ e2function angle entity:heading(vector pos)
 
 	-- elevation
 	local len = pos:Length()--sqrt(x*x + y*y + z*z)
-	if len < delta then return { 0, bearing, 0 } end
+	if len < delta then return Angle(0, bearing, 0) end
 	local elevation = rad2deg*asin(pos.z / len)
 
-	return { elevation, bearing, 0 }
+	return Angle(elevation, bearing, 0)
 end
 
 __e2setcost(10)
@@ -318,16 +318,16 @@ e2function number entity:mass()
 end
 
 e2function vector entity:massCenter()
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
 	local phys = this:GetPhysicsObject()
-	if not phys:IsValid() then return self:throw("Invalid physics object!", {0, 0, 0}) end
+	if not phys:IsValid() then return self:throw("Invalid physics object!", Vector(0, 0, 0)) end
 	return this:LocalToWorld(phys:GetMassCenter())
 end
 
 e2function vector entity:massCenterL()
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
 	local phys = this:GetPhysicsObject()
-	if not phys:IsValid() then return self:throw("Invalid physics object!", {0, 0, 0}) end
+	if not phys:IsValid() then return self:throw("Invalid physics object!", Vector(0, 0, 0)) end
 	return phys:GetMassCenter()
 end
 
@@ -450,9 +450,9 @@ end
 // Functions getting angles
 
 e2function angle entity:angles()
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Angle(0, 0, 0)) end
 	local ang = this:GetAngles()
-	return {ang.p, ang.y, ang.r}
+	return Angle(ang.p, ang.y, ang.r)
 end
 
 /******************************************************************************/
@@ -654,7 +654,7 @@ e2function void entity:applyTorque(vector torque)
 end
 
 e2function vector entity:inertia()
-	if not validPhysics(this) then return self:throw("Invalid physics object!", {0, 0, 0}) end
+	if not validPhysics(this) then return self:throw("Invalid physics object!", Vector(0, 0, 0)) end
 	return this:GetPhysicsObject():GetInertia()
 end
 
@@ -702,28 +702,28 @@ end
 __e2setcost(10)
 
 e2function vector entity:boxSize()
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
 	return this:OBBMaxs() - this:OBBMins()
 end
 
 e2function vector entity:boxCenter()
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
 	return this:OBBCenter()
 end
 
 -- Same as using E:toWorld(E:boxCenter()) in E2, but since Lua runs faster, this is more efficient.
 e2function vector entity:boxCenterW()
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
 	return this:LocalToWorld(this:OBBCenter())
 end
 
 e2function vector entity:boxMax()
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
 	return this:OBBMaxs()
 end
 
 e2function vector entity:boxMin()
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
 	return this:OBBMins()
 end
 
@@ -732,21 +732,21 @@ end
 
 -- Returns the entity's (min) axis-aligned bounding box
 e2function vector entity:aabbMin()
-	if not IsValid(this) or not IsValid(this:GetPhysicsObject()) then return self:throw("Invalid physics object!", {0, 0, 0}) end
+	if not IsValid(this) or not IsValid(this:GetPhysicsObject()) then return self:throw("Invalid physics object!", Vector(0, 0, 0)) end
 	local ret, _ = this:GetPhysicsObject():GetAABB()
-	return ret or {0,0,0}
+	return ret or Vector(0, 0, 0)
 end
 
 -- Returns the entity's (max) axis-aligned bounding box
 e2function vector entity:aabbMax()
-	if not IsValid(this) or not IsValid(this:GetPhysicsObject()) then return self:throw("Invalid physics object!", {0, 0, 0}) end
+	if not IsValid(this) or not IsValid(this:GetPhysicsObject()) then return self:throw("Invalid physics object!", Vector(0, 0, 0)) end
 	local _, ret = this:GetPhysicsObject():GetAABB()
-	return ret or {0,0,0}
+	return ret or Vector(0, 0, 0)
 end
 
 -- Returns the entity's axis-aligned bounding box size
 e2function vector entity:aabbSize()
-	if not IsValid(this) or not IsValid(this:GetPhysicsObject()) then return self:throw("Invalid physics object!", {0, 0, 0}) end
+	if not IsValid(this) or not IsValid(this:GetPhysicsObject()) then return self:throw("Invalid physics object!", Vector(0, 0, 0)) end
 	local ret, ret2 = this:GetPhysicsObject():GetAABB()
 	ret = ret or Vector(0,0,0)
 	ret2 = ret2 or Vector(0,0,0)
@@ -758,21 +758,21 @@ end
 
 -- Returns the rotated entity's min world-axis-aligned bounding box corner
 e2function vector entity:aabbWorldMin()
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
 	local ret, _ = this:WorldSpaceAABB()
-	return ret or {0,0,0}
+	return ret or Vector(0, 0, 0)
 end
 
 -- Returns the rotated entity's max world-axis-aligned bounding box corner
 e2function vector entity:aabbWorldMax()
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
 	local _, ret = this:WorldSpaceAABB()
-	return ret or {0,0,0}
+	return ret or Vector(0, 0, 0)
 end
 
 -- Returns the rotated entity's world-axis-aligned bounding box size
 e2function vector entity:aabbWorldSize()
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
 	local ret, ret2 = this:WorldSpaceAABB()
 	ret = ret or Vector(0,0,0)
 	ret2 = ret2 or Vector(0,0,0)
@@ -872,36 +872,36 @@ end
 
 --- Returns <this>'s attachment position associated with <attachmentID>
 e2function vector entity:attachmentPos(attachmentID)
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
 	local attachment = this:GetAttachment(attachmentID)
-	if not attachment then return { 0, 0, 0 } end
+	if not attachment then return Vector(0, 0, 0) end
 	return attachment.Pos
 end
 
 --- Returns <this>'s attachment angle associated with <attachmentID>
 e2function angle entity:attachmentAng(attachmentID)
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Angle(0, 0, 0)) end
 	local attachment = this:GetAttachment(attachmentID)
-	if not attachment then return { 0, 0, 0 } end
+	if not attachment then return Angle(0, 0, 0) end
 	local ang = attachment.Ang
-	return { ang.p, ang.y, ang.r }
+	return Angle(ang.p, ang.y, ang.r)
 end
 
 --- Same as <this>:attachmentPos(entity:lookupAttachment(<attachmentName>))
 e2function vector entity:attachmentPos(string attachmentName)
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
 	local attachment = this:GetAttachment(this:LookupAttachment(attachmentName))
-	if not attachment then return { 0, 0, 0 } end
+	if not attachment then return Vector(0, 0, 0) end
 	return attachment.Pos
 end
 
 --- Same as <this>:attachmentAng(entity:lookupAttachment(<attachmentName>))
 e2function angle entity:attachmentAng(string attachmentName)
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Angle(0, 0, 0)) end
 	local attachment = this:GetAttachment(this:LookupAttachment(attachmentName))
-	if not attachment then return { 0, 0, 0 } end
+	if not attachment then return Angle(0, 0, 0) end
 	local ang = attachment.Ang
-	return { ang.p, ang.y, ang.r }
+	return Angle(ang.p, ang.y, ang.r)
 end
 
 __e2setcost(20)
@@ -922,7 +922,7 @@ end
 __e2setcost(15)
 
 e2function vector entity:nearestPoint( vector point )
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
 	return this:NearestPoint( Vector(point[1],point[2],point[3]) )
 end
 

--- a/lua/entities/gmod_wire_expression2/core/hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/hologram.lua
@@ -837,7 +837,7 @@ e2function vector holoScale(index)
 	local Holo = CheckIndex(self, index)
 	if not Holo then return end
 
-	return Holo.scale or {0,0,0} -- TODO: maybe {1,1,1}?
+	return Holo.scale or Vector(0, 0, 0) -- TODO: maybe 1,1,1?
 end
 
 e2function void holoScaleUnits(index, vector size)
@@ -855,9 +855,9 @@ end
 
 e2function vector holoScaleUnits(index)
 	local Holo = CheckIndex(self, index)
-	if not Holo then return self:throw("Holo at index " .. index .. " does not exist!", {0,0,0}) end
+	if not Holo then return self:throw("Holo at index " .. index .. " does not exist!", Vector(0, 0, 0)) end
 
-	local scale = Holo.scale or {0,0,0} -- TODO: maybe {1,1,1}?
+	local scale = Holo.scale or Vector(0, 0, 0) -- TODO: maybe 1,1,1?
 
 	local propsize = Holo.ent:OBBMaxs()-Holo.ent:OBBMins()
 
@@ -885,25 +885,25 @@ end
 
 e2function vector holoBoneScale(index, boneindex)
 	local Holo = CheckIndex(self, index)
-	if not Holo then return {0,0,0} end
-	if not CheckBone(self, index, boneindex, Holo) then return {0,0,0} end
+	if not Holo then return Vector(0, 0, 0) end
+	if not CheckBone(self, index, boneindex, Holo) then return Vector(0, 0, 0) end
 
-	return Holo.bone_scale[boneindex] or {1,1,1}
+	return Holo.bone_scale[boneindex] or Vector(1, 1, 1)
 end
 
 e2function vector holoBoneScale(index, string bone)
 	local Holo = CheckIndex(self, index)
-	if not Holo then return {0,0,0} end
+	if not Holo then return Vector(0, 0, 0) end
 	local boneindex = Holo.ent:LookupBone(bone)
 
-	if boneindex == nil then return self:throw("Holo at index " .. index .. " does not have a bone ['" .. bone .. "']!", {0,0,0}) end
-	return Holo.bone_scale[boneindex] or {1,1,1}
+	if boneindex == nil then return self:throw("Holo at index " .. index .. " does not have a bone ['" .. bone .. "']!", Vector(0, 0, 0)) end
+	return Holo.bone_scale[boneindex] or Vector(1, 1, 1)
 end
 
 e2function vector holoBonePos(index, boneindex)
 	local Holo = CheckIndex(self, index)
-	if not Holo then return {0,0,0} end
-	if not CheckBone(self, index, boneindex, Holo) then return {0,0,0} end
+	if not Holo then return Vector(0, 0, 0) end
+	if not CheckBone(self, index, boneindex, Holo) then return Vector(0, 0, 0) end
 	
 	return Holo.ent:GetBoneMatrix(boneindex):GetTranslation()
 end
@@ -911,17 +911,17 @@ end
 
 e2function vector holoBonePos(index, string bone)
 	local Holo = CheckIndex(self, index)
-	if not Holo then return self:throw("Holo at index " .. index .. " does not exist!", {0,0,0}) end
+	if not Holo then return self:throw("Holo at index " .. index .. " does not exist!", Vector(0, 0, 0)) end
 
 	local boneindex = Holo.ent:LookupBone(bone)
-	if boneindex == nil then return self:throw("Holo at index " .. index .. " does not have a bone ['" .. bone .. "']!", {0,0,0}) end
+	if boneindex == nil then return self:throw("Holo at index " .. index .. " does not have a bone ['" .. bone .. "']!", Vector(0, 0, 0)) end
 	return Holo.ent:GetBoneMatrix(boneindex):GetTranslation()
 end
 
 e2function angle holoBoneAng(index, boneindex)
 	local Holo = CheckIndex(self, index)
-	if not Holo then return {0,0,0} end
-	if not CheckBone(self, index, boneindex, Holo) then return {0,0,0} end
+	if not Holo then return Angle(0, 0, 0) end
+	if not CheckBone(self, index, boneindex, Holo) then return Angle(0, 0, 0) end
 	
 	return Holo.ent:GetBoneMatrix(boneindex):GetAngles()
 end
@@ -929,10 +929,10 @@ end
 
 e2function angle holoBoneAng(index, string bone)
 	local Holo = CheckIndex(self, index)
-	if not Holo then return self:throw("Holo at index " .. index .. " does not exist!", {0,0,0}) end
+	if not Holo then return self:throw("Holo at index " .. index .. " does not exist!", Angle(0, 0, 0)) end
 
 	local boneindex = Holo.ent:LookupBone(bone)
-	if boneindex == nil then return self:throw("Holo at index " .. index .. " does not have a bone ['" .. bone .. "']!", {0,0,0}) end
+	if boneindex == nil then return self:throw("Holo at index " .. index .. " does not have a bone ['" .. bone .. "']!", Angle(0, 0, 0)) end
 	return Holo.ent:GetBoneMatrix(boneindex):GetAngles()
 end
 

--- a/lua/entities/gmod_wire_expression2/core/matrix.lua
+++ b/lua/entities/gmod_wire_expression2/core/matrix.lua
@@ -559,9 +559,9 @@ e2function matrix operator*(matrix rv1, rv2)
 end
 
 e2function vector operator*(matrix rv1, vector rv2)
-	return { rv1[1] * rv2[1] + rv1[2] * rv2[2] + rv1[3] * rv2[3],
+	return Vector( rv1[1] * rv2[1] + rv1[2] * rv2[2] + rv1[3] * rv2[3],
 			 rv1[4] * rv2[1] + rv1[5] * rv2[2] + rv1[6] * rv2[3],
-			 rv1[7] * rv2[1] + rv1[8] * rv2[2] + rv1[9] * rv2[3] }
+			 rv1[7] * rv2[1] + rv1[8] * rv2[2] + rv1[9] * rv2[3] )
 end
 
 e2function matrix operator*(matrix rv1, matrix rv2)

--- a/lua/entities/gmod_wire_expression2/core/matrix.lua
+++ b/lua/entities/gmod_wire_expression2/core/matrix.lua
@@ -428,7 +428,7 @@ local function toEulerZYX(a1, a4, a7, a8, a9)
 	local pitch = math.asin( -a7 ) * rad2deg
 	local yaw = math.atan2( a4, a1 ) * rad2deg
 	local roll = math.atan2( a8, a9 ) * rad2deg
-	return { pitch, yaw, roll }
+	return Angle(pitch, yaw, roll)
 end
 
 /******************************************************************************/
@@ -622,7 +622,7 @@ e2function vector matrix:row(rv2)
 	local x = this[k - 2]
 	local y = this[k - 1]
 	local z = this[k]
-	return { x, y, z }
+	return Vector(x, y, z)
 end
 
 e2function vector matrix:column(rv2)
@@ -635,7 +635,7 @@ e2function vector matrix:column(rv2)
 	local x = this[k]
 	local y = this[k + 3]
 	local z = this[k + 6]
-	return { x, y, z }
+	return Vector(x, y, z)
 end
 
 e2function matrix matrix:setRow(rv2, rv3, rv4, rv5)
@@ -819,7 +819,7 @@ end
 // Useful matrix maths functions
 
 e2function vector diagonal(matrix rv1)
-	return { rv1[1], rv1[5], rv1[9] }
+	return Vector(rv1[1], rv1[5], rv1[9])
 end
 
 e2function number trace(matrix rv1)
@@ -862,15 +862,15 @@ e2function matrix matrix(entity rv1)
 end
 
 e2function vector matrix:x()
-	return { this[1], this[4], this[7] }
+	return Vector(this[1], this[4], this[7])
 end
 
 e2function vector matrix:y()
-	return { this[2], this[5], this[8] }
+	return Vector(this[2], this[5], this[8])
 end
 
 e2function vector matrix:z()
-	return { this[3], this[6], this[9] }
+	return Vector(this[3], this[6], this[9])
 end
 
 // Returns a 3x3 reference frame matrix as described by the angle <ang>. Multiplying by this matrix will be the same as rotating by the given angle.
@@ -894,15 +894,15 @@ end
 e2function matrix mRotation(vector rv1, rv2)
 
 	local vec
-	local len = (rv1[1] * rv1[1] + rv1[2] * rv1[2] + rv1[3] * rv1[3]) ^ 0.5
+	local len = rv1:Length()
 	if len == 1 then vec = rv1
-	elseif len > delta then vec = { rv1[1] / len, rv1[2] / len, rv1[3] / len }
+	elseif len > delta then vec = Vector(rv1[1] / len, rv1[2] / len, rv1[3] / len)
 	else return { 0, 0, 0,
 				  0, 0, 0,
 				  0, 0, 0 }
 	end
 
-	local vec2 = { vec[1] * vec[1], vec[2] * vec[2], vec[3] * vec[3] }
+	local vec2 = Vector( vec[1] * vec[1], vec[2] * vec[2], vec[3] * vec[3] )
 	local a = rv2 * 3.14159265 / 180
 	local cos = math.cos(a)
 	local sin = math.sin(a)
@@ -1488,19 +1488,19 @@ e2function matrix4 matrix4(entity rv1)
 end
 
 e2function vector matrix4:x()
-	return { this[1], this[5], this[9] }
+	return Vector(this[1], this[5], this[9])
 end
 
 e2function vector matrix4:y()
-	return { this[2], this[6], this[10] }
+	return Vector(this[2], this[6], this[10])
 end
 
 e2function vector matrix4:z()
-	return { this[3], this[7], this[11] }
+	return Vector(this[3], this[7], this[11])
 end
 
 e2function vector matrix4:pos()
-	return { this[4], this[8], this[12] }
+	return Vector(this[4], this[8], this[12])
 end
 
 --- Returns a 4x4 reference frame matrix as described by the angle <ang>. Multiplying by this matrix will be the same as rotating by the given angle.

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -43,31 +43,31 @@ end
 __e2setcost(8)
 
 e2function vector entity:shootPos()
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
-	if not this:IsPlayer() and not this:IsNPC() then return self:throw("Expected a Player or NPC in shootPos", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
+	if not this:IsPlayer() and not this:IsNPC() then return self:throw("Expected a Player or NPC in shootPos", Vector(0, 0, 0)) end
 	return this:GetShootPos()
 end
 
 e2function vector entity:eye()
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
 	return this:IsPlayer() and this:GetAimVector() or this:GetForward()
 end
 
 --- Returns an angle describing player <this>'s view angles.
 e2function angle entity:eyeAngles()
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Angle(0, 0, 0)) end
 	local ang = this:EyeAngles()
-	return { ang.p, ang.y, ang.r }
+	return Angle(ang.p, ang.y, ang.r)
 end
 
 -- TODO: remove this check at some point in the future when LocalEyeAngles is available in the stable version of gmod
 if FindMetaTable("Player").LocalEyeAngles then
 	--- Gets a player's view direction, relative to any vehicle they sit in. This function is needed to reproduce the behavior of cam controller. This is different from Vehicle:toLocal(Ply:eyeAngles()).
 	e2function angle entity:eyeAnglesVehicle()
-		if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
-		if not this:IsPlayer() then return self:throw("Expected a Player but got an Entity!", {0, 0, 0}) end
+		if not IsValid(this) then return self:throw("Invalid entity!", Angle(0, 0, 0)) end
+		if not this:IsPlayer() then return self:throw("Expected a Player but got an Entity!", Angle(0, 0, 0)) end
 		local ang = this:LocalEyeAngles()
-		return { ang.p, ang.y, ang.r }
+		return Angle(ang.p, ang.y, ang.r)
 	end
 end
 
@@ -161,7 +161,7 @@ end
 
 e2function vector teamColor(index)
 	local col = team.GetColor(index)
-	return { col.r, col.g, col.b }
+	return Vector(col.r, col.g, col.b)
 end
 
 __e2setcost(10)
@@ -609,15 +609,15 @@ e2function entity entity:aimEntity()
 end
 
 e2function vector entity:aimPos()
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
-	if not this:IsPlayer() then return self:throw("Expected a Player, got Entity", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
+	if not this:IsPlayer() then return self:throw("Expected a Player, got Entity", Vector(0, 0, 0)) end
 
 	return this:GetEyeTraceNoCursor().HitPos
 end
 
 e2function vector entity:aimNormal()
-	if not IsValid(this) then return self:throw("Invalid entity!", {0, 0, 0}) end
-	if not this:IsPlayer() then return self:throw("Expected a Player, got Entity", {0, 0, 0}) end
+	if not IsValid(this) then return self:throw("Invalid entity!", Vector(0, 0, 0)) end
+	if not this:IsPlayer() then return self:throw("Expected a Player, got Entity", Vector(0, 0, 0)) end
 
 	return this:GetEyeTraceNoCursor().HitNormal
 end

--- a/lua/entities/gmod_wire_expression2/core/quaternion.lua
+++ b/lua/entities/gmod_wire_expression2/core/quaternion.lua
@@ -621,22 +621,22 @@ end
 e2function vector quaternion:right()
 	local this1, this2, this3, this4 = this[1], this[2], this[3], this[4]
 	local t2, t3, t4 = this2 * 2, this3 * 2, this4 * 2
-	return {
+	return Vector(
 		t4 * this1 - t2 * this3,
 		this2 * this2 - this1 * this1 + this4 * this4 - this3 * this3,
 		- t2 * this1 - t3 * this4
-	}
+	)
 end
 
 --- Returns vector pointing up for <this>
 e2function vector quaternion:up()
 	local this1, this2, this3, this4 = this[1], this[2], this[3], this[4]
 	local t2, t3, t4 = this2 * 2, this3 * 2, this4 * 2
-	return {
+	return Vector(
 		t3 * this1 + t2 * this4,
 		t3 * this4 - t2 * this1,
 		this1 * this1 - this2 * this2 - this3 * this3 + this4 * this4
-	}
+	)
 end
 
 /******************************************************************************/

--- a/lua/entities/gmod_wire_expression2/core/quaternion.lua
+++ b/lua/entities/gmod_wire_expression2/core/quaternion.lua
@@ -610,11 +610,11 @@ __e2setcost(7)
 e2function vector quaternion:forward()
 	local this1, this2, this3, this4 = this[1], this[2], this[3], this[4]
 	local t2, t3, t4 = this2 * 2, this3 * 2, this4 * 2
-	return {
+	return Vector(
 		this1 * this1 + this2 * this2 - this3 * this3 - this4 * this4,
 		t3 * this2 + t4 * this1,
 		t4 * this2 - t3 * this1
-	}
+	)
 end
 
 --- Returns vector pointing right for <this>
@@ -674,20 +674,20 @@ end
 --- Returns the axis of rotation (by coder0xff)
 e2function vector rotationAxis(quaternion q)
 	local m2 = q[2] * q[2] + q[3] * q[3] + q[4] * q[4]
-	if m2 == 0 then return { 0, 0, 1 } end
+	if m2 == 0 then return Vector(0, 0, 1) end
 	local m = sqrt(m2)
-	return { q[2] / m, q[3] / m, q[4] / m}
+	return Vector(q[2] / m, q[3] / m, q[4] / m)
 end
 
 --- Returns the rotation vector - rotation axis where magnitude is the angle of rotation in degress (by coder0xff)
 e2function vector rotationVector(quaternion q)
 	local l2 = q[1]*q[1] + q[2]*q[2] + q[3]*q[3] + q[4]*q[4]
 	local m2 = math.max( q[2]*q[2] + q[3]*q[3] + q[4]*q[4], 0 )
-	if l2 == 0 or m2 == 0 then return { 0, 0, 0 } end
+	if l2 == 0 or m2 == 0 then return Vector(0, 0, 0) end
 	local s = 2 * acos( math.Clamp( q[1] / sqrt(l2), -1, 1 ) ) * rad2deg
 	if s > 180 then s = s - 360 end
 	s = s / sqrt(m2)
-	return { q[2] * s, q[3] * s, q[4] * s }
+	return Vector( q[2] * s, q[3] * s, q[4] * s )
 end
 
 /******************************************************************************/
@@ -695,7 +695,7 @@ __e2setcost(3)
 
 --- Converts <q> to a vector by dropping the real component
 e2function vector vec(quaternion q)
-	return { q[2], q[3], q[4] }
+	return Vector(q[2], q[3], q[4])
 end
 
 __e2setcost(15)
@@ -713,7 +713,7 @@ end
 --- Returns angle represented by <this>
 e2function angle quaternion:toAngle()
 	local l = sqrt(this[1]*this[1]+this[2]*this[2]+this[3]*this[3]+this[4]*this[4])
-	if l == 0 then return {0,0,0} end
+	if l == 0 then return Angle(0, 0, 0) end
 	local q1, q2, q3, q4 = this[1]/l, this[2]/l, this[3]/l, this[4]/l
 
 	local x = Vector(q1*q1 + q2*q2 - q3*q3 - q4*q4,
@@ -736,7 +736,7 @@ e2function angle quaternion:toAngle()
 	local dot = q2*q1 + q3*q4
 	if dot < 0 then roll = -roll end
 
-	return {ang.p, ang.y, roll}
+	return Angle(ang.p, ang.y, roll)
 end
 
 --- Returns new normalized quaternion

--- a/lua/entities/gmod_wire_expression2/core/ranger.lua
+++ b/lua/entities/gmod_wire_expression2/core/ranger.lua
@@ -420,7 +420,7 @@ end
 
 --- Returns the position of the input ranger data trace IF it hit anything, else returns vec(0,0,0)
 e2function vector ranger:position()
-	if not this then return self:throw("Invalid ranger!", {0, 0, 0}) end
+	if not this then return self:throw("Invalid ranger!", Vector(0, 0, 0)) end
 	if this.StartSolid then return this.StartPos end
 	return this.HitPos
 end
@@ -428,7 +428,7 @@ end
 -- Returns the position of the input ranger data trace IF it it anything, else returns vec(0,0,0).
 -- NOTE: This function works like Lua's trace, while the above "position" function returns the same as positionLeftSolid IF it was created inside the world.
 e2function vector ranger:pos()
-	if not this then return self:throw("Invalid ranger!", {0, 0, 0}) end
+	if not this then return self:throw("Invalid ranger!", Vector(0, 0, 0)) end
 	return this.HitPos
 end
 
@@ -455,7 +455,7 @@ end
 
 --- Outputs a normalized vector perpendicular to the surface the ranger is pointed at.
 e2function vector ranger:hitNormal()
-	if not this then return self:throw("Invalid ranger!", {0, 0, 0}) end
+	if not this then return self:throw("Invalid ranger!", Vector(0, 0, 0)) end
 	return this.HitNormal
 end
 
@@ -479,7 +479,7 @@ end
 
 -- Returns the position at which the trace left the world if it was started inside the world
 e2function vector ranger:positionLeftSolid()
-	if not this then return self:throw("Invalid ranger!", {0, 0, 0}) end
+	if not this then return self:throw("Invalid ranger!", Vector(0, 0, 0)) end
 	return this.StartPos
 end
 

--- a/lua/entities/gmod_wire_expression2/core/vector.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector.lua
@@ -110,7 +110,7 @@ end
 --------------------------------------------------------------------------------
 
 e2function vector vector:operator_neg()
-	return Vector(-this[1], -this[2], -this[3])
+	return -this
 end
 
 e2function vector operator+(lhs, vector rhs)
@@ -122,7 +122,7 @@ e2function vector operator+(vector lhs, rhs)
 end
 
 e2function vector operator+(vector lhs, vector rhs)
-	return Vector(lhs[1] + rhs[1], lhs[2] + rhs[2], lhs[3] + rhs[3])
+	return lhs + rhs
 end
 
 e2function vector operator-(lhs, vector rhs)
@@ -134,7 +134,7 @@ e2function vector operator-(vector lhs, rhs)
 end
 
 e2function vector operator-(vector lhs, vector rhs)
-	return Vector(lhs[1] - rhs[1], lhs[2] - rhs[2], lhs[3] - rhs[3])
+	return lhs - rhs
 end
 
 e2function vector operator*(lhs, vector rhs)
@@ -146,7 +146,7 @@ e2function vector operator*(vector lhs, rhs)
 end
 
 e2function vector operator*(vector lhs, vector rhs)
-	return Vector(lhs[1] * rhs[1], lhs[2] * rhs[2], lhs[3] * rhs[3])
+	return lhs * rhs
 end
 
 e2function vector operator/(lhs, vector rhs)
@@ -158,7 +158,7 @@ e2function vector operator/(vector lhs, rhs)
 end
 
 e2function vector operator/(vector lhs, vector rhs)
-	return Vector(lhs[1] / rhs[1], lhs[2] / rhs[2], lhs[3] / rhs[3] )
+	return lhs / rhs
 end
 
 e2function number vector:operator[](index)
@@ -262,11 +262,11 @@ e2function number vector:dot( vector other )
 end
 
 e2function vector vector:cross( vector other )
-	return {
+	return Vector(
 		this[2] * other[3] - this[3] * other[2],
 		this[3] * other[1] - this[1] * other[3],
 		this[1] * other[2] - this[2] * other[1],
-	}
+	)
 end
 
 __e2setcost(10)
@@ -287,16 +287,16 @@ e2function vector vector:rotateAroundAxis(vector axis, degrees)
 	local length = (x*x+y*y+z*z)^0.5
 	x,y,z = x/length, y/length, z/length
 
-	return {(ca + (x^2)*(1-ca)) * this[1] + (x*y*(1-ca) - z*sa) * this[2] + (x*z*(1-ca) + y*sa) * this[3],
+	return Vector((ca + (x^2)*(1-ca)) * this[1] + (x*y*(1-ca) - z*sa) * this[2] + (x*z*(1-ca) + y*sa) * this[3],
 			(y*x*(1-ca) + z*sa) * this[1] + (ca + (y^2)*(1-ca)) * this[2] + (y*z*(1-ca) - x*sa) * this[3],
-			(z*x*(1-ca) - y*sa) * this[1] + (z*y*(1-ca) + x*sa) * this[2] + (ca + (z^2)*(1-ca)) * this[3]}
+			(z*x*(1-ca) - y*sa) * this[1] + (z*y*(1-ca) + x*sa) * this[2] + (ca + (z^2)*(1-ca)) * this[3])
 end
 
 __e2setcost(5)
 
 e2function vector vector:rotate( angle ang )
 	local v = Vector(this[1], this[2], this[3])
-	v:Rotate(Angle(ang[1], ang[2], ang[3]))
+	v:Rotate(ang)
 	return v
 end
 
@@ -313,11 +313,11 @@ e2function vector2 vector:dehomogenized()
 end
 
 e2function vector positive(vector rv1)
-	return {
+	return Vector(
 		rv1[1] >= 0 and rv1[1] or -rv1[1],
 		rv1[2] >= 0 and rv1[2] or -rv1[2],
 		rv1[3] >= 0 and rv1[3] or -rv1[3],
-	}
+	)
 end
 
 __e2setcost(3)
@@ -390,54 +390,54 @@ end
 __e2setcost(6)
 
 e2function vector round(vector rv1)
-	return {
+	return Vector(
 		floor(rv1[1] + 0.5),
 		floor(rv1[2] + 0.5),
 		floor(rv1[3] + 0.5)
-	}
+	)
 end
 
 e2function vector round(vector rv1, decimals)
 	local shf = 10 ^ decimals
-	return {
+	return Vector(
 		floor(rv1[1] * shf + 0.5) / shf,
 		floor(rv1[2] * shf + 0.5) / shf,
 		floor(rv1[3] * shf + 0.5) / shf
-	}
+	)
 end
 
 e2function vector ceil( vector rv1 )
-	return {
+	return Vector(
 		ceil(rv1[1]),
 		ceil(rv1[2]),
 		ceil(rv1[3])
-	}
+	)
 end
 
 e2function vector ceil(vector rv1, decimals)
 	local shf = 10 ^ decimals
-	return {
+	return Vector (
 		ceil(rv1[1] * shf) / shf,
 		ceil(rv1[2] * shf) / shf,
 		ceil(rv1[3] * shf) / shf
-	}
+	)
 end
 
 e2function vector floor(vector rv1)
-	return {
+	return Vector(
 		floor(rv1[1]),
 		floor(rv1[2]),
 		floor(rv1[3])
-	}
+	)
 end
 
 e2function vector floor(vector rv1, decimals)
 	local shf = 10 ^ decimals
-	return {
+	return Vector(
 		floor(rv1[1] * shf) / shf,
 		floor(rv1[2] * shf) / shf,
 		floor(rv1[3] * shf) / shf
-	}
+	)
 end
 
 __e2setcost(10)
@@ -457,37 +457,37 @@ end
 
 --- component-wise min/max
 e2function vector maxVec(vector rv1, vector rv2)
-	return {
+	return Vector(
 		rv1[1] > rv2[1] and rv1[1] or rv2[1],
 		rv1[2] > rv2[2] and rv1[2] or rv2[2],
 		rv1[3] > rv2[3] and rv1[3] or rv2[3],
-	}
+	)
 end
 
 e2function vector minVec(vector rv1, vector rv2)
-	return {
+	return Vector(
 		rv1[1] < rv2[1] and rv1[1] or rv2[1],
 		rv1[2] < rv2[2] and rv1[2] or rv2[2],
 		rv1[3] < rv2[3] and rv1[3] or rv2[3],
-	}
+	)
 end
 
 --- Performs modulo on x,y,z separately
 e2function vector mod(vector rv1, rv2)
-	return {
+	return Vector(
 		rv1[1] >= 0 and rv1[1] % rv2 or rv1[1] % -rv2,
 		rv1[2] >= 0 and rv1[2] % rv2 or rv1[2] % -rv2,
 		rv1[3] >= 0 and rv1[3] % rv2 or rv1[3] % -rv2,
-	}
+	)
 end
 
 --- Modulo where divisors are defined as a vector
 e2function vector mod(vector rv1, vector rv2)
-	return {
+	return Vector(
 		rv1[1] >= 0 and rv1[1] % rv2[1] or rv1[1] % -rv2[1],
 		rv1[2] >= 0 and rv1[2] % rv2[2] or rv1[2] % -rv2[2],
 		rv1[3] >= 0 and rv1[3] % rv2[3] or rv1[3] % -rv2[3],
-	}
+	)
 end
 
 --- Clamp according to limits defined by two min/max vectors
@@ -511,19 +511,19 @@ end
 
 --- Mix two vectors by a given proportion (between 0 and 1)
 e2function vector mix(vector vec1, vector vec2, ratio)
-	return {
+	return Vector(
 		vec1[1] * ratio + vec2[1] * (1-ratio),
 		vec1[2] * ratio + vec2[2] * (1-ratio),
 		vec1[3] * ratio + vec2[3] * (1-ratio)
-	}
+	)
 end
 
 e2function vector bezier(vector startVec, vector control, vector endVec, ratio)
-	return {
+	return Vector(
 		(1-ratio)^2 * startVec[1] + (2 * (1-ratio) * ratio * control[1]) + ratio^2 * endVec[1],
 		(1-ratio)^2 * startVec[2] + (2 * (1-ratio) * ratio * control[2]) + ratio^2 * endVec[2],
 		(1-ratio)^2 * startVec[3] + (2 * (1-ratio) * ratio * control[3]) + ratio^2 * endVec[3]
-	}
+	)
 end
 
 __e2setcost(2)
@@ -558,13 +558,11 @@ end
 __e2setcost(3)
 
 e2function angle vector:toAngle()
-	local angle = Vector(this[1], this[2], this[3]):Angle()
-	return Angle(angle.p, angle.y, angle.r)
+	return Vector(this[1], this[2], this[3]):Angle()
 end
 
 e2function angle vector:toAngle(vector up)
-	local angle = Vector(this[1], this[2], this[3]):AngleEx(Vector(up[1], up[2], up[3]))
-	return Angle(angle.p, angle.y, angle.r)
+	return Vector(this[1], this[2], this[3]):AngleEx(up)
 end
 
 --------------------------------------------------------------------------------
@@ -624,11 +622,11 @@ end
 __e2setcost( 15 )
 
 e2function string pointContents( vector point )
-	return cache_concatenated_parts[util.PointContents( Vector(point[1],point[2],point[3]))]
+	return cache_concatenated_parts[util.PointContents(point)]
 end
 
 e2function array pointContentsArray( vector point )
-	return cache_parts_array[util.PointContents( Vector(point[1],point[2],point[3]))]
+	return cache_parts_array[util.PointContents(point)]
 end
 
 --------------------------------------------------------------------------------
@@ -637,67 +635,42 @@ __e2setcost(15)
 
 --- Converts a local position/angle to a world position/angle and returns the position
 e2function vector toWorld( vector localpos, angle localang, vector worldpos, angle worldang )
-	local localpos = Vector(localpos[1],localpos[2],localpos[3])
-	local localang = Angle(localang[1],localang[2],localang[3])
-	local worldpos = Vector(worldpos[1],worldpos[2],worldpos[3])
-	local worldang = Angle(worldang[1],worldang[2],worldang[3])
-	return LocalToWorld(localpos,localang,worldpos,worldang)
+	return LocalToWorld(localpos, localang, worldpos, worldang)
 end
 
 --- Converts a local position/angle to a world position/angle and returns the angle
 e2function angle toWorldAng( vector localpos, angle localang, vector worldpos, angle worldang )
-	local localpos = Vector(localpos[1],localpos[2],localpos[3])
-	local localang = Angle(localang[1],localang[2],localang[3])
-	local worldpos = Vector(worldpos[1],worldpos[2],worldpos[3])
-	local worldang = Angle(worldang[1],worldang[2],worldang[3])
-	local pos, ang = LocalToWorld(localpos,localang,worldpos,worldang)
-	return Angle(ang.p, ang.y, ang.r)
+	local pos, ang = LocalToWorld(localpos, localang, worldpos, worldang)
+	return ang
 end
 
 --- Converts a local position/angle to a world position/angle and returns both in an array
 e2function array toWorldPosAng( vector localpos, angle localang, vector worldpos, angle worldang )
-	local localpos = Vector(localpos[1],localpos[2],localpos[3])
-	local localang = Angle(localang[1],localang[2],localang[3])
-	local worldpos = Vector(worldpos[1],worldpos[2],worldpos[3])
-	local worldang = Angle(worldang[1],worldang[2],worldang[3])
-	local pos, ang = LocalToWorld(localpos,localang,worldpos,worldang)
-	return {pos, Angle(ang.p, ang.y, ang.r)}
+	return { LocalToWorld(localpos,localang,worldpos,worldang) }
 end
 
 --- Converts a world position/angle to a local position/angle and returns the position
 e2function vector toLocal( vector localpos, angle localang, vector worldpos, angle worldang )
-	local localpos = Vector(localpos[1],localpos[2],localpos[3])
-	local localang = Angle(localang[1],localang[2],localang[3])
-	local worldpos = Vector(worldpos[1],worldpos[2],worldpos[3])
-	local worldang = Angle(worldang[1],worldang[2],worldang[3])
 	return WorldToLocal(localpos,localang,worldpos,worldang)
 end
 
 --- Converts a world position/angle to a local position/angle and returns the angle
 e2function angle toLocalAng( vector localpos, angle localang, vector worldpos, angle worldang )
-	local localpos = Vector(localpos[1],localpos[2],localpos[3])
-	local localang = Angle(localang[1],localang[2],localang[3])
-	local worldpos = Vector(worldpos[1],worldpos[2],worldpos[3])
-	local worldang = Angle(worldang[1],worldang[2],worldang[3])
 	local vec, ang = WorldToLocal(localpos,localang,worldpos,worldang)
-	return Angle(ang.p, ang.y, ang.r)
+	return ang
 end
 
 --- Converts a world position/angle to a local position/angle and returns both in an array
 e2function array toLocalPosAng( vector localpos, angle localang, vector worldpos, angle worldang )
-	local localpos = Vector(localpos[1],localpos[2],localpos[3])
-	local localang = Angle(localang[1],localang[2],localang[3])
-	local worldpos = Vector(worldpos[1],worldpos[2],worldpos[3])
-	local worldang = Angle(worldang[1],worldang[2],worldang[3])
 	local pos, ang = WorldToLocal(localpos,localang,worldpos,worldang)
-	return {pos, Angle(ang.p, ang.y, ang.r)}
+	return {pos, ang}
 end
 
 --------------------------------------------------------------------------------
 -- Credits to Wizard of Ass for bearing(v,a,v) and elevation(v,a,v)
 
 local ANG_ZERO = Angle(0, 0, 0)
-e2function number bearing(vector originpos,angle originangle, vector pos)
+e2function number bearing(vector originpos, angle originangle, vector pos)
 	pos = WorldToLocal(pos, ANG_ZERO, originpos, originangle)
 	return rad2deg * -atan2(pos.y, pos.x)
 end

--- a/lua/entities/gmod_wire_expression2/core/vector.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector.lua
@@ -21,16 +21,15 @@ local deg2rad = pi / 180
 
 --------------------------------------------------------------------------------
 
-registerType("vector", "v", { 0, 0, 0 },
+registerType("vector", "v", Vector(0, 0, 0),
 	nil,
-	function(self, output) return Vector(output[1], output[2], output[3]) end,
+	function(self, output) return Vector(output:Unpack()) end,
 	function(retval)
 		if isvector(retval) then return end
-		if not istable(retval) then error("Return value is neither a Vector nor a table, but a "..type(retval).."!",0) end
-		if #retval ~= 3 then error("Return value does not have exactly 3 entries!",0) end
+		error("Return value is not a Vector, but a "..type(retval).."!",0)
 	end,
 	function(v)
-		return not isvector(v) and (not istable(v) or #v ~= 3)
+		return not isvector(v)
 	end
 )
 
@@ -39,34 +38,34 @@ registerType("vector", "v", { 0, 0, 0 },
 __e2setcost(1) -- approximated
 
 e2function vector vec()
-	return { 0, 0, 0 }
+	return Vector(0, 0, 0)
 end
 
 __e2setcost(2)
 
 e2function vector vec(x)
-	return { x, x, x }
+	return Vector(x, x, x)
 end
 
 e2function vector vec(x, y, z)
-	return { x, y, z }
+	return Vector(x, y, z)
 end
 
 e2function vector vec(vector2 v2)
-	return { v2[1], v2[2], 0 }
+	return Vector(v2[1], v2[2], 0)
 end
 
 e2function vector vec(vector2 v2, z)
-	return { v2[1], v2[2], z }
+	return Vector(v2[1], v2[2], z)
 end
 
 e2function vector vec(vector4 v4)
-	return { v4[1], v4[2], v4[3] }
+	return Vector(v4[1], v4[2], v4[3])
 end
 
 --- Convert Angle -> Vector
 e2function vector vec(angle ang)
-	return { ang[1], ang[2], ang[3] }
+	return Vector(ang[1], ang[2], ang[3])
 end
 
 --------------------------------------------------------------------------------
@@ -111,55 +110,55 @@ end
 --------------------------------------------------------------------------------
 
 e2function vector vector:operator_neg()
-	return { -this[1], -this[2], -this[3] }
+	return Vector(-this[1], -this[2], -this[3])
 end
 
 e2function vector operator+(lhs, vector rhs)
-	return { lhs + rhs[1], lhs + rhs[2], lhs + rhs[3] }
+	return Vector(lhs + rhs[1], lhs + rhs[2], lhs + rhs[3])
 end
 
 e2function vector operator+(vector lhs, rhs)
-	return { lhs[1] + rhs, lhs[2] + rhs, lhs[3] + rhs }
+	return Vector(lhs[1] + rhs, lhs[2] + rhs, lhs[3] + rhs)
 end
 
 e2function vector operator+(vector lhs, vector rhs)
-	return { lhs[1] + rhs[1], lhs[2] + rhs[2], lhs[3] + rhs[3] }
+	return Vector(lhs[1] + rhs[1], lhs[2] + rhs[2], lhs[3] + rhs[3])
 end
 
 e2function vector operator-(lhs, vector rhs)
-	return { lhs - rhs[1], lhs - rhs[2], lhs - rhs[3] }
+	return Vector(lhs - rhs[1], lhs - rhs[2], lhs - rhs[3])
 end
 
 e2function vector operator-(vector lhs, rhs)
-	return { lhs[1] - rhs, lhs[2] - rhs, lhs[3] - rhs }
+	return Vector(lhs[1] - rhs, lhs[2] - rhs, lhs[3] - rhs)
 end
 
 e2function vector operator-(vector lhs, vector rhs)
-	return { lhs[1] - rhs[1], lhs[2] - rhs[2], lhs[3] - rhs[3] }
+	return Vector(lhs[1] - rhs[1], lhs[2] - rhs[2], lhs[3] - rhs[3])
 end
 
 e2function vector operator*(lhs, vector rhs)
-	return { lhs * rhs[1], lhs * rhs[2], lhs * rhs[3] }
+	return Vector(lhs * rhs[1], lhs * rhs[2], lhs * rhs[3])
 end
 
 e2function vector operator*(vector lhs, rhs)
-	return { lhs[1] * rhs, lhs[2] * rhs, lhs[3] * rhs }
+	return Vector(lhs[1] * rhs, lhs[2] * rhs, lhs[3] * rhs)
 end
 
 e2function vector operator*(vector lhs, vector rhs)
-	return { lhs[1] * rhs[1], lhs[2] * rhs[2], lhs[3] * rhs[3] }
+	return Vector(lhs[1] * rhs[1], lhs[2] * rhs[2], lhs[3] * rhs[3])
 end
 
 e2function vector operator/(lhs, vector rhs)
-	return { lhs / rhs[1], lhs / rhs[2], lhs / rhs[3] }
+	return Vector(lhs / rhs[1], lhs / rhs[2], lhs / rhs[3])
 end
 
 e2function vector operator/(vector lhs, rhs)
-	return { lhs[1] / rhs, lhs[2] / rhs, lhs[3] / rhs }
+	return Vector(lhs[1] / rhs, lhs[2] / rhs, lhs[3] / rhs )
 end
 
 e2function vector operator/(vector lhs, vector rhs)
-	return { lhs[1] / rhs[1], lhs[2] / rhs[2], lhs[3] / rhs[3] }
+	return Vector(lhs[1] / rhs[1], lhs[2] / rhs[2], lhs[3] / rhs[3] )
 end
 
 e2function number vector:operator[](index)
@@ -252,9 +251,9 @@ end
 e2function vector vector:normalized()
 	local len = (this[1] * this[1] + this[2] * this[2] + this[3] * this[3]) ^ 0.5
 	if len > delta then
-		return { this[1] / len, this[2] / len, this[3] / len }
+		return Vector(this[1] / len, this[2] / len, this[3] / len )
 	else
-		return { 0, 0, 0 }
+		return Vector(0, 0, 0)
 	end
 end
 
@@ -350,7 +349,7 @@ e2function vector clamp(vector Input, Min, Max)
 		return Input
 	end
 
-	return { x*length, y*length, z*length }
+	return Vector(x*length, y*length, z*length)
 end
 
 --------------------------------------------------------------------------------
@@ -373,17 +372,17 @@ __e2setcost(2)
 
 --- SET method that returns a new vector with x replaced
 e2function vector vector:setX(x)
-	return { x, this[2], this[3] }
+	return Vector(x, this[2], this[3])
 end
 
 --- SET method that returns a new vector with y replaced
 e2function vector vector:setY(y)
-	return { this[1], y, this[3] }
+	return Vector(this[1], y, this[3])
 end
 
 --- SET method that returns a new vector with z replaced
 e2function vector vector:setZ(z)
-	return { this[1], this[2], z }
+	return Vector(this[1], this[2], z)
 end
 
 --------------------------------------------------------------------------------
@@ -507,7 +506,7 @@ e2function vector clamp(vector value, vector min, vector max)
 	elseif value[3] > max[3] then z = max[3]
 	else z = value[3] end
 
-	return {x, y, z}
+	return Vector(x, y, z)
 end
 
 --- Mix two vectors by a given proportion (between 0 and 1)
@@ -531,12 +530,12 @@ __e2setcost(2)
 
 --- Circular shift function: shiftR(vec(x,y,z)) = vec(z,x,y)
 e2function vector shiftR(vector vec)
-	return { vec[3], vec[1], vec[2] }
+	return Vector(vec[3], vec[1], vec[2])
 end
 
 --- Circular shift function: shiftL(vec(x,y,z)) = vec(y,z,x)
 e2function vector shiftL(vector vec)
-	return { vec[2], vec[3], vec[1] }
+	return Vector(vec[2], vec[3], vec[1])
 end
 
 __e2setcost(5)
@@ -560,12 +559,12 @@ __e2setcost(3)
 
 e2function angle vector:toAngle()
 	local angle = Vector(this[1], this[2], this[3]):Angle()
-	return { angle.p, angle.y, angle.r }
+	return Angle(angle.p, angle.y, angle.r)
 end
 
 e2function angle vector:toAngle(vector up)
 	local angle = Vector(this[1], this[2], this[3]):AngleEx(Vector(up[1], up[2], up[3]))
-	return { angle.p, angle.y, angle.r }
+	return Angle(angle.p, angle.y, angle.r)
 end
 
 --------------------------------------------------------------------------------
@@ -652,7 +651,7 @@ e2function angle toWorldAng( vector localpos, angle localang, vector worldpos, a
 	local worldpos = Vector(worldpos[1],worldpos[2],worldpos[3])
 	local worldang = Angle(worldang[1],worldang[2],worldang[3])
 	local pos, ang = LocalToWorld(localpos,localang,worldpos,worldang)
-	return {ang.p,ang.y,ang.r}
+	return Angle(ang.p, ang.y, ang.r)
 end
 
 --- Converts a local position/angle to a world position/angle and returns both in an array
@@ -662,7 +661,7 @@ e2function array toWorldPosAng( vector localpos, angle localang, vector worldpos
 	local worldpos = Vector(worldpos[1],worldpos[2],worldpos[3])
 	local worldang = Angle(worldang[1],worldang[2],worldang[3])
 	local pos, ang = LocalToWorld(localpos,localang,worldpos,worldang)
-	return {pos, {ang.p,ang.y,ang.r}}
+	return {pos, Angle(ang.p, ang.y, ang.r)}
 end
 
 --- Converts a world position/angle to a local position/angle and returns the position
@@ -681,7 +680,7 @@ e2function angle toLocalAng( vector localpos, angle localang, vector worldpos, a
 	local worldpos = Vector(worldpos[1],worldpos[2],worldpos[3])
 	local worldang = Angle(worldang[1],worldang[2],worldang[3])
 	local vec, ang = WorldToLocal(localpos,localang,worldpos,worldang)
-	return {ang.p,ang.y,ang.r}
+	return Angle(ang.p, ang.y, ang.r)
 end
 
 --- Converts a world position/angle to a local position/angle and returns both in an array
@@ -691,32 +690,33 @@ e2function array toLocalPosAng( vector localpos, angle localang, vector worldpos
 	local worldpos = Vector(worldpos[1],worldpos[2],worldpos[3])
 	local worldang = Angle(worldang[1],worldang[2],worldang[3])
 	local pos, ang = WorldToLocal(localpos,localang,worldpos,worldang)
-	return {pos, {ang.p,ang.y,ang.r}}
+	return {pos, Angle(ang.p, ang.y, ang.r)}
 end
 
 --------------------------------------------------------------------------------
 -- Credits to Wizard of Ass for bearing(v,a,v) and elevation(v,a,v)
 
+local ANG_ZERO = Angle(0, 0, 0)
 e2function number bearing(vector originpos,angle originangle, vector pos)
-	pos = WorldToLocal(Vector(pos[1],pos[2],pos[3]),Angle(0,0,0),Vector(originpos[1],originpos[2],originpos[3]),Angle(originangle[1],originangle[2],originangle[3]))
-	return rad2deg*-atan2(pos.y, pos.x)
+	pos = WorldToLocal(pos, ANG_ZERO, originpos, originangle)
+	return rad2deg * -atan2(pos.y, pos.x)
 end
 
-e2function number elevation(vector originpos,angle originangle, vector pos)
-	pos = WorldToLocal(Vector(pos[1],pos[2],pos[3]),Angle(0,0,0),Vector(originpos[1],originpos[2],originpos[3]),Angle(originangle[1],originangle[2],originangle[3]))
+e2function number elevation(vector originpos, angle originangle, vector pos)
+	pos = WorldToLocal(pos, ANG_ZERO, originpos, originangle)
 	local len = pos:Length()
 	if (len < delta) then return 0 end
-	return rad2deg*asin(pos.z / len)
+	return rad2deg * asin(pos.z / len)
 end
 
 e2function angle heading(vector originpos,angle originangle, vector pos)
-	pos = WorldToLocal(Vector(pos[1],pos[2],pos[3]),Angle(0,0,0),Vector(originpos[1],originpos[2],originpos[3]),Angle(originangle[1],originangle[2],originangle[3]))
+	pos = WorldToLocal(pos, ANG_ZERO, originpos, originangle)
 
 	local bearing = rad2deg*-atan2(pos.y, pos.x)
 
 	local len = pos:Length()
-	if (len < delta) then return { 0, bearing, 0 } end
-	return { rad2deg*asin(pos.z / len), bearing, 0 }
+	if (len < delta) then return Angle(0, bearing, 0) end
+	return Angle(rad2deg*asin(pos.z / len), bearing, 0)
 end
 
 --------------------------------------------------------------------------------
@@ -725,7 +725,7 @@ __e2setcost( 10 )
 
 
 e2function number vector:isInWorld()
-	if util.IsInWorld(Vector(this[1], this[2], this[3])) then return 1 else return 0 end
+	if util.IsInWorld(this) then return 1 else return 0 end
 end
 
 __e2setcost( 5 )

--- a/lua/entities/gmod_wire_expression2/core/vector.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector.lua
@@ -23,7 +23,7 @@ local deg2rad = pi / 180
 
 registerType("vector", "v", Vector(0, 0, 0),
 	nil,
-	function(self, output) return Vector(output:Unpack()) end,
+	function(self, output) return Vector(output) end,
 	function(retval)
 		if isvector(retval) then return end
 		error("Return value is not a Vector, but a "..type(retval).."!",0)

--- a/lua/entities/gmod_wire_expression2/core/vector2.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector2.lua
@@ -801,8 +801,8 @@ registerFunction("dehomogenized", "xv4:", "v", function(self, args)
 	local op1 = args[2]
 	local rv1 = op1[1](self, op1)
 	local w = rv1[4]
-	if w == 0 then return { rv1[1], rv1[2], rv1[3] } end
-	return { rv1[1]/w, rv1[2]/w, rv1[3]/w }
+	if w == 0 then return Vector(rv1[1], rv1[2], rv1[3]) end
+	return Vector(rv1[1]/w, rv1[2]/w, rv1[3]/w)
 end)
 
 __e2setcost(4)

--- a/lua/entities/gmod_wire_expression2/core/wirelink.lua
+++ b/lua/entities/gmod_wire_expression2/core/wirelink.lua
@@ -307,14 +307,14 @@ e2function void wirelink:setXyz(vector value)
 end
 
 e2function vector wirelink:xyz()
-	if not validWirelink(self, this) then return { 0, 0, 0 } end
+	if not validWirelink(self, this) then return Vector(0, 0, 0) end
 
-	if not this.Outputs then return { 0, 0, 0 } end
+	if not this.Outputs then return Vector(0, 0, 0) end
 	local x, y, z = this.Outputs["X"], this.Outputs["Y"], this.Outputs["Z"]
 
-	if not x or not y or not z then return { 0, 0, 0 } end
-	if x.Type ~= "NORMAL" or y.Type ~= "NORMAL" or z.Type ~= "NORMAL" then return { 0, 0, 0 } end
-	return { x.Value, y.Value, z.Value }
+	if not x or not y or not z then return Vector(0, 0, 0) end
+	if x.Type ~= "NORMAL" or y.Type ~= "NORMAL" or z.Type ~= "NORMAL" then return Vector(0, 0, 0) end
+	return Vector(x.Value, y.Value, z.Value)
 end
 
 /******************************************************************************/
@@ -446,7 +446,7 @@ end
 
 --- V=XWL[N,vector]
 e2function vector wirelink:operator[T](address)
-	if not validWirelink(self, this) then return { 0, 0, 0 } end
+	if not validWirelink(self, this) then return Vector(0, 0, 0) end
 
 	if not this.ReadCell then return 0 end
 	return {

--- a/lua/entities/gmod_wire_expression2/core/wirelink.lua
+++ b/lua/entities/gmod_wire_expression2/core/wirelink.lua
@@ -449,11 +449,11 @@ e2function vector wirelink:operator[T](address)
 	if not validWirelink(self, this) then return Vector(0, 0, 0) end
 
 	if not this.ReadCell then return 0 end
-	return {
+	return Vector(
 		this:ReadCell(address) or 0,
 		this:ReadCell(address+1) or 0,
 		this:ReadCell(address+2) or 0,
-	}
+	)
 end
 
 --- XWL[N,string]=S


### PR DESCRIPTION
The E2 ``vector`` and ``angle`` types supported both the ``Vector`` and ``Angle`` gmod userdata types, as well as tables with three numbers in them. Since it had no idea which it was dealing with, it instead treated all of them as tables with three numbers, requiring constant calls to the vector/angle constructors for use in actual glua functions. This converts the e2 vector and angle types to only support gmod userdata (rather than also supporting tables with three numbers).

This should boost performance a good bit especially for physics/angle heavy E2s (and I still will need to make another PR to replace fixDefault to use a function, for further perf boosts)



⚠️ **This breaks backwards compatibility with any E2 extensions giving tables to E2. Doing so will most likely cause lua errors now**  
Because of this, maybe we want to reach out to common extension creators to update their extensions to use the userdata instead. (Although I checked @sirpapate's extensions, they don't seem to return vector or angle, so should be fine.)

Fixes #2218