### PR TITLE
Prevent forcers from pushing world entities

### DIFF
--- a/lua/entities/gmod_wire_forcer.lua
+++ b/lua/entities/gmod_wire_forcer.lua
@@ -70,13 +70,16 @@ function ENT:Think()
 	}
 
 	if not IsValid(trace.Entity) then return end
+	
+	if trace.Entity:GetMoveType() == MOVETYPE_PUSH then return end
+	
 	local convar_value = wire_forcer_permissions:GetInt()
 	if convar_value==1 then
 		if not IsValid(self:GetPlayer()) or gamemode.Call( "GravGunPunt", self:GetPlayer(), trace.Entity )==false then return end
 	elseif convar_value==2 then
 		if not IsValid(self:GetPlayer()) or gamemode.Call( "GravGunPickupAllowed", self:GetPlayer(), trace.Entity )==false then return end
 	end
-
+	
 	if trace.Entity:GetMoveType() == MOVETYPE_VPHYSICS then
 		local phys = trace.Entity:GetPhysicsObject()
 		if not IsValid(phys) then return end


### PR DESCRIPTION
Prevents entities with MOVETYPE_PUSH from being pushed by the forcer. My testing shows that entities with MOVETYPE_PUSH seem to include all world props, including doors, map props, etc. 


Below is a screenshot of my friend's screen I took after enabling halos for all the props with MOVETYPE_PUSH. You can see they are almost all doors, with some other world props as well.
![image](https://user-images.githubusercontent.com/51889746/188254023-2a7019c6-f8e6-4516-a98c-473de30f7fa5.png)


fixes #1934 