### PR TITLE
Tokenizer Rewrite

### DIFF
--- a/data/expression2/tests/parsing.txt
+++ b/data/expression2/tests/parsing.txt
@@ -17,6 +17,8 @@ Num1 = 0x2042
 Num2 = 0b00111001
 Num3 = 2432.2352
 Num4 = 2193e2
+Num5 = 2j + 4.4k + k + j
+Num6 = 3i + 2.7i + i
 
 function f() {}
 function r() { return }

--- a/data/expression2/tests/parsing.txt
+++ b/data/expression2/tests/parsing.txt
@@ -10,7 +10,8 @@
 #[ Comment ]#
 # Single line
 
-Str = "abcdefghijklmnopqrs\n\t\r"
+Str = "abcdefghijklm
+nopqrs\n\t\r\a\v\b\\"
 
 Num1 = 0x2042
 Num2 = 0b00111001
@@ -18,6 +19,7 @@ Num3 = 2432.2352
 Num4 = 2193e2
 
 function f() {}
+function r() { return }
 
 function number test() { return 55 }
 function entity:test() { return void }

--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -144,8 +144,7 @@ function Parser:GetTokenData()
 end
 
 function Parser:GetTokenTrace()
-	-- print("trace", self.token:display())
-	return { self.token.start_line, self.token.start_col, self.token:display() }
+	return { self.token.start_line, self.token.start_col }
 end
 
 

--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -80,9 +80,19 @@ KeyValue = Expr1 ("=" Expr1)?
 ]]
 -- ----------------------------------------------------------------------------------
 
-E2Lib.Parser = {}
-local Parser = E2Lib.Parser
+---@class Parser
+---@field readtoken Token
+---@field tokens Token[]
+---@field index integer
+---@field count integer
+local Parser = {}
 Parser.__index = Parser
+
+E2Lib.Parser = Parser
+
+local Tokenizer = E2Lib.Tokenizer
+local Token, TokenVariant = Tokenizer.Token, Tokenizer.Variant
+local Keyword, Grammar, Operator = E2Lib.Keyword, E2Lib.Grammar, E2Lib.Operator
 
 local parserDebug = CreateConVar("wire_expression2_parser_debug", 0,
 	"Print an E2's abstract syntax tree after parsing"
@@ -96,14 +106,17 @@ function Parser.Execute(...)
 	return xpcall(Parser.Process, E2Lib.errorHandler, instance, ...)
 end
 
+---@param message string
+---@param token Token?
 function Parser:Error(message, token)
 	if token then
-		error(message .. " at line " .. token[4] .. ", char " .. token[5], 0)
+		error(message .. " at line " .. token.start_line .. ", char " .. token.start_col, 0)
 	else
-		error(message .. " at line " .. self.token[4] .. ", char " .. self.token[5], 0)
+		error(message .. " at line " .. self.token.start_line .. ", char " .. self.token.start_col, 0)
 	end
 end
 
+---@param tokens Token[]
 function Parser:Process(tokens, params)
 	self.tokens = tokens
 	self.index = 0
@@ -121,16 +134,18 @@ end
 
 -- ---------------------------------------------------------------------
 
+---@return Token?
 function Parser:GetToken()
 	return self.token
 end
 
 function Parser:GetTokenData()
-	return self.token[2]
+	return self.token.value
 end
 
 function Parser:GetTokenTrace()
-	return { self.token[4], self.token[5] }
+	-- print("trace", self.token:display())
+	return { self.token.start_line, self.token.start_col, self.token:display() }
 end
 
 
@@ -148,7 +163,7 @@ function Parser:NextToken()
 		if self.index > 0 then
 			self.token = self.readtoken
 		else
-			self.token = { "", "", false, 1, 1 }
+			self.token = setmetatable({ value = "", variant = 1, whitespaced = false, start_col = 1, start_line = 1, end_col = 1, end_line = 1 }, Token) -- { "", "", false, 1, 1 }
 		end
 
 		self.index = self.index + 1
@@ -164,41 +179,51 @@ function Parser:TrackBack()
 end
 
 
-function Parser:AcceptRoamingToken(name)
+---@param variant TokenVariant
+---@param value? number|string|boolean
+---@return boolean
+function Parser:AcceptRoamingToken(variant, value)
 	local token = self.readtoken
-	if not token or token[1] ~= name then return false end
+	if not token or token.variant ~= variant then return false end
+	if value ~= nil and token.value ~= value then return false end
 
 	self:NextToken()
 	return true
 end
 
-function Parser:AcceptTailingToken(name)
+---@param variant TokenVariant
+---@param value? number|string|boolean
+function Parser:AcceptTailingToken(variant, value)
 	local token = self.readtoken
-	if not token or token[3] then return false end
+	if not token or token.whitespaced then return false end
 
-	return self:AcceptRoamingToken(name)
+	return self:AcceptRoamingToken(variant, value)
 end
 
-function Parser:AcceptLeadingToken(name)
+---@param variant TokenVariant
+---@param value? number|string|boolean
+function Parser:AcceptLeadingToken(variant, value)
 	local token = self.tokens[self.index + 1]
-	if not token or token[3] then return false end
+	if not token or token.whitespaced then return false end
 
-	return self:AcceptRoamingToken(name)
+	return self:AcceptRoamingToken(variant, value)
 end
 
 
+---@param func function
+---@param tbl Operator[]
 function Parser:RecurseLeft(func, tbl)
 	local expr = func(self)
 	local hit = true
 
 	while hit do
 		hit = false
-		for i = 1, #tbl do
-			if self:AcceptRoamingToken(tbl[i]) then
+		for _, op in ipairs(tbl) do
+			if self:AcceptRoamingToken(TokenVariant.Operator, op) then
 				local trace = self:GetTokenTrace()
 
 				hit = true
-				expr = self:Instruction(trace, tbl[i], expr, func(self))
+				expr = self:Instruction(trace, E2Lib.OperatorNames[op]:lower(), expr, func(self))
 				break
 			end
 		end
@@ -224,7 +249,7 @@ function Parser:Stmts()
 	if not self:HasTokens() then return stmts end
 
 	while true do
-		if self:AcceptRoamingToken("com") then
+		if self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.Comma) then
 			self:Error("Statement separator (,) must not appear multiple times")
 		end
 
@@ -232,8 +257,8 @@ function Parser:Stmts()
 
 		if not self:HasTokens() then break end
 
-		if not self:AcceptRoamingToken("com") then
-			if self.readtoken[3] == false then
+		if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.Comma) then
+			if not self.readtoken.whitespaced then
 				self:Error("Statements must be separated by comma (,) or whitespace")
 			end
 		end
@@ -244,7 +269,7 @@ end
 
 
 function Parser:Stmt1()
-	if self:AcceptRoamingToken("if") then
+	if self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.If) then
 		local trace = self:GetTokenTrace()
 		return self:Instruction(trace, "if", self:Cond(), self:Block("if condition"), self:IfElseIf())
 	end
@@ -253,7 +278,7 @@ function Parser:Stmt1()
 end
 
 function Parser:Stmt2()
-	if self:AcceptRoamingToken("whl") then
+	if self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.While) then
 		local trace = self:GetTokenTrace()
 		loopdepth = loopdepth + 1
 		local whl = self:Instruction(trace, "whl", self:Cond(), self:Block("while condition"),
@@ -266,38 +291,38 @@ function Parser:Stmt2()
 end
 
 function Parser:Stmt3()
-	if self:AcceptRoamingToken("for") then
+	if self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.For) then
 		local trace = self:GetTokenTrace()
 		loopdepth = loopdepth + 1
 
-		if not self:AcceptRoamingToken("lpa") then
+		if not self:AcceptRoamingToken(TokenVariant.Grammar, Operator.LParen) then
 			self:Error("Left parenthesis (() must appear before condition")
 		end
 
-		if not self:AcceptRoamingToken("var") then
+		if not self:AcceptRoamingToken(TokenVariant.Ident) then
 			self:Error("Variable expected for the numeric index")
 		end
 
 		local var = self:GetTokenData()
 
-		if not self:AcceptRoamingToken("ass") then
+		if not self:AcceptRoamingToken(TokenVariant.Operator, Operator.Ass) then
 			self:Error("Assignment operator (=) expected to preceed variable")
 		end
 
 		local estart = self:Expr1()
 
-		if not self:AcceptRoamingToken("com") then
+		if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.Comma) then
 			self:Error("Comma (,) expected after start value")
 		end
 
 		local estop = self:Expr1()
 
 		local estep
-		if self:AcceptRoamingToken("com") then
+		if self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.Comma) then
 			estep = self:Expr1()
 		end
 
-		if not self:AcceptRoamingToken("rpa") then
+		if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RParen) then
 			self:Error("Right parenthesis ()) missing, to close condition")
 		end
 
@@ -311,23 +336,23 @@ function Parser:Stmt3()
 end
 
 function Parser:Stmt4()
-	if self:AcceptRoamingToken("fea") then
+	if self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.Foreach) then
 		local trace = self:GetTokenTrace()
 		loopdepth = loopdepth + 1
 
-		if not self:AcceptRoamingToken("lpa") then
+		if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.LParen) then
 			self:Error("Left parenthesis missing (() after foreach statement")
 		end
 
-		if not self:AcceptRoamingToken("var") then
+		if not self:AcceptRoamingToken(TokenVariant.Ident) then
 			self:Error("Variable expected to hold the key")
 		end
 		local keyvar = self:GetTokenData()
 
 		local keytype
 
-		if self:AcceptRoamingToken("col") then
-			if not self:AcceptRoamingToken("fun") then
+		if self:AcceptRoamingToken(TokenVariant.Operator, Operator.Col) then
+			if not self:AcceptRoamingToken(TokenVariant.LowerIdent) then
 				self:Error("Type expected after colon")
 			end
 
@@ -341,22 +366,23 @@ function Parser:Stmt4()
 			keytype = wire_expression_types[string.upper(keytype)][1]
 		end
 
-		if not self:AcceptRoamingToken("com") then
+		if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.Comma) then
 			self:Error("Comma (,) expected after key variable")
 		end
 
-		if not self:AcceptRoamingToken("var") then
+		if not self:AcceptRoamingToken(TokenVariant.Ident) then
 			self:Error("Variable expected to hold the value")
 		end
 		local valvar = self:GetTokenData()
 
-		if not self:AcceptRoamingToken("col") then
+		if not self:AcceptRoamingToken(TokenVariant.Operator, Operator.Col) then
 			self:Error("Colon (:) expected to separate type from variable")
 		end
 
-		if not self:AcceptRoamingToken("fun") and not self:AcceptRoamingToken("udf") then
+		if not self:AcceptRoamingToken(TokenVariant.LowerIdent) then
 			self:Error("Type expected after colon")
 		end
+
 		local valtype = self:GetTokenData()
 		if valtype == "number" then valtype = "normal" end
 		if wire_expression_types[string.upper(valtype)] == nil then
@@ -364,13 +390,13 @@ function Parser:Stmt4()
 		end
 		valtype = wire_expression_types[string.upper(valtype)][1]
 
-		if not self:AcceptRoamingToken("ass") then
+		if not self:AcceptRoamingToken(TokenVariant.Operator, Operator.Ass) then
 			self:Error("Equals sign (=) expected after value type to specify table")
 		end
 
 		local tableexpr = self:Expr1()
 
-		if not self:AcceptRoamingToken("rpa") then
+		if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RParen) then
 			self:Error("Missing right parenthesis after foreach statement")
 		end
 
@@ -383,14 +409,14 @@ function Parser:Stmt4()
 end
 
 function Parser:Stmt5()
-	if self:AcceptRoamingToken("brk") then
+	if self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.Break) then
 		if loopdepth > 0 then
 			local trace = self:GetTokenTrace()
 			return self:Instruction(trace, "brk")
 		else
 			self:Error("Break may not exist outside of a loop")
 		end
-	elseif self:AcceptRoamingToken("cnt") then
+	elseif self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.Continue) then
 		if loopdepth > 0 then
 			local trace = self:GetTokenTrace()
 			return self:Instruction(trace, "cnt")
@@ -403,19 +429,19 @@ function Parser:Stmt5()
 end
 
 function Parser:Stmt6()
-	if self:AcceptRoamingToken("var") then
+	if self:AcceptRoamingToken(TokenVariant.Ident) then
 		local trace = self:GetTokenTrace()
 		local var = self:GetTokenData()
 
-		if self:AcceptTailingToken("inc") then
+		if self:AcceptTailingToken(TokenVariant.Operator, Operator.Inc) then
 			return self:Instruction(trace, "inc", var)
-		elseif self:AcceptRoamingToken("inc") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Inc) then
 			self:Error("Increment operator (++) must not be preceded by whitespace")
 		end
 
-		if self:AcceptTailingToken("dec") then
+		if self:AcceptTailingToken(TokenVariant.Operator, Operator.Dec) then
 			return self:Instruction(trace, "dec", var)
-		elseif self:AcceptRoamingToken("dec") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Dec) then
 			self:Error("Decrement operator (--) must not be preceded by whitespace")
 		end
 
@@ -426,17 +452,17 @@ function Parser:Stmt6()
 end
 
 function Parser:Stmt7()
-	if self:AcceptRoamingToken("var") then
+	if self:AcceptRoamingToken(TokenVariant.Ident) then
 		local trace = self:GetTokenTrace()
 		local var = self:GetTokenData()
 
-		if self:AcceptRoamingToken("aadd") then
+		if self:AcceptRoamingToken(TokenVariant.Operator, Operator.Aadd) then
 			return self:Instruction(trace, "ass", var, self:Instruction(trace, "add", self:Instruction(trace, "var", var), self:Expr1()))
-		elseif self:AcceptRoamingToken("asub") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Asub) then
 			return self:Instruction(trace, "ass", var, self:Instruction(trace, "sub", self:Instruction(trace, "var", var), self:Expr1()))
-		elseif self:AcceptRoamingToken("amul") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Amul) then
 			return self:Instruction(trace, "ass", var, self:Instruction(trace, "mul", self:Instruction(trace, "var", var), self:Expr1()))
-		elseif self:AcceptRoamingToken("adiv") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Adiv) then
 			return self:Instruction(trace, "ass", var, self:Instruction(trace, "div", self:Instruction(trace, "var", var), self:Expr1()))
 		end
 
@@ -447,12 +473,12 @@ function Parser:Stmt7()
 end
 
 function Parser:Index()
-	if self:AcceptTailingToken("lsb") then
+	if self:AcceptTailingToken(TokenVariant.Grammar, Grammar.LSquare) then
 		local trace = self:GetTokenTrace()
 		local exp = self:Expr1()
 
-		if self:AcceptRoamingToken("com") then
-			if not self:AcceptRoamingToken("fun") then
+		if self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.Comma) then
+			if not self:AcceptRoamingToken(TokenVariant.LowerIdent) then
 				self:Error("Indexing operator ([]) requires a lower case type [X,t]")
 			end
 
@@ -460,7 +486,7 @@ function Parser:Index()
 			if typename == "number" then typename = "normal" end
 			local type = wire_expression_types[string.upper(typename)]
 
-			if not self:AcceptRoamingToken("rsb") then
+			if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RSquare) then
 				self:Error("Right square bracket (]) missing, to close indexing operator [X,t]")
 			end
 
@@ -470,7 +496,7 @@ function Parser:Index()
 
 			return { exp, type[1], trace }, self:Index()
 
-		elseif self:AcceptTailingToken("rsb") then
+		elseif self:AcceptTailingToken(TokenVariant.Grammar, Grammar.RSquare) then
 			return { exp, nil, trace }
 
 		else
@@ -482,21 +508,21 @@ end
 
 function Parser:Stmt8(parentLocalized)
 	local localized
-	if self:AcceptRoamingToken("loc") then
+	if self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.Local) then
 		if parentLocalized ~= nil then self:Error("Assignment can't contain roaming local operator") end
 		localized = true
 	end
 
-	if self:AcceptRoamingToken("var") then
+	if self:AcceptRoamingToken(TokenVariant.Ident) then
 		local tbpos = self.index
 		local trace = self:GetTokenTrace()
 		local var = self:GetTokenData()
 
-		if self:AcceptTailingToken("lsb") then
+		if self:AcceptTailingToken(TokenVariant.Grammar, Grammar.LSquare) then
 			self:TrackBack()
 			local indexs = { self:Index() }
 
-			if self:AcceptRoamingToken("ass") then
+			if self:AcceptRoamingToken(TokenVariant.Operator, Operator.Ass) then
 				if localized or parentLocalized then
 					self:Error("Invalid operator (local).")
 				end
@@ -515,7 +541,7 @@ function Parser:Stmt8(parentLocalized)
 				return inst
 			end
 
-		elseif self:AcceptRoamingToken("ass") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Ass) then
 			if localized or parentLocalized then
 				return self:Instruction(trace, "assl", var, self:Stmt8(true))
 			else
@@ -535,20 +561,20 @@ function Parser:Stmt8(parentLocalized)
 end
 
 function Parser:Stmt9()
-	if self:AcceptRoamingToken("swh") then
+	if self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.Switch) then
 		local trace = self:GetTokenTrace()
 
-		if not self:AcceptRoamingToken("lpa") then
+		if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.LParen) then
 			self:Error("Left parenthesis (() expected before switch condition")
 		end
 
 		local expr = self:Expr1()
 
-		if not self:AcceptRoamingToken("rpa") then
+		if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RParen) then
 			self:Error("Right parenthesis ()) expected after switch condition")
 		end
 
-		if not self:AcceptRoamingToken("lcb") then
+		if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.LCurly) then
 			self:Error("Left curly bracket ({) expected after switch condition")
 		end
 
@@ -563,7 +589,7 @@ function Parser:Stmt9()
 end
 
 function Parser:Stmt10()
-	if self:AcceptRoamingToken("func") then
+	if self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.Function) then
 
 		local Trace = self:GetTokenTrace()
 
@@ -573,13 +599,12 @@ function Parser:Stmt10()
 		local Args, Temp = {}, {}
 
 
-		-- Errors are handeled after line 49, both 'fun' and 'var' tokens are used for accurate error reports.
-		if self:AcceptRoamingToken("fun") or self:AcceptRoamingToken("var") or self:AcceptRoamingToken("void") then --get the name
+		if self:AcceptRoamingToken(TokenVariant.LowerIdent) or self:AcceptRoamingToken(TokenVariant.Ident) then --get the name
 			Name = self:GetTokenData()
 			NameToken = self.token -- Copy the current token for error reporting
 
 			-- We check if the previous token was actualy the return not the name
-			if self:AcceptRoamingToken("fun") or self:AcceptRoamingToken("var") or self:AcceptRoamingToken("void") then
+			if self:AcceptRoamingToken(TokenVariant.LowerIdent) or self:AcceptRoamingToken(TokenVariant.Ident) then
 				Return = Name
 				ReturnToken = NameToken
 
@@ -587,9 +612,9 @@ function Parser:Stmt10()
 				NameToken = self.token
 			end
 
-			-- We check if the name token is actualy the type
-			if self:AcceptRoamingToken("col") then
-				if self:AcceptRoamingToken("fun") or self:AcceptRoamingToken("var") then
+			-- We check if the name token is actually the type
+			if self:AcceptRoamingToken(TokenVariant.Operator, Operator.Col) then
+				if self:AcceptRoamingToken(TokenVariant.LowerIdent) or self:AcceptRoamingToken(TokenVariant.Ident) then
 					Type = Name
 					TypeToken = NameToken
 
@@ -648,7 +673,7 @@ function Parser:Stmt10()
 		if Name[1] ~= Name[1]:lower() then self:Error("Function name must start with a lower case letter", NameToken) end
 
 
-		if not self:AcceptRoamingToken("lpa") then
+		if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.LParen) then
 			self:Error("Left parenthesis (() must appear after function name")
 		end
 
@@ -676,18 +701,18 @@ function Parser:Stmt10()
 		return Inst
 
 		-- Return Statment
-	elseif self:AcceptRoamingToken("ret") then
+	elseif self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.Return) then
 
 		local Trace = self:GetTokenTrace()
 
-		if self:AcceptRoamingToken("void") or (self.readtoken[1] and self.readtoken[1] == "rcb") then
+		if self:AcceptRoamingToken(TokenVariant.LowerIdent, "void") or (self.readtoken.value and self.readtoken.value == "}") then
 			return self:Instruction(Trace, "return")
 		end
 
 		return self:Instruction(Trace, "return", self:Expr1())
 
 		-- Void Missplacement
-	elseif self:AcceptRoamingToken("void") then
+	elseif self:AcceptRoamingToken(TokenVariant.LowerIdent, "void") then
 		self:Error("Void may only exist after return")
 	end
 
@@ -695,21 +720,21 @@ function Parser:Stmt10()
 end
 
 function Parser:Stmt11()
-	if self:AcceptRoamingToken("inclu") then
+	if self:AcceptRoamingToken(TokenVariant.Keyword, Keyword["#Include"]) then
 
 		local Trace = self:GetTokenTrace()
 
-		-- if not self:AcceptRoamingToken("lpa") then
+		-- if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.LParen) then
 		-- self:Error("Left parenthesis (() must appear after include")
 		-- end
 
-		if not self:AcceptRoamingToken("str") then
+		if not self:AcceptRoamingToken(TokenVariant.String) then
 			self:Error("include path (string) expected after include")
 		end
 
 		local Path = self:GetTokenData()
 
-		-- if not self:AcceptRoamingToken("rpa") then
+		-- if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RParen) then
 		-- self:Error("Right parenthesis ()) must appear after include path")
 		-- end
 
@@ -722,20 +747,20 @@ function Parser:Stmt11()
 end
 
 function Parser:Stmt12()
-	if self:AcceptRoamingToken("try") then
+	if self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.Try) then
 		local trace = self:GetTokenTrace()
 		local stmt = self:Block("try block")
-		if self:AcceptRoamingToken("catch") then
-			if not self:AcceptRoamingToken("lpa") then
+		if self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.Catch) then
+			if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.LParen) then
 				self:Error("Left parenthesis (() expected after catch keyword")
 			end
 
-			if not self:AcceptRoamingToken("var") then
+			if not self:AcceptRoamingToken(TokenVariant.Ident) then
 				self:Error("Variable expected after left parenthesis (() in catch statement")
 			end
 			local var_name = self:GetTokenData()
 
-			if not self:AcceptRoamingToken("rpa") then
+			if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RParen) then
 				self:Error("Right parenthesis ()) missing, to close catch statement")
 			end
 
@@ -748,13 +773,13 @@ function Parser:Stmt12()
 end
 
 function Parser:Stmt13()
-	if self:AcceptRoamingToken("do") then
+	if self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.Do) then
 		local trace = self:GetTokenTrace()
 
 		loopdepth = loopdepth + 1
 		local code = self:Block("do keyword")
 
-		if not self:AcceptRoamingToken("whl") then
+		if not self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.While) then
 			self:Error("while expected after do and code block (do {...} )")
 		end
 
@@ -772,24 +797,24 @@ function Parser:Stmt13()
 end
 
 function Parser:FunctionArgs(Temp, Args)
-	if self:HasTokens() and not self:AcceptRoamingToken("rpa") then
+	if self:HasTokens() and not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RParen) then
 		while true do
 
-			if self:AcceptRoamingToken("com") then self:Error("Argument separator (,) must not appear multiple times") end
+			if self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.Comma) then self:Error("Argument separator (,) must not appear multiple times") end
 
 			-- ...Array:array
-			if self:AcceptRoamingToken("spread") then
-				if not self:AcceptRoamingToken("fun") and not self:AcceptRoamingToken("var") then
+			if self:AcceptRoamingToken(TokenVariant.Operator, Operator.Spread) then
+				if not self:AcceptRoamingToken(TokenVariant.LowerIdent) and not self:AcceptRoamingToken(TokenVariant.Ident) then
 					self:Error("Variable name expected after spread operator")
 				end
 
 				local name = self:GetTokenData()
 
-				if not self:AcceptRoamingToken("col") then
+				if not self:AcceptRoamingToken(TokenVariant.Operator, Operator.Col) then
 					self:Error("Colon (:) expected after spread argument name")
 				end
 
-				if not self:AcceptRoamingToken("fun") then
+				if not self:AcceptRoamingToken(TokenVariant.LowerIdent) then
 					self:Error("Variable type expected after colon (:)")
 				end
 
@@ -808,11 +833,11 @@ function Parser:FunctionArgs(Temp, Args)
 					self:Error("Only array or table type is supported for spread arguments")
 				end
 
-				if self:AcceptRoamingToken("com") then
+				if self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.Comma) then
 					self:Error("Spread argument must be the last argument")
 				end
 
-				if not self:AcceptRoamingToken("rpa") then
+				if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RParen) then
 					self:Error("Right parenthesis ()) expected after spread argument")
 				end
 
@@ -822,16 +847,16 @@ function Parser:FunctionArgs(Temp, Args)
 				return
 			end
 
-			if self:AcceptRoamingToken("var") or self:AcceptRoamingToken("fun") then
+			if self:AcceptRoamingToken(TokenVariant.Ident) or self:AcceptRoamingToken(TokenVariant.LowerIdent) then
 				self:FunctionArg(Temp, Args)
-			elseif self:AcceptRoamingToken("lsb") then
+			elseif self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.LSquare) then
 				self:FunctionArgList(Temp, Args)
 			end
 
-			if self:AcceptRoamingToken("rpa") then
+			if self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RParen) then
 				break
 
-			elseif not self:AcceptRoamingToken("com") then
+			elseif not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.Comma) then
 				self:NextToken()
 				self:Error("Right parenthesis ()) expected after function arguments")
 			end
@@ -850,8 +875,8 @@ function Parser:FunctionArg(Temp, Args)
 
 	if Temp[Name] then self:Error("Variable '" .. Name .. "' is already used as an argument,") end
 
-	if self:AcceptRoamingToken("col") then
-		if self:AcceptRoamingToken("fun") or self:AcceptRoamingToken("var") then
+	if self:AcceptRoamingToken(TokenVariant.Operator, Operator.Col) then
+		if self:AcceptRoamingToken(TokenVariant.LowerIdent) or self:AcceptRoamingToken(TokenVariant.Ident) then
 			Type = self:GetTokenData()
 		else
 			self:Error("Type expected after colon (:)")
@@ -879,7 +904,7 @@ function Parser:FunctionArgList(Temp, Args)
 
 		local Vars = {}
 		while true do
-			if self:AcceptRoamingToken("fun") or self:AcceptRoamingToken("var") then
+			if self:AcceptRoamingToken(TokenVariant.LowerIdent) or self:AcceptRoamingToken(TokenVariant.Ident) then
 				local Name = self:GetTokenData()
 
 				if not Name then self:Error("Variable required") end
@@ -890,7 +915,7 @@ function Parser:FunctionArgList(Temp, Args)
 
 				Temp[Name] = true
 				Vars[#Vars + 1] = Name
-			elseif self:AcceptRoamingToken("rsb") then
+			elseif self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RSquare) then
 				break
 
 			else -- if !self:HasTokens() then
@@ -907,8 +932,8 @@ function Parser:FunctionArgList(Temp, Args)
 
 		local Type = "normal"
 
-		if self:AcceptRoamingToken("col") then
-			if self:AcceptRoamingToken("fun") or self:AcceptRoamingToken("var") then
+		if self:AcceptRoamingToken(TokenVariant.Operator, Operator.Col) then
+			if self:AcceptRoamingToken(TokenVariant.LowerIdent) or self:AcceptRoamingToken(TokenVariant.Ident) then
 				Type = self:GetTokenData()
 			else
 				self:Error("Type expected after colon (:)")
@@ -935,7 +960,7 @@ function Parser:FunctionArgList(Temp, Args)
 end
 
 function Parser:IfElseIf()
-	if self:AcceptRoamingToken("eif") then
+	if self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.Elseif) then
 		local trace = self:GetTokenTrace()
 		return self:Instruction(trace, "if", self:Cond(), self:Block("elseif condition"), self:IfElseIf())
 	end
@@ -944,7 +969,7 @@ function Parser:IfElseIf()
 end
 
 function Parser:IfElse()
-	if self:AcceptRoamingToken("els") then
+	if self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.Else) then
 		return self:Block("else")
 	end
 
@@ -953,13 +978,13 @@ function Parser:IfElse()
 end
 
 function Parser:Cond()
-	if not self:AcceptRoamingToken("lpa") then
+	if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.LParen) then
 		self:Error("Left parenthesis (() expected before condition")
 	end
 
 	local expr = self:Expr1()
 
-	if not self:AcceptRoamingToken("rpa") then
+	if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RParen) then
 		self:Error("Right parenthesis ()) missing, to close condition")
 	end
 
@@ -971,34 +996,34 @@ function Parser:Block(block_type)
 	local trace = self:GetTokenTrace()
 	local stmts = self:Instruction(trace, "seq")
 
-	if not self:AcceptRoamingToken("lcb") then
+	if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.LCurly) then
 		self:Error("Left curly bracket ({) expected after " .. (block_type or "condition"))
 	end
 
 	local token = self:GetToken()
 
-	if self:AcceptRoamingToken("rcb") then
+	if self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RCurly) then
 		return stmts
 	end
 
 	if self:HasTokens() then
 		while true do
-			if self:AcceptRoamingToken("com") then
+			if self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.Comma) then
 				self:Error("Statement separator (,) must not appear multiple times")
-			elseif self:AcceptRoamingToken("rcb") then
+			elseif self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RCurly) then
 				self:Error("Statement separator (,) must be suceeded by statement")
 			end
 
 			stmts[#stmts + 1] = self:Stmt1()
 
-			if self:AcceptRoamingToken("rcb") then
+			if self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RCurly) then
 				return stmts
 			end
 
-			if not self:AcceptRoamingToken("com") then
+			if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.Comma) then
 				if not self:HasTokens() then break end
 
-				if self.readtoken[3] == false then
+				if not self.readtoken.whitespaced then
 					self:Error("Statements must be separated by comma (,) or whitespace")
 				end
 			end
@@ -1012,9 +1037,9 @@ function Parser:SwitchBlock() -- Shhh this is a secret. Do not tell anybody abou
 	local cases = {}
 	local default
 
-	if self:HasTokens() and not self:AcceptRoamingToken("rpa") then
+	if self:HasTokens() and not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RParen) then
 
-		if not self:AcceptRoamingToken("case") and not self:AcceptRoamingToken("default") then
+		if not self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.Case) and not self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.Default) then
 			self:Error("Case Operator (case) expected in case block.", self:GetToken())
 		end
 
@@ -1022,22 +1047,22 @@ function Parser:SwitchBlock() -- Shhh this is a secret. Do not tell anybody abou
 
 		while true do
 
-			if self:AcceptRoamingToken("case") then
+			if self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.Case) then
 				local expr = self:Expr1()
 
-				if not self:AcceptRoamingToken("com") then
+				if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.Comma) then
 					self:Error("Comma (,) expected after case condition")
 				end
 
 				cases[#cases + 1] = { expr, self:CaseBlock() }
 
-			elseif self:AcceptRoamingToken("default") then
+			elseif self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.Default) then
 
 				if default then
 					self:Error("Only one default case (default:) may exist.")
 				end
 
-				if not self:AcceptRoamingToken("com") then
+				if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.Comma) then
 					self:Error("Comma (,) expected after default case")
 				end
 
@@ -1050,7 +1075,7 @@ function Parser:SwitchBlock() -- Shhh this is a secret. Do not tell anybody abou
 		end
 	end
 
-	if not self:AcceptRoamingToken("rcb") then
+	if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RCurly) then
 		self:Error("Right curly bracket (}) missing, to close statement block", self:GetToken())
 	end
 
@@ -1064,21 +1089,21 @@ function Parser:CaseBlock() -- Shhh this is a secret. Do not tell anybody about 
 		if self:HasTokens() then
 			while true do
 
-				if self:AcceptRoamingToken("case") or self:AcceptRoamingToken("default") or self:AcceptRoamingToken("rcb") then
+				if self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.Case) or self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.Default) or self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RCurly) then
 					self:TrackBack()
 					return stmts
-				elseif self:AcceptRoamingToken("com") then
+				elseif self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.Comma) then
 					self:Error("Statement separator (,) must not appear multiple times")
-				elseif self:AcceptRoamingToken("rcb") then
+				elseif self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RCurly) then
 					self:Error("Statement separator (,) must be suceeded by statement")
 				end
 
 				stmts[#stmts + 1] = self:Stmt1()
 
-				if not self:AcceptRoamingToken("com") then
+				if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.Comma) then
 					if not self:HasTokens() then break end
 
-					if self.readtoken[3] == false then
+					if not self.readtoken.whitespaced then
 						self:Error("Statements must be separated by comma (,) or whitespace")
 					end
 				end
@@ -1092,18 +1117,18 @@ end
 function Parser:Expr1()
 	self.exprtoken = self:GetToken()
 
-	if self:AcceptRoamingToken("var") then
-		if self:AcceptRoamingToken("ass") then
+	if self:AcceptRoamingToken(TokenVariant.Ident) then
+		if self:AcceptRoamingToken(TokenVariant.Operator, Operator.Ass) then
 			self:Error("Assignment operator (=) must not be part of equation")
 		end
 
-		if self:AcceptRoamingToken("aadd") then
+		if self:AcceptRoamingToken(TokenVariant.Operator, Operator.Aadd) then
 			self:Error("Additive assignment operator (+=) must not be part of equation")
-		elseif self:AcceptRoamingToken("asub") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Asub) then
 			self:Error("Subtractive assignment operator (-=) must not be part of equation")
-		elseif self:AcceptRoamingToken("amul") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Amul) then
 			self:Error("Multiplicative assignment operator (*=) must not be part of equation")
-		elseif self:AcceptRoamingToken("adiv") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Adiv) then
 			self:Error("Divisive assignment operator (/=) must not be part of equation")
 		end
 
@@ -1116,18 +1141,18 @@ end
 function Parser:Expr2()
 	local expr = self:Expr3()
 
-	if self:AcceptRoamingToken("qsm") then
+	if self:AcceptRoamingToken(TokenVariant.Operator, Operator.Qsm) then
 		local trace = self:GetTokenTrace()
 		local exprtrue = self:Expr1()
 
-		if not self:AcceptRoamingToken("col") then -- perhaps we want to make sure there is space around this (method bug)
+		if not self:AcceptRoamingToken(TokenVariant.Operator, Operator.Col) then -- perhaps we want to make sure there is space around this (method bug)
 			self:Error("Conditional operator (:) must appear after expression to complete conditional", self:GetToken())
 		end
 
 		return self:Instruction(trace, "cnd", expr, exprtrue, self:Expr1())
 	end
 
-	if self:AcceptRoamingToken("def") then
+	if self:AcceptRoamingToken(TokenVariant.Operator, Operator.Def) then
 		local trace = self:GetTokenTrace()
 
 		return self:Instruction(trace, "def", expr, self:Expr1())
@@ -1137,67 +1162,67 @@ function Parser:Expr2()
 end
 
 function Parser:Expr3()
-	return self:RecurseLeft(self.Expr4, { "or" })
+	return self:RecurseLeft(self.Expr4, { Operator.Or })
 end
 
 function Parser:Expr4()
-	return self:RecurseLeft(self.Expr5, { "and" })
+	return self:RecurseLeft(self.Expr5, { Operator.And })
 end
 
 function Parser:Expr5()
-	return self:RecurseLeft(self.Expr6, { "bor" })
+	return self:RecurseLeft(self.Expr6, { Operator.Bor })
 end
 
 function Parser:Expr6()
-	return self:RecurseLeft(self.Expr7, { "band" })
+	return self:RecurseLeft(self.Expr7, { Operator.Band })
 end
 
 function Parser:Expr7()
-	return self:RecurseLeft(self.Expr8, { "bxor" })
+	return self:RecurseLeft(self.Expr8, { Operator.Bxor })
 end
 
 function Parser:Expr8()
-	return self:RecurseLeft(self.Expr9, { "eq", "neq" })
+	return self:RecurseLeft(self.Expr9, { Operator.Eq, Operator.Neq })
 end
 
 function Parser:Expr9()
-	return self:RecurseLeft(self.Expr10, { "gth", "lth", "geq", "leq" })
+	return self:RecurseLeft(self.Expr10, { Operator.Gth, Operator.Lth, Operator.Geq, Operator.Leq })
 end
 
 function Parser:Expr10()
-	return self:RecurseLeft(self.Expr11, { "bshr", "bshl" })
+	return self:RecurseLeft(self.Expr11, { Operator.Bshr, Operator.Bshl })
 end
 
 function Parser:Expr11()
-	return self:RecurseLeft(self.Expr12, { "add", "sub" })
+	return self:RecurseLeft(self.Expr12, { Operator.Add, Operator.Sub })
 end
 
 function Parser:Expr12()
-	return self:RecurseLeft(self.Expr13, { "mul", "div", "mod" })
+	return self:RecurseLeft(self.Expr13, { Operator.Mul, Operator.Div, Operator.Mod })
 end
 
 function Parser:Expr13()
-	return self:RecurseLeft(self.Expr14, { "exp" })
+	return self:RecurseLeft(self.Expr14, { Operator.Exp })
 end
 
 function Parser:Expr14()
-	if self:AcceptLeadingToken("add") then
+	if self:AcceptLeadingToken(TokenVariant.Operator, Operator.Add) then
 		return self:Expr15()
-	elseif self:AcceptRoamingToken("add") then
+	elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Add) then
 		self:Error("Identity operator (+) must not be succeeded by whitespace")
 	end
 
-	if self:AcceptLeadingToken("sub") then
+	if self:AcceptLeadingToken(TokenVariant.Operator, Operator.Sub) then
 		local trace = self:GetTokenTrace()
 		return self:Instruction(trace, "neg", self:Expr15())
-	elseif self:AcceptRoamingToken("sub") then
+	elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Sub) then
 		self:Error("Negation operator (-) must not be succeeded by whitespace")
 	end
 
-	if self:AcceptLeadingToken("not") then
+	if self:AcceptLeadingToken(TokenVariant.Operator, Operator.Not) then
 		local trace = self:GetTokenTrace()
 		return self:Instruction(trace, "not", self:Expr14())
-	elseif self:AcceptRoamingToken("not") then
+	elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Not) then
 		self:Error("Logical not operator (!) must not be succeeded by whitespace")
 	end
 
@@ -1208,9 +1233,9 @@ function Parser:Expr15()
 	local expr = self:Expr16()
 
 	while true do
-		if self:AcceptTailingToken("col") then
-			if not self:AcceptTailingToken("fun") then
-				if self:AcceptRoamingToken("fun") then
+		if self:AcceptTailingToken(TokenVariant.Operator, Operator.Col) then
+			if not self:AcceptTailingToken(TokenVariant.LowerIdent) then
+				if self:AcceptRoamingToken(TokenVariant.LowerIdent) then
 					self:Error("Method operator (:) must not be preceded by whitespace")
 				else
 					self:Error("Method operator (:) must be followed by method name")
@@ -1220,8 +1245,8 @@ function Parser:Expr15()
 			local trace = self:GetTokenTrace()
 			local fun = self:GetTokenData()
 
-			if not self:AcceptTailingToken("lpa") then
-				if self:AcceptRoamingToken("lpa") then
+			if not self:AcceptTailingToken(TokenVariant.Grammar, Grammar.LParen) then
+				if self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.LParen) then
 					self:Error("Left parenthesis (() must not be preceded by whitespace")
 				else
 					self:Error("Left parenthesis (() must appear after method name")
@@ -1230,39 +1255,39 @@ function Parser:Expr15()
 
 			local token = self:GetToken()
 
-			if self:AcceptRoamingToken("rpa") then
+			if self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RParen) then
 				expr = self:Instruction(trace, "methodcall", fun, expr, {})
 			else
 				local exprs = { self:Expr1() }
 
-				while self:AcceptRoamingToken("com") do
+				while self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.Comma) do
 					exprs[#exprs + 1] = self:Expr1()
 				end
 
-				if not self:AcceptRoamingToken("rpa") then
+				if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RParen) then
 					self:Error("Right parenthesis ()) missing, to close method argument list", token)
 				end
 
 				expr = self:Instruction(trace, "methodcall", fun, expr, exprs)
 			end
-			--elseif self:AcceptRoamingToken("col") then
+			--elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Col) then
 			--	self:Error("Method operator (:) must not be preceded by whitespace")
-		elseif self:AcceptTailingToken("lsb") then
+		elseif self:AcceptTailingToken(TokenVariant.Grammar, Grammar.LSquare) then
 			local trace = self:GetTokenTrace()
 
-			if self:AcceptRoamingToken("rsb") then
+			if self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RSquare) then
 				self:Error("Indexing operator ([]) requires an index [X]")
 			end
 
 			local aexpr = self:Expr1()
-			if self:AcceptRoamingToken("com") then
-				if not self:AcceptRoamingToken("fun") then
+			if self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.Comma) then
+				if not self:AcceptRoamingToken(TokenVariant.LowerIdent) then
 					self:Error("Indexing operator ([]) requires a lower case type [X,t]")
 				end
 
 				local longtp = self:GetTokenData()
 
-				if not self:AcceptRoamingToken("rsb") then
+				if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RSquare) then
 					self:Error("Right square bracket (]) missing, to close indexing operator [X,t]")
 				end
 
@@ -1273,41 +1298,41 @@ function Parser:Expr15()
 
 				local tp = wire_expression_types[string.upper(longtp)][1]
 				expr = self:Instruction(trace, "get", expr, aexpr, tp)
-			elseif self:AcceptRoamingToken("rsb") then
+			elseif self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RSquare) then
 				expr = self:Instruction(trace, "get", expr, aexpr)
 			else
 				self:Error("Indexing operator ([]) needs to be closed with comma (,) or right square bracket (])")
 			end
-		elseif self:AcceptRoamingToken("lsb") then
+		elseif self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.LSquare) then
 			self:Error("Indexing operator ([]) must not be preceded by whitespace")
-		elseif self:AcceptTailingToken("lpa") then
+		elseif self:AcceptTailingToken(TokenVariant.Grammar, Grammar.LParen) then
 			local trace = self:GetTokenTrace()
 
 			local token = self:GetToken()
 			local exprs
 
-			if self:AcceptRoamingToken("rpa") then
+			if self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RParen) then
 				exprs = {}
 			else
 				exprs = { self:Expr1() }
 
-				while self:AcceptRoamingToken("com") do
+				while self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.Comma) do
 					exprs[#exprs + 1] = self:Expr1()
 				end
 
-				if not self:AcceptRoamingToken("rpa") then
+				if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RParen) then
 					self:Error("Right parenthesis ()) missing, to close function argument list", token)
 				end
 			end
 
-			if self:AcceptRoamingToken("lsb") then
-				if not self:AcceptRoamingToken("fun") then
+			if self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.LSquare) then
+				if not self:AcceptRoamingToken(TokenVariant.LowerIdent) then
 					self:Error("Return type operator ([]) requires a lower case type [type]")
 				end
 
 				local longtp = self:GetTokenData()
 
-				if not self:AcceptRoamingToken("rsb") then
+				if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RSquare) then
 					self:Error("Right square bracket (]) missing, to close return type operator [type]")
 				end
 
@@ -1331,24 +1356,24 @@ function Parser:Expr15()
 end
 
 function Parser:Expr16()
-	if self:AcceptRoamingToken("lpa") then
+	if self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.LParen) then
 		local token = self:GetToken()
 
 		local expr = self:Expr1()
 
-		if not self:AcceptRoamingToken("rpa") then
+		if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RParen) then
 			self:Error("Right parenthesis ()) missing, to close grouped equation", token)
 		end
 
 		return expr
 	end
 
-	if self:AcceptRoamingToken("fun") then
+	if self:AcceptRoamingToken(TokenVariant.LowerIdent) then
 		local trace = self:GetTokenTrace()
 		local fun = self:GetTokenData()
 
-		if not self:AcceptTailingToken("lpa") then
-			if self:AcceptRoamingToken("lpa") then
+		if not self:AcceptTailingToken(TokenVariant.Grammar, Grammar.LParen) then
+			if self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.LParen) then
 				self:Error("Left parenthesis (() must not be preceded by whitespace")
 			else
 				self:Error("Left parenthesis (() must appear after function name, variables must start with uppercase letter,")
@@ -1357,7 +1382,7 @@ function Parser:Expr16()
 
 		local token = self:GetToken()
 
-		if self:AcceptRoamingToken("rpa") then
+		if self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RParen) then
 			return self:Instruction(trace, "call", fun, {})
 		else
 
@@ -1369,8 +1394,8 @@ function Parser:Expr16()
 
 				local key = self:Expr1()
 
-				if self:AcceptRoamingToken("ass") then
-					if self:AcceptRoamingToken("rpa") then
+				if self:AcceptRoamingToken(TokenVariant.Operator, Operator.Ass) then
+					if self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RParen) then
 						self:Error("Expression expected, got right paranthesis ())", self:GetToken())
 					end
 
@@ -1382,12 +1407,12 @@ function Parser:Expr16()
 				end
 
 				if kvtable then
-					while self:AcceptRoamingToken("com") do
+					while self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.Comma) do
 						local key = self:Expr1()
 						local token = self:GetToken()
 
-						if self:AcceptRoamingToken("ass") then
-							if self:AcceptRoamingToken("rpa") then
+						if self:AcceptRoamingToken(TokenVariant.Operator, Operator.Ass) then
+							if self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RParen) then
 								self:Error("Expression expected, got right paranthesis ())", self:GetToken())
 							end
 
@@ -1397,7 +1422,7 @@ function Parser:Expr16()
 						end
 					end
 
-					if not self:AcceptRoamingToken("rpa") then
+					if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RParen) then
 						self:Error("Right parenthesis ()) missing, to close function argument list", self:GetToken())
 					end
 
@@ -1407,11 +1432,11 @@ function Parser:Expr16()
 				exprs = { self:Expr1() }
 			end
 
-			while self:AcceptRoamingToken("com") do
+			while self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.Comma) do
 				exprs[#exprs + 1] = self:Expr1()
 			end
 
-			if not self:AcceptRoamingToken("rpa") then
+			if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RParen) then
 				self:Error("Right parenthesis ()) missing, to close function argument list", token)
 			end
 
@@ -1423,7 +1448,7 @@ function Parser:Expr16()
 end
 
 function Parser:Expr17()
-	if self:AcceptRoamingToken("num") then
+	if self:AcceptRoamingToken(TokenVariant.Decimal) or self:AcceptRoamingToken(TokenVariant.Hexadecimal) or self:AcceptRoamingToken(TokenVariant.Binary) or self:AcceptRoamingToken(TokenVariant.Complex) then
 		local trace = self:GetTokenTrace()
 		local tokendata = self:GetTokenData()
 		if isnumber(tokendata) then
@@ -1446,17 +1471,18 @@ function Parser:Expr17()
 		return self:Instruction(trace, "literal", value, type)
 	end
 
-	if self:AcceptRoamingToken("str") then
+	if self:AcceptRoamingToken(TokenVariant.String) then
 		local trace = self:GetTokenTrace()
 		local str = self:GetTokenData()
+
 		return self:Instruction(trace, "literal", str, "s")
 	end
 
-	if self:AcceptRoamingToken("trg") then
+	if self:AcceptRoamingToken(TokenVariant.Operator, Operator.Trg) then
 		local trace = self:GetTokenTrace()
 
-		if not self:AcceptTailingToken("var") then
-			if self:AcceptRoamingToken("var") then
+		if not self:AcceptTailingToken(TokenVariant.Ident) then
+			if self:AcceptRoamingToken(TokenVariant.Ident) then
 				self:Error("Triggered operator (~) must not be succeeded by whitespace")
 			else
 				self:Error("Triggered operator (~) must be preceded by variable")
@@ -1467,11 +1493,11 @@ function Parser:Expr17()
 		return self:Instruction(trace, "trg", var)
 	end
 
-	if self:AcceptRoamingToken("dlt") then
+	if self:AcceptRoamingToken(TokenVariant.Operator, Operator.Dlt) then
 		local trace = self:GetTokenTrace()
 
-		if not self:AcceptTailingToken("var") then
-			if self:AcceptRoamingToken("var") then
+		if not self:AcceptTailingToken(TokenVariant.Ident) then
+			if self:AcceptRoamingToken(TokenVariant.Ident) then
 				self:Error("Delta operator ($) must not be succeeded by whitespace")
 			else
 				self:Error("Delta operator ($) must be preceded by variable")
@@ -1484,11 +1510,11 @@ function Parser:Expr17()
 		return self:Instruction(trace, "dlt", var)
 	end
 
-	if self:AcceptRoamingToken("imp") then
+	if self:AcceptRoamingToken(TokenVariant.Operator, Operator.Imp) then
 		local trace = self:GetTokenTrace()
 
-		if not self:AcceptTailingToken("var") then
-			if self:AcceptRoamingToken("var") then
+		if not self:AcceptTailingToken(TokenVariant.Ident) then
+			if self:AcceptRoamingToken(TokenVariant.Ident) then
 				self:Error("Connected operator (->) must not be succeeded by whitespace")
 			else
 				self:Error("Connected operator (->) must be preceded by variable")
@@ -1504,16 +1530,16 @@ function Parser:Expr17()
 end
 
 function Parser:Expr18()
-	if self:AcceptRoamingToken("var") then
-		if self:AcceptTailingToken("inc") then
+	if self:AcceptRoamingToken(TokenVariant.Ident) then
+		if self:AcceptTailingToken(TokenVariant.Operator, Operator.Inc) then
 			self:Error("Increment operator (++) must not be part of equation")
-		elseif self:AcceptRoamingToken("inc") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Inc) then
 			self:Error("Increment operator (++) must not be preceded by whitespace")
 		end
 
-		if self:AcceptTailingToken("dec") then
+		if self:AcceptTailingToken(TokenVariant.Operator, Operator.Dec) then
 			self:Error("Decrement operator (--) must not be part of equation")
-		elseif self:AcceptRoamingToken("dec") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Dec) then
 			self:Error("Decrement operator (--) must not be preceded by whitespace")
 		end
 
@@ -1524,7 +1550,7 @@ function Parser:Expr18()
 end
 
 function Parser:Expr19()
-	if self:AcceptRoamingToken("var") then
+	if self:AcceptRoamingToken(TokenVariant.Ident) then
 		local trace = self:GetTokenTrace()
 		local var = self:GetTokenData()
 		return self:Instruction(trace, "var", var)
@@ -1535,80 +1561,80 @@ end
 
 function Parser:ExprError()
 	if self:HasTokens() then
-		if self:AcceptRoamingToken("add") then
+		if self:AcceptRoamingToken(TokenVariant.Operator, Operator.Add) then
 			self:Error("Addition operator (+) must be preceded by equation or value")
-		elseif self:AcceptRoamingToken("sub") then -- can't occur (unary minus)
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Sub) then -- can't occur (unary minus)
 			self:Error("Subtraction operator (-) must be preceded by equation or value")
-		elseif self:AcceptRoamingToken("mul") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Mul) then
 			self:Error("Multiplication operator (*) must be preceded by equation or value")
-		elseif self:AcceptRoamingToken("div") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Div) then
 			self:Error("Division operator (/) must be preceded by equation or value")
-		elseif self:AcceptRoamingToken("mod") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Mod) then
 			self:Error("Modulo operator (%) must be preceded by equation or value")
-		elseif self:AcceptRoamingToken("exp") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Exp) then
 			self:Error("Exponentiation operator (^) must be preceded by equation or value")
 
-		elseif self:AcceptRoamingToken("ass") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Ass) then
 			self:Error("Assignment operator (=) must be preceded by variable")
-		elseif self:AcceptRoamingToken("aadd") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Aadd) then
 			self:Error("Additive assignment operator (+=) must be preceded by variable")
-		elseif self:AcceptRoamingToken("asub") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Asub) then
 			self:Error("Subtractive assignment operator (-=) must be preceded by variable")
-		elseif self:AcceptRoamingToken("amul") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Amul) then
 			self:Error("Multiplicative assignment operator (*=) must be preceded by variable")
-		elseif self:AcceptRoamingToken("adiv") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Adiv) then
 			self:Error("Divisive assignment operator (/=) must be preceded by variable")
 
-		elseif self:AcceptRoamingToken("and") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.And) then
 			self:Error("Logical and operator (&) must be preceded by equation or value")
-		elseif self:AcceptRoamingToken("or") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Or) then
 			self:Error("Logical or operator (|) must be preceded by equation or value")
 
-		elseif self:AcceptRoamingToken("eq") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Eq) then
 			self:Error("Equality operator (==) must be preceded by equation or value")
-		elseif self:AcceptRoamingToken("neq") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Neq) then
 			self:Error("Inequality operator (!=) must be preceded by equation or value")
-		elseif self:AcceptRoamingToken("gth") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Gth) then
 			self:Error("Greater than or equal to operator (>=) must be preceded by equation or value")
-		elseif self:AcceptRoamingToken("lth") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Lth) then
 			self:Error("Less than or equal to operator (<=) must be preceded by equation or value")
-		elseif self:AcceptRoamingToken("geq") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Geq) then
 			self:Error("Greater than operator (>) must be preceded by equation or value")
-		elseif self:AcceptRoamingToken("leq") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Leq) then
 			self:Error("Less than operator (<) must be preceded by equation or value")
 
-		elseif self:AcceptRoamingToken("inc") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Inc) then
 			self:Error("Increment operator (++) must be preceded by variable")
-		elseif self:AcceptRoamingToken("dec") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Dec) then
 			self:Error("Decrement operator (--) must be preceded by variable")
 
-		elseif self:AcceptRoamingToken("rpa") then
+		elseif self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RParen) then
 			self:Error("Right parenthesis ()) without matching left parenthesis")
-		elseif self:AcceptRoamingToken("lcb") then
+		elseif self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.LCurly) then
 			self:Error("Left curly bracket ({) must be part of an if/while/for-statement block")
-		elseif self:AcceptRoamingToken("rcb") then
+		elseif self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RCurly) then
 			self:Error("Right curly bracket (}) without matching left curly bracket")
-		elseif self:AcceptRoamingToken("lsb") then
+		elseif self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.LSquare) then
 			self:Error("Left square bracket ([) must be preceded by variable")
-		elseif self:AcceptRoamingToken("rsb") then
+		elseif self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RSquare) then
 			self:Error("Right square bracket (]) without matching left square bracket")
 
-		elseif self:AcceptRoamingToken("com") then
+		elseif self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.Comma) then
 			self:Error("Comma (,) not expected here, missing an argument?")
-		elseif self:AcceptRoamingToken("col") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Col) then
 			self:Error("Method operator (:) must not be preceded by whitespace")
-		elseif self:AcceptRoamingToken("spread") then
+		elseif self:AcceptRoamingToken(TokenVariant.Operator, Operator.Spread) then
 			self:Error("Spread operator (...) must only be used as a function parameter")
 
-		elseif self:AcceptRoamingToken("if") then
+		elseif self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.If) then
 			self:Error("If keyword (if) must not appear inside an equation")
-		elseif self:AcceptRoamingToken("eif") then
+		elseif self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.Elseif) then
 			self:Error("Else-if keyword (elseif) must be part of an if-statement")
-		elseif self:AcceptRoamingToken("els") then
+		elseif self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.Else) then
 			self:Error("Else keyword (else) must be part of an if-statement")
 
 		else
-			self:Error("Unexpected token found (" .. self.readtoken[1] .. ")")
+			self:Error("Unexpected token found (" .. self.readtoken:display() .. ")")
 		end
 	else
 		self:Error("Further input required at end of code, incomplete expression", self.exprtoken)

--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -1447,12 +1447,15 @@ function Parser:Expr16()
 end
 
 function Parser:Expr17()
-	if self:AcceptRoamingToken(TokenVariant.Decimal) or self:AcceptRoamingToken(TokenVariant.Hexadecimal) or self:AcceptRoamingToken(TokenVariant.Binary) or self:AcceptRoamingToken(TokenVariant.Complex) then
+	-- Basic lua supported numeric literals (decimal, hex, binary)
+	if self:AcceptRoamingToken(TokenVariant.Decimal) or self:AcceptRoamingToken(TokenVariant.Hexadecimal) or self:AcceptRoamingToken(TokenVariant.Binary) then
+		return self:Instruction(self:GetTokenTrace(), "literal", self:GetTokenData(), "n")
+	end
+
+	if self:AcceptRoamingToken(TokenVariant.Complex) or self:AcceptRoamingToken(TokenVariant.Quat) then
 		local trace = self:GetTokenTrace()
 		local tokendata = self:GetTokenData()
-		if isnumber(tokendata) then
-			return self:Instruction(trace, "literal", tokendata, "n")
-		end
+
 		local num, suffix = tokendata:match("^([-+e0-9.]*)(.*)$")
 		num = assert(tonumber(num), "unparseable numeric literal")
 		local value, type
@@ -1465,7 +1468,7 @@ function Parser:Expr17()
 		elseif suffix == "k" then
 			value, type = {0, 0, 0, num}, "q"
 		else
-			assert(false, "unrecognized numeric suffix " .. suffix)
+			error("unrecognized numeric suffix " .. suffix)
 		end
 		return self:Instruction(trace, "literal", value, type)
 	end

--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -704,7 +704,7 @@ function Parser:Stmt10()
 
 		local Trace = self:GetTokenTrace()
 
-		if self:AcceptRoamingToken(TokenVariant.LowerIdent, "void") or (self.readtoken.value and self.readtoken.value == "}") then
+		if self:AcceptRoamingToken(TokenVariant.LowerIdent, "void") or (self.readtoken.variant == TokenVariant.Grammar and self.readtoken.value == Grammar.RCurly) then
 			return self:Instruction(Trace, "return")
 		end
 

--- a/lua/entities/gmod_wire_expression2/base/tokenizer.lua
+++ b/lua/entities/gmod_wire_expression2/base/tokenizer.lua
@@ -1,289 +1,356 @@
 --[[
-  Expression 2 Tokenizer for Garry's Mod
-  Andreas "Syranide" Svensson, me@syranide.com
+	Expression 2 Tokenizer for Garry's Mod
+
+	Rewritten by Vurv
+	Notable changes:
+		* void is no longer a keyword, it is treated like any other type as a lowercase identifier.
+		* tokens are proper instances of a class to allow for methods and simpler usage.
+		* should be much faster to parse, and simpler to read
+		* boolean literals are reserved for later use.
+		* internal representations are stored as enums for faster computation (operators, keywords, grammar)
+		* emmylua annotations
 ]]
 
 AddCSLuaFile()
 
-E2Lib.Tokenizer = {}
-local Tokenizer = E2Lib.Tokenizer
+---@class Tokenizer
+---@field pos integer
+---@field col integer
+---@field line integer
+---@field code string?
+local Tokenizer = {}
 Tokenizer.__index = Tokenizer
 
-function Tokenizer.Execute(...)
+E2Lib.Tokenizer = Tokenizer
+
+---@enum TokenVariant
+local TokenVariant = {
+	Hexadecimal = 1,
+	Binary = 2,
+	Decimal = 3,
+	Quat = 4, -- quat number (4j)
+
+	String = 5, -- "foo"
+
+	Boolean = 6, -- true, false
+
+	Grammar = 7, -- [] () {} ,
+	Operator = 8, -- += + / *
+
+	Keyword = 9,
+	LowerIdent = 10, -- function_name
+
+	Ident = 11, -- VariableName
+
+	Constant = 12, -- _CONST
+}
+
+Tokenizer.Variant = TokenVariant
+
+local VariantLookup = {}
+
+for k, v in pairs(TokenVariant) do
+	VariantLookup[v] = k
+end
+
+Tokenizer.VariantLookup = VariantLookup
+
+
+---@class Token
+---@field variant TokenVariant
+---@field value number|string|boolean
+---@field whitespaced boolean
+---@field start_line integer
+---@field end_line integer
+---@field start_col integer
+---@field end_col integer
+local Token = {}
+Token.__index = Token
+
+Tokenizer.Token = Token
+
+--- Creates a new (partially filled) token
+--- Line, column and whitespaced need to be added manually.
+---@param variant TokenVariant
+---@param value number|string|boolean
+---@return Token
+function Token.new(variant, value)
+	return setmetatable({ variant = variant, value = value }, Token)
+end
+
+--- Returns a debug representation of a token
+---@return string
+function Token:debug()
+	if self.variant == TokenVariant.Operator then
+		return "Token { variant = " .. (VariantLookup[self.variant] or "nil") .. ", value = " .. (E2Lib.OperatorNames[self.value] or "nil") .. "}"
+	elseif self.variant == TokenVariant.Keyword then
+		return "Token { variant = " .. (VariantLookup[self.variant] or "nil") .. ", value = " .. (E2Lib.KeywordNames[self.value] or "nil") .. "}"
+	elseif self.variant == TokenVariant.Grammar then
+		return "Token { variant = " .. (VariantLookup[self.variant] or "nil") .. ", value = " .. (E2Lib.GrammarNames[self.value] or "nil") .. "}"
+	else
+		return "Token { variant = " .. (VariantLookup[self.variant] or "nil") .. ", value = " .. (self.value or "nil") .. "}"
+	end
+end
+
+--- Returns the 'name' of a token for passing to a user.
+---@return string
+function Token:display()
+	if self.variant == TokenVariant.Operator then
+		return E2Lib.OperatorNames[self.value] or "unknown?!"
+	elseif self.variant == TokenVariant.Keyword then
+		return E2Lib.KeywordNames[self.value] or "unknown?!"
+	elseif self.variant == TokenVariant.Grammar then
+		return E2Lib.GrammarNames[self.value] or "unknown?!"
+	else
+		return VariantLookup[self.variant]
+	end
+end
+
+function Tokenizer.Execute(code)
 	-- instantiate Tokenizer
 	local instance = setmetatable({}, Tokenizer)
 
 	-- and pcall the new instance's Process method.
-	return xpcall(Tokenizer.Process, E2Lib.errorHandler, instance, ...)
+	return xpcall(Tokenizer.Process, E2Lib.errorHandler, instance, code)
+end
+
+function Tokenizer:Reset()
+	self.pos = 1
+	self.col = 1
+	self.line = 1
+	self.code = nil
 end
 
 function Tokenizer:Error(message, offset)
-	error(message .. " at line " .. self.tokenline .. ", char " .. (self.tokenchar + (offset or 0)), 0)
+	error(message .. " at line " .. self.line .. ", char " .. (self.col + (offset or 0)), 0)
 end
 
-function Tokenizer:Process(buffer, params)
-	self.buffer = buffer
-	self.length = buffer:len()
-	self.position = 0
+local Escapes = {
+	['\\'] = '\\',
+	['"'] = '"',
+	['a'] = '\a',
+	['b'] = '\b',
+	['f'] = '\f',
+	['n'] = '\n',
+	['r'] = '\r',
+	['t'] = '\t',
+	['v'] = '\v'
+}
 
-	self:SkipCharacter()
+---@return Token?
+function Tokenizer:Next()
+	local match = self:ConsumePattern("^0x[0-9A-F]+")
 
-	local tokens = {}
-	local tokenname, tokendata, tokenspace
-	self.tokendata = ""
+	if match then
+		local val = tonumber(match) or self:Error("Invalid number format (" .. E2Lib.limitString(match, 10) .. ")")
+		return Token.new(TokenVariant.Hexadecimal, val)
+	end
 
-	while self.character do
-		tokenspace = self:NextPattern("%s+") and true or false
+	match = self:ConsumePattern("^0b[0-1]+")
+	if match then
+		local val = tonumber(match) or self:Error("Invalid number format (" .. E2Lib.limitString(match, 10) .. ")")
+		return Token.new(TokenVariant.Binary, val)
+	end
 
-		if not self.character then break end
+	match = self:ConsumePattern("^[0-9]+%.?[0-9]*[eE][+-]?[0-9]+")
+	if match then
+		-- Decimal number with exponent part
+		local val = tonumber(match) or self:Error("Invalid number format (" .. E2Lib.limitString(match, 10) .. ")")
+		return Token.new(TokenVariant.Decimal, val)
+	end
 
-		self.tokenline = self.readline
-		self.tokenchar = self.readchar
-		self.tokendata = ""
+	match = self:ConsumePattern("^[0-9]+%.?[0-9]*[ijk]")
+	if match then
+		-- Quaternion number
+		local val = tonumber(match) or self:Error("Invalid number format (" .. E2Lib.limitString(match, 10) .. ")")
+		return Token.new(TokenVariant.Quat, val)
+	end
 
-		tokenname, tokendata = self:NextSymbol()
+	match = self:ConsumePattern("^[0-9]+%.?[0-9]*")
+	if match then
+		-- Decimal number
+		local val = tonumber(match) or self:Error("Invalid number format (" .. E2Lib.limitString(match, 10) .. ")")
+		return Token.new(TokenVariant.Decimal, val)
+	end
 
-		if tokenname == nil then
-			tokenname, tokendata = self:NextOperator()
+	--[[
+		TODO: Quaternion/Complex numbers
+	]]
 
-			if tokenname == nil then
-				self:Error("Unknown character found (" .. self.character .. ")")
+	match = self:ConsumePattern("^[a-z#][a-zA-Z0-9_]*")
+	if match then
+		-- Keyword/Function
+		if E2Lib.KeywordLookup[match] then
+			return Token.new(TokenVariant.Keyword, E2Lib.KeywordLookup[match])
+		elseif match == "true" then
+			return Token.new(TokenVariant.Boolean, true)
+		elseif match == "false" then
+			return Token.new(TokenVariant.Boolean, false)
+		else
+			-- TODO: Also check if it's a complex number call ? god these are a headache
+			return Token.new(TokenVariant.LowerIdent, match)
+		end
+	end
+
+	match = self:ConsumePattern("^[A-Z][a-zA-Z0-9_]*")
+	if match then
+		return Token.new(TokenVariant.Ident, match)
+	end
+
+	match = self:ConsumePattern("^_[A-Z0-9_]*")
+	if match then
+		-- Constant value
+		local value = wire_expression2_constants[match]
+
+		if isnumber(value) then
+			return Token.new(TokenVariant.Decimal, value)
+		elseif isstring(value) then
+			return Token.new(TokenVariant.String, value)
+		else
+			self:Error("Constant (" .. match .. ") has invalid data type (" .. type(value) .. ")")
+		end
+	end
+
+	if self:At() == "\"" then
+		self:NextChar()
+		local buffer, nbuffer = {}, 0
+		while true do
+			local m = self:ConsumePattern("^[^\"\\]*[\"\\]", true)
+
+			if m then
+				nbuffer = nbuffer + 1
+				buffer[nbuffer] = m:sub(1, -2)
+
+				-- See if the last char in the match was a quote or an escape char
+				if m:sub( -1, -1) == "\"" then
+					break
+				else -- Escape
+					local c = self:At()
+					c = Escapes[c] or c
+
+					if not c then
+						-- self:Error("Invalid escape \\" .. c)
+						c = '\\'
+					end
+
+					self:NextChar()
+
+					nbuffer = nbuffer + 1
+					buffer[nbuffer] = c
+				end
+			else
+				self:Error("Missing \" to end string")
 			end
 		end
 
-		tokens[#tokens + 1] = { tokenname, tokendata, tokenspace, self.tokenline, self.tokenchar }
+		return Token.new(TokenVariant.String, table.concat(buffer, '', 1, nbuffer))
+	end
+
+	if E2Lib.GrammarLookup[self:At()] then
+		local c = self:At()
+		self:NextChar()
+		return Token.new(TokenVariant.Grammar, E2Lib.GrammarLookup[c])
+	end
+
+	---@type string|Operator|nil
+	local op = self:At()
+	while E2Lib.OperatorChars[self:At()] do
+		local c = self:NextChar()
+		if E2Lib.OperatorLookup[op .. c] then
+			op = op .. c
+		elseif E2Lib.OperatorLookup[op .. c .. self:PeekChar()] then
+			op = op .. c .. self:NextChar()
+		elseif E2Lib.OperatorLookup[op] then
+			op = E2Lib.OperatorLookup[op]
+			break
+		else
+			op = nil
+			break
+		end
+	end
+
+	if op then
+		return Token.new(TokenVariant.Operator, op)
+	end
+end
+
+---@return string?
+function Tokenizer:At()
+	return self.code:sub(self.pos, self.pos)
+end
+
+---@return string?
+function Tokenizer:PeekChar()
+	return self.code:sub(self.pos + 1, self.pos + 1)
+end
+
+---@return string?
+function Tokenizer:NextChar()
+	self.pos = self.pos + 1
+	return self.code:sub(self.pos, self.pos)
+end
+
+---@param pattern string
+---@param ws boolean? Whether the pattern may contain newlines. Default false
+---@return string?
+function Tokenizer:ConsumePattern(pattern, ws)
+	local start, ed = self.code:find(pattern, self.pos)
+	if not start then return end
+
+	local match = self.code:sub(start, ed)
+
+	if ws then
+		-- Newlines could possibly be matched.
+		local _, newlines = match:gsub("\n", "")
+
+		if newlines ~= 0 then
+			local final_nl, final_char = match:find("\n[^\n]*$")
+
+			self.pos = ed + 1
+			self.col = final_char - final_nl + 1
+			self.line = self.line + newlines
+
+			return match
+		end
+	end
+
+	-- Assume no newlines were matched past here.
+
+	self.pos = self.pos + (ed - start + 1)
+	self.col = self.col + (ed - start + 1)
+
+	return match
+end
+
+function Tokenizer:Process(code)
+	self:Reset()
+
+	local length = #code
+	local tokens, ntok = {}, 0
+	self.code = code
+
+	local line, col = self.line, self.col
+	while self.pos <= length do
+		local whitespaced = self:ConsumePattern("^%s+", true) ~= nil
+
+		if self.pos > length then
+			break
+		end
+
+		local tok = self:Next()
+		if not tok then
+			self:Error("Failed to parse token")
+		end
+
+		tok.start_line, tok.start_col = line, col + 1
+		tok.end_line, tok.end_col = self.line, self.col + 1
+		tok.whitespaced = whitespaced
+
+		line, col = self.line, self.col
+
+		ntok = ntok + 1
+		tokens[ntok] = tok
 	end
 
 	return tokens
-end
-
--- ---------------------------------------------------------------------------------------
-
-function Tokenizer:SkipCharacter()
-	if self.position < self.length then
-		if self.position > 0 then
-			if self.character == "\n" then
-				self.readline = self.readline + 1
-				self.readchar = 1
-			else
-				self.readchar = self.readchar + 1
-			end
-		else
-			self.readline = 1
-			self.readchar = 1
-		end
-
-		self.position = self.position + 1
-		self.character = self.buffer:sub(self.position, self.position)
-	else
-		self.character = nil
-	end
-end
-
-function Tokenizer:NextCharacter()
-	self.tokendata = self.tokendata .. self.character
-	self:SkipCharacter()
-end
-
--- Returns true on success, nothing if it fails.
-function Tokenizer:NextPattern(pattern)
-	if not self.character then return false end
-	local startpos, endpos, text = self.buffer:find(pattern, self.position)
-
-	if startpos ~= self.position then return false end
-	local buf = self.buffer:sub(startpos, endpos)
-	if not text then text = buf end
-
-	self.tokendata = self.tokendata .. text
-
-
-	self.position = endpos + 1
-	if self.position <= self.length then
-		self.character = self.buffer:sub(self.position, self.position)
-	else
-		self.character = nil
-	end
-
-	buf = string.Explode("\n", buf)
-	if #buf > 1 then
-		self.readline = self.readline + #buf - 1
-		self.readchar = #buf[#buf] + 1
-	else
-		self.readchar = self.readchar + #buf[#buf]
-	end
-	return true
-end
-
-function Tokenizer:NextSymbol()
-	local tokenname
-
-	if self:NextPattern("^0x[0-9A-F]+") then
-		-- Hexadecimal number literal
-		tokenname = "num"
-		self.tokendata = tonumber(self.tokendata) or self:Error("Invalid number format (" .. E2Lib.limitString(self.tokendata, 10) .. ")")
-	elseif self:NextPattern("^0b[0-1]+") then
-		-- Binary number literal
-		tokenname = "num"
-		self.tokendata = tonumber(self.tokendata:sub(3), 2) or self:Error("Invalid number format (" .. E2Lib.limitString(self.tokendata, 10) .. ")")
-	elseif self:NextPattern("^[0-9]+%.?[0-9]*") then
-		-- real/imaginary/quaternion number literals
-		local errorpos = self.tokendata:match("^0()[0-9]") or self.tokendata:find("%.$")
-		if self:NextPattern("^[eE][+-]?[0-9][0-9]*") then
-			errorpos = errorpos or self.tokendata:match("[eE][+-]?()0[0-9]")
-		end
-
-		self:NextPattern("^[ijk]")
-		if self:NextPattern("^[a-zA-Z_]") then
-			errorpos = errorpos or self.tokendata:len()
-		end
-
-		if errorpos then
-			self:Error("Invalid number format (" .. E2Lib.limitString(self.tokendata, 10) .. ")", errorpos - 1)
-		end
-
-		tokenname = "num"
-
-	elseif self:NextPattern("^[a-z#][a-zA-Z0-9_]*") then
-		-- keywords/functions
-		if self.tokendata == "if" then
-			tokenname = "if"
-		elseif self.tokendata == "elseif" then
-			tokenname = "eif"
-		elseif self.tokendata == "else" then
-			tokenname = "els"
-		elseif self.tokendata == "local" then
-			tokenname = "loc"
-		elseif self.tokendata == "while" then
-			tokenname = "whl"
-		elseif self.tokendata == "for" then
-			tokenname = "for"
-		elseif self.tokendata == "break" then
-			tokenname = "brk"
-		elseif self.tokendata == "continue" then
-			tokenname = "cnt"
-		elseif self.tokendata == "switch" then
-			tokenname = "swh"
-		elseif self.tokendata == "case" then
-			tokenname = "case"
-		elseif self.tokendata == "default" then
-			tokenname = "default"
-		elseif self.tokendata == "foreach" then
-			tokenname = "fea"
-		elseif self.tokendata == "function" then
-			tokenname = "func"
-		elseif self.tokendata == "return" then
-			tokenname = "ret"
-		elseif self.tokendata == "void" then
-			tokenname = "void"
-		elseif self.tokendata == "#include" then
-			tokenname = "inclu"
-		elseif self.tokendata == "try" then
-			tokenname = "try"
-		elseif self.tokendata == "catch" then
-			tokenname = "catch"
-		elseif self.tokendata == "do" then
-			tokenname = "do"
-		elseif self.tokendata:match("^[ijk]$") and self.character ~= "(" then
-			tokenname, self.tokendata = "num", "1" .. self.tokendata
-		else
-			tokenname = "fun"
-		end
-
-	elseif self:NextPattern("^[A-Z][a-zA-Z0-9_]*") then
-		-- variables
-		tokenname = "var"
-
-	elseif self.character == "_" then
-		-- constants
-		self:NextCharacter()
-		self:NextPattern("^[A-Z0-9_]*")
-
-		local value = wire_expression2_constants[self.tokendata]
-
-		if isnumber(value) then
-			tokenname = "num"
-			self.tokendata = value
-		elseif isstring(value) then
-			tokenname = "str"
-			self.tokendata = value
-		else
-			self:Error("Constant (" .. self.tokendata .. ") has invalid data type (" .. type(value) .. ")")
-		end
-
-	elseif self.character == "\"" then
-		-- strings
-
-		-- skip opening quotation mark
-		self:SkipCharacter()
-
-		-- loop until the closing quotation mark
-		while self.character ~= "\"" do
-			-- check for line/file endings
-			if not self.character then
-				self:Error("Unterminated string (\"" .. E2Lib.limitString(self.tokendata, 10):gsub("\n", "") .. ")")
-			end
-
-			if self.character == "\\" then
-				self:SkipCharacter()
-				if self.character == "a" then
-					self.tokendata = self.tokendata .. "\a"
-					self:SkipCharacter()
-				elseif self.character == "b" then
-					self.tokendata = self.tokendata .. "\b"
-					self:SkipCharacter()
-				elseif self.character == "f" then
-					self.tokendata = self.tokendata .. "\f"
-					self:SkipCharacter()
-				elseif self.character == "n" then
-					self.tokendata = self.tokendata .. "\n"
-					self:SkipCharacter()
-				elseif self.character == "r" then
-					self.tokendata = self.tokendata .. "\r"
-					self:SkipCharacter()
-				elseif self.character == "t" then
-					self.tokendata = self.tokendata .. "\t"
-					self:SkipCharacter()
-				elseif self.character == "v" then
-					self.tokendata = self.tokendata .. "\v"
-					self:SkipCharacter()
-				else
-					self:NextCharacter()
-				end
-			else
-				self:NextCharacter()
-			end
-		end
-		-- skip closing quotation mark
-		self:SkipCharacter()
-
-		tokenname = "str"
-
-	else
-		-- nothing
-		return
-	end
-
-	return tokenname, self.tokendata
-end
-
-function Tokenizer:NextOperator()
-	local op = E2Lib.optable[self.character]
-
-	if not op then return end
-
-	while true do
-		self:NextCharacter()
-
-		-- Check for the end of the string.
-		if not self.character then return op[1] end
-
-		-- Check whether we are at a leaf and can't descend any further.
-		if not op[2] then return op[1] end
-
-		-- Check whether we are at a node with no matching branches.
-		if not op[2][self.character] then return op[1] end
-
-		-- branch
-		op = op[2][self.character]
-	end
 end

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -337,13 +337,6 @@ E2Lib.optable_inv = {
 	qsm = "?",
 	col = ":",
 	def = "?:",
-	com = ",",
-	lpa = "(",
-	rpa = ")",
-	lcb = "{",
-	rcb = "}",
-	lsb = "[",
-	rsb = "]",
 	dlt = "$",
 	trg = "~",
 	imp = "->",
@@ -374,7 +367,7 @@ for token, op in pairs(E2Lib.optable_inv) do
 end
 
 function E2Lib.printops()
-	local op_order = { ["+"] = 1, ["-"] = 2, ["*"] = 3, ["/"] = 4, ["%"] = 5, ["^"] = 6, ["="] = 7, ["!"] = 8, [">"] = 9, ["<"] = 10, ["&"] = 11, ["|"] = 12, ["?"] = 13, [":"] = 14, [","] = 15, ["("] = 16, [")"] = 17, ["{"] = 18, ["}"] = 19, ["["] = 20, ["]"] = 21, ["$"] = 22, ["~"] = 23 }
+	local op_order = { ["+"] = 1, ["-"] = 2, ["*"] = 3, ["/"] = 4, ["%"] = 5, ["^"] = 6, ["="] = 7, ["!"] = 8, [">"] = 9, ["<"] = 10, ["&"] = 11, ["|"] = 12, ["?"] = 13, [":"] = 14, ["$"] = 15, ["~"] = 16 }
 	print("E2Lib.optable = {")
 	for k, v in pairs_sortkeys(E2Lib.optable, function(a, b) return (op_order[a] or math.huge) < (op_order[b] or math.huge) end) do
 		local tblstring = table.ToString(v)
@@ -385,6 +378,200 @@ function E2Lib.printops()
 	end
 	print("}")
 end
+
+---@enum Keyword
+local Keyword = {
+	-- ``if``
+	If = 1,
+	-- ``elseif``
+	Elseif = 2,
+	-- ``else``
+	Else = 3,
+	-- ``local``
+	Local = 4,
+	-- ``while``
+	While = 5,
+	-- ``for``
+	For = 6,
+	-- ``break``
+	Break = 7,
+	-- ``continue``
+	Continue = 8,
+	-- ``switch``
+	Switch = 9,
+	-- ``case``
+	Case = 10,
+	-- ``default``
+	Default = 11,
+	-- ``foreach``
+	Foreach = 12,
+	-- ``function``
+	Function = 13,
+	-- ``return``
+	Return = 14,
+	-- ``#include``
+	["#Include"] = 15,
+	-- ``try``
+	Try = 16,
+	-- ``catch``
+	Catch = 17,
+	-- ``do``
+	Do = 18
+}
+
+E2Lib.Keyword = Keyword
+
+---@type table<string, Keyword>
+E2Lib.KeywordLookup = {}
+
+for kw, v in pairs(Keyword) do
+	E2Lib.KeywordLookup[kw:lower()] = v
+end
+
+local KeywordNames = {}
+for name, val in pairs(Keyword) do
+	KeywordNames[val] = name
+end
+E2Lib.KeywordNames = KeywordNames
+
+---@enum Grammar
+local Grammar = {
+	-- {
+	LCurly = 1,
+	-- }
+	RCurly = 2,
+	-- (
+	LParen = 3,
+	-- )
+	RParen = 4,
+	-- [
+	LSquare = 5,
+	-- ]
+	RSquare = 6,
+	-- ,
+	Comma = 7
+}
+
+E2Lib.Grammar = Grammar
+E2Lib.GrammarLookup = {
+	['{'] = Grammar.LCurly,
+	['}'] = Grammar.RCurly,
+	['('] = Grammar.LParen,
+	[')'] = Grammar.RParen,
+	['['] = Grammar.LSquare,
+	[']'] = Grammar.RSquare,
+	[','] = Grammar.Comma
+}
+
+local GrammarNames = {}
+for name, val in pairs(Grammar) do
+	GrammarNames[val] = name
+end
+E2Lib.GrammarNames = GrammarNames
+
+---@enum Operator
+local Operator = {
+	-- `+`
+	Add = 1,
+	-- `-`
+	Sub = 2,
+	-- `*`
+	Mul = 3,
+	-- `/`
+	Div = 4,
+	-- `%`
+	Mod = 5,
+	-- `^`
+	Exp = 6,
+	-- `=`
+	Ass = 7,
+	-- +=
+	Aadd = 8,
+	-- -=
+	Asub = 9,
+	-- `*=`
+	Amul = 10,
+	-- `/=`
+	Adiv = 11,
+	-- `++`
+	Inc = 12,
+	-- `--`
+	Dec = 13,
+	-- `==`
+	Eq = 14,
+	-- `!=`
+	Neq = 15,
+	-- `<`
+	Lth = 16,
+	-- `>=`
+	Geq = 17,
+	-- `<=`
+	Leq = 18,
+	-- `>`
+	Gth = 19,
+	-- `&&`
+	Band = 20,
+	-- `||`
+	Bor = 21,
+	-- `^^`
+	Bxor = 22,
+	-- `>>`
+	Bshr = 23,
+	-- `<<`
+	Bshl = 24,
+	-- `!`
+	Not = 25,
+	-- `&`
+	And = 26,
+	-- `|`
+	Or = 27,
+	-- `?`
+	Qsm = 28,
+	-- `:`
+	Col = 29,
+	-- `?:`
+	Def = 30,
+	-- `$`
+	Dlt = 31,
+	-- `~`
+	Trg = 32,
+	-- `->`
+	Imp = 33,
+	-- `...`
+	Spread = 34
+}
+
+E2Lib.Operator = Operator
+
+local OperatorNames = {}
+for name, val in pairs(Operator) do
+	OperatorNames[val] = name
+end
+E2Lib.OperatorNames = OperatorNames
+
+local OperatorLookup = {
+	["+"] = Operator.Add, ["-"] = Operator.Sub, ["*"] = Operator.Mul, ["/"] = Operator.Div,
+	["%"] = Operator.Mod, ["^"] = Operator.Exp, ["="] = Operator.Ass, ["+="] = Operator.Aadd,
+	["-="] = Operator.Asub, ["*="] = Operator.Amul, ["/="] = Operator.Adiv, ["++"] = Operator.Inc,
+	["--"] = Operator.Dec, ["=="] = Operator.Eq, ["!="] = Operator.Neq, ["<"] = Operator.Lth,
+	[">="] = Operator.Geq, ["<="] = Operator.Leq, [">"] = Operator.Gth, ["&&"] = Operator.Band,
+	["||"] = Operator.Bor, ["^^"] = Operator.Bxor, [">>"] = Operator.Bshr, ["<<"] = Operator.Bshl,
+	["!"] = Operator.Not, ["&"] = Operator.And, ["|"] = Operator.Or, ["?"] = Operator.Qsm,
+	[":"] = Operator.Col, ["?:"] = Operator.Def, ["$"] = Operator.Dlt, ["~"] = Operator.Trg,
+	["->"] = Operator.Imp, ["..."] = Operator.Spread
+}
+
+E2Lib.OperatorLookup = OperatorLookup
+
+local OperatorChars = {}
+for op in pairs(OperatorLookup) do
+	for i = 1, #op do
+		local c = op:sub(i, i)
+		OperatorChars[c] = true
+	end
+end
+
+E2Lib.OperatorChars = OperatorChars
 
 E2Lib.blocked_array_types = {
 	["t"] = true,
@@ -825,7 +1012,7 @@ end
 ---@return boolean success If ran successfully
 ---@return string|function compiled Compiled function, or error message if not success
 function E2Lib.compileScript(code, owner, run)
-	local status, directives, code = E2Lib.PreProcessor.Execute(code,nil,ctx)
+	local status, directives, code = E2Lib.PreProcessor.Execute(code)
 	if not status then return false, directives end -- Preprocessor failed.
 
 	local status, tokens = E2Lib.Tokenizer.Execute(code)


### PR DESCRIPTION
This shouldn't change any common behavior for E2 users but makes the tokenizer *much* faster and simpler. This is part of a greater effort to rewrite the internals of the E2 Compiler (no promises on rewriting the parser though, that would take significantly more time)

The only changed behavior would be no longer allowing usage of booleans (`true` / `false`) for function names, and now allowing `void` to be used as a function name (same as the rest of the types, since it has been changed to no longer be a keyword)

### Notable Changes
* `void` is no longer a keyword, it is treated like any other type.
* tokens are proper instances of a class to allow for methods and simpler usage.
* should be much faster to parse, and simpler to read
* boolean literals (`true` / `false`) are reserved for later use.
* internal representations are stored as enums for faster computation (operators, keywords, grammar)
* emmylua annotations

Since this is such a large change I would appreciate any tests with massive E2 chips from the community to make sure they still compile (or just send me the code to test)