### PR TITLE
Fix vector/angle operations

### DIFF
--- a/data/expression2/tests/regressions/2420.txt
+++ b/data/expression2/tests/regressions/2420.txt
@@ -1,0 +1,39 @@
+## SHOULD_PASS:EXECUTE
+
+local Ang = ang(1, 2, 3)
+
+assert(Ang:pitch() == 1)
+assert(Ang:yaw() == 2)
+assert(Ang:roll() == 3)
+
+assert(Ang == ang(1, 2, 3))
+assert(Ang * 2 == ang(2, 4, 6))
+assert(2 * Ang == ang(2, 4, 6))
+
+assert(Ang / 2 == ang(0.5, 1, 1.5))
+assert(2 / Ang == ang(2, 1, 2/3))
+
+assert(Ang + 2 == ang(3, 4, 5))
+assert(2 + Ang == ang(3, 4, 5))
+
+assert(Ang - 2 == ang(-1, 0, 1))
+assert(2 - Ang == ang(1, 0, -1))
+
+local Vec = vec(1, 2, 3)
+
+assert(Vec:x() == 1)
+assert(Vec:y() == 2)
+assert(Vec:z() == 3)
+
+assert(Vec == vec(1, 2, 3))
+assert(Vec * 2 == vec(2, 4, 6))
+assert(2 * Vec == vec(2, 4, 6))
+
+assert(Vec / 2 == vec(0.5, 1, 3/2))
+assert(2 / Vec == vec(2, 1, 2/3))
+
+assert(Vec + 2 == vec(3, 4, 5))
+assert(2 + Vec == vec(3, 4, 5))
+
+assert(Vec - 2 == vec(-1, 0, 1))
+assert(2 - Vec == vec(1, 0, -1))

--- a/lua/entities/gmod_wire_expression2/core/angle.lua
+++ b/lua/entities/gmod_wire_expression2/core/angle.lua
@@ -140,27 +140,28 @@ e2function angle operator-(angle rv1, angle rv2)
 end
 
 e2function angle operator*(angle rv1, angle rv2)
-	return rv1 * rv2
+	return Angle( rv1[1] * rv2[1], rv1[2] * rv2[2], rv1[3] * rv2[3] )
 end
 
 e2function angle operator*(rv1, angle rv2)
-	return Angle(rv1 * rv2[1], rv1 * rv2[2], rv1 * rv2[3])
+	return rv1 * rv2
 end
 
 e2function angle operator*(angle rv1, rv2)
-	return Angle(rv1[1] * rv2, rv1[2] * rv2, rv1[3] * rv2)
+	return rv1 * rv2
 end
 
+-- Yes this needs to be in pure lua. Angle/Vector operations in reverse order act as Angle / Number rather than Number / Angle properly. Amazing.
 e2function angle operator/(rv1, angle rv2)
-    return Angle(rv1 / rv2[1], rv1 / rv2[2], rv1 / rv2[3])
+    return Angle( rv1 / rv2[1], rv1 / rv2[2], rv1 / rv2[3] )
 end
 
 e2function angle operator/(angle rv1, rv2)
-    return Angle(rv1[1] / rv2, rv1[2] / rv2, rv1[3] / rv2)
+    return  rv1 / rv2
 end
 
 e2function angle operator/(angle rv1, angle rv2)
-	return rv1 / rv2
+	return Angle( rv1[1] / rv2[1], rv1[2] / rv2[2], rv1[3] / rv2[3] )
 end
 
 e2function number angle:operator[](index)

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -979,6 +979,9 @@ function E2Lib.raiseException(msg, level, trace, can_catch)
 end
 
 --- Unpacks either an exception object as seen above or an error string.
+---@return boolean catchable
+---@return string msg
+---@return TokenTrace? trace
 function E2Lib.unpackException(struct)
 	if isstring(struct) then
 		return false, struct, nil
@@ -1074,8 +1077,13 @@ function E2Lib.compileScript(code, owner, run)
 		if success then
 			return true
 		else
-			why = select(2, E2Lib.unpackException(why))
-			return false, why
+			local _, why, trace = E2Lib.unpackException(why)
+
+			if trace then
+				return false, "Runtime error: '" .. why .. "' at line " .. trace[1] .. ", col " .. trace[2]
+			else
+				return false, why
+			end
 		end
 	end
 end

--- a/lua/entities/gmod_wire_expression2/core/vector.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector.lua
@@ -138,27 +138,28 @@ e2function vector operator-(vector lhs, vector rhs)
 end
 
 e2function vector operator*(lhs, vector rhs)
-	return Vector(lhs * rhs[1], lhs * rhs[2], lhs * rhs[3])
-end
-
-e2function vector operator*(vector lhs, rhs)
-	return Vector(lhs[1] * rhs, lhs[2] * rhs, lhs[3] * rhs)
-end
-
-e2function vector operator*(vector lhs, vector rhs)
 	return lhs * rhs
 end
 
+e2function vector operator*(vector lhs, rhs)
+	return lhs * rhs
+end
+
+e2function vector operator*(vector lhs, vector rhs)
+	return Vector( lhs[1] * rhs[1], lhs[2] * rhs[2], lhs[3] * rhs[3] )
+end
+
+-- Yes this needs to be in pure lua. Angle/Vector operations in reverse order act as Angle / Number rather than Number / Angle properly. Amazing.
 e2function vector operator/(lhs, vector rhs)
-	return Vector(lhs / rhs[1], lhs / rhs[2], lhs / rhs[3])
+	return Vector( lhs / rhs[1], lhs / rhs[2], lhs / rhs[3] )
 end
 
 e2function vector operator/(vector lhs, rhs)
-	return Vector(lhs[1] / rhs, lhs[2] / rhs, lhs[3] / rhs )
+	return lhs / rhs
 end
 
 e2function vector operator/(vector lhs, vector rhs)
-	return lhs / rhs
+	return Vector( lhs[1] / rhs[1], lhs[2] / rhs[2], lhs[3] / rhs[3] )
 end
 
 e2function number vector:operator[](index)


### PR DESCRIPTION
Also added unit tests. Broke because the add/sub operators only accept angles yet the mul/div operators only accept numbers.. amazing

Additionally made the E2Lib.compileScript function return a human-friendly error in case a trace is returned from a runtime error (usual case), so the ``e2test`` now prints with actually useful error traces.

Fixes #2420 