### PR TITLE
Implement warning system for preprocessor/tokenizer/parser, plus more warnings

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -10,18 +10,30 @@ AddCSLuaFile()
 ---@class Compiler
 ---@field warnings table<number|string, Warning> # Array of warnings (main file) with keys to included file warnings.
 ---@field include string? # Current include file or nil if main file
-E2Lib.Compiler = {}
-local Compiler = E2Lib.Compiler
+---@field Scopes Scope[]
+---@field Scope Scope?
+---@field ScopeID integer
+---@field GlobalScope Scope
+---@field persist table<string, string> # Variable: Type
+---@field inputs table<string, string> # Variable: Type
+---@field outputs table<string, string> # Variable: Type
+local Compiler = {}
 Compiler.__index = Compiler
+E2Lib.Compiler = Compiler
 
 local BLOCKED_ARRAY_TYPES = E2Lib.blocked_array_types
 
+---@return boolean ok
+---@return function script
+---@return Compiler self
 function Compiler.Execute(...)
 	-- instantiate Compiler
 	local instance = setmetatable({ warnings = {} }, Compiler)
 
 	-- and pcall the new instance's Process method.
-	return xpcall(Compiler.Process, E2Lib.errorHandler, instance, ...)
+	local ok, script = xpcall(Compiler.Process, E2Lib.errorHandler, instance, ...)
+
+	return ok, script, instance
 end
 
 function Compiler:Error(message, instr)
@@ -43,14 +55,15 @@ function Compiler:CallInstruction(name, trace, ...)
 	return self["Instr" .. string_upper(name)](self, trace, ...)
 end
 
+---@return function script
 function Compiler:Process(root, inputs, outputs, persist, delta, includes) -- Took params out becuase it isnt used.
 	self.context = {}
 
 	self:InitScope() -- Creates global scope!
 
-	self.inputs = inputs
-	self.outputs = outputs
-	self.persist = persist
+	self.inputs = inputs[3]
+	self.outputs = outputs[3]
+	self.persist = persist[3]
 	self.includes = includes or {}
 	self.prfcounter = 0
 	self.prfcounters = {}
@@ -60,16 +73,16 @@ function Compiler:Process(root, inputs, outputs, persist, delta, includes) -- To
 	self.funcs_ret = {}
 	self.EnclosingFunctions = { --[[ { ReturnType: string } ]] }
 
-	for name, v in pairs(inputs) do
-		self:SetGlobalVariableType(name, wire_expression_types[v][1], { nil, { 0, 0 } })
+	for name, v in pairs(inputs[3]) do
+		self:SetGlobalVariableType(name, wire_expression_types[v][1], { nil, inputs[5][name] }, true)
 	end
 
-	for name, v in pairs(outputs) do
-		self:SetGlobalVariableType(name, wire_expression_types[v][1], { nil, { 0, 0 } })
+	for name, v in pairs(outputs[3]) do
+		self:SetGlobalVariableType(name, wire_expression_types[v][1], { nil, outputs[5][name] }, false)
 	end
 
-	for name, v in pairs(persist) do
-		self:SetGlobalVariableType(name, wire_expression_types[v][1], { nil, { 0, 0 } })
+	for name, v in pairs(persist[3]) do
+		self:SetGlobalVariableType(name, wire_expression_types[v][1], { nil, persist[5][name] }, false)
 	end
 
 	for name, v in pairs(delta) do
@@ -80,9 +93,15 @@ function Compiler:Process(root, inputs, outputs, persist, delta, includes) -- To
 
 	local script = self:CallInstruction(root[1], root)
 
+	for name, var in pairs(self.GlobalScope) do
+		if var.var_tok then
+			self:Warning("Unused global variable [" .. name .. "]", var.var_tok)
+		end
+	end
+
 	self:PopScope()
 
-	return script, self
+	return script
 end
 
 function tps_pretty(tps)
@@ -99,6 +118,13 @@ end
 local function op_find(name)
 	return E2Lib.optable_inv[name] or "unknown?!"
 end
+
+---@class ScopeData
+---@field type string
+---@field var_tok table? # Instance token pointing to the declaration, only exists if variable has yet to be used.
+---@field initialized boolean # Whether the variable is defined as initialized (e.g. whether a @persist variable has been assigned to by the user)
+
+---@alias Scope table<string, ScopeData>
 
 --[[
 	Scopes: Rusketh
@@ -135,34 +161,46 @@ function Compiler:LoadScopes(Scopes)
 end
 
 function Compiler:SetLocalVariableType(name, type, instance)
-	local typ = self.Scope[name]
-	if typ and typ ~= type then
-		self:Error("Variable (" .. E2Lib.limitString(name, 10) .. ") of type [" .. tps_pretty({ typ }) .. "] cannot be assigned value of type [" .. tps_pretty({ type }) .. "]", instance)
+	local var = self.Scope[name]
+	if var and var.type ~= type then
+		self:Error("Variable (" .. E2Lib.limitString(name, 10) .. ") of type [" .. tps_pretty({ var.type }) .. "] cannot be assigned value of type [" .. tps_pretty({ type }) .. "]", instance)
 	end
 
-	self.Scope[name] = type
+	self.Scope[name] = { type = type, var_tok = instance, initialized = true }
 	return self.ScopeID
 end
 
-function Compiler:SetGlobalVariableType(name, type, instance)
+---@param initialized boolean
+function Compiler:SetGlobalVariableType(name, type, instance, initialized)
 	for i = self.ScopeID, 0, -1 do
-		local typ = self.Scopes[i][name]
-		if typ and typ ~= type then
-			self:Error("Variable (" .. E2Lib.limitString(name, 10) .. ") of type [" .. tps_pretty({ typ }) .. "] cannot be assigned value of type [" .. tps_pretty({ type }) .. "]", instance)
-		elseif typ then
+		local var = self.Scopes[i][name]
+		if var then
+			if var.type ~= type then
+				self:Error("Variable (" .. E2Lib.limitString(name, 10) .. ") of type [" .. tps_pretty({ var.type }) .. "] cannot be assigned value of type [" .. tps_pretty({ type }) .. "]", instance)
+			elseif i == 0 and not var.initialized then
+				var.var_tok = instance
+				var.initialized = true
+				return i
+			end
+			return i
+		end
+		if var and var.type ~= type then
+			self:Error("Variable (" .. E2Lib.limitString(name, 10) .. ") of type [" .. tps_pretty({ var.type }) .. "] cannot be assigned value of type [" .. tps_pretty({ type }) .. "]", instance)
+		elseif var then
 			return i
 		end
 	end
 
-	self.GlobalScope[name] = type
+	self.GlobalScope[name] = { type = type, var_tok = instance, initialized = initialized }
 	return 0
 end
 
 function Compiler:GetVariableType(instance, name)
 	for i = self.ScopeID, 0, -1 do
-		local type = self.Scopes[i][name]
-		if type then
-			return type, i
+		local var = self.Scopes[i][name]
+		if var then
+			var.var_tok = nil
+			return var.type, i, var.initialized
 		end
 	end
 
@@ -183,7 +221,7 @@ function Compiler:EvaluateStatement(args, index)
 
 	return ex, tp, name, extra
 end
- 
+
 function Compiler:Evaluate(args, index)
 	local ex, tp, name = self:EvaluateStatement(args, index)
 
@@ -328,6 +366,45 @@ end
 
 -- ------------------------------------------------------------------------
 
+--- Warnings for expressions in statement positions
+-- "add", "sub", "mul", "div", "mod", "exp", "eq", "neq", "geq", "leq", "gth", "lth", "band", "band", "bor", "bxor", "bshl", "bshr"
+local ExprWarnings = {
+	["GET"] = "Cannot discard value of an index (Remove this pointless indexing)",
+	["LITERAL"] = "This literal won't have any effect on the code",
+
+	["NOT"] = "Cannot discard result of logical NOT operation (!)",
+	["AND"] = "Cannot discard result of logical AND operation (&)",
+	["OR"] = "Cannot discard result of logical OR operation (|)",
+
+	["BAND"] = "Cannot discard result of binary AND operation (&&)",
+	["BOR"] = "Cannot discard result of binary OR operation (||)",
+
+	["BXOR"] = "Cannot discard result of binary XOR operation (^^)",
+
+	["BSHL"] = "Cannot discard result of binary left shift operation (<<)",
+	["BSHR"] = "Cannot discard result of binary right shift operation (>>)",
+
+	["ADD"] = "Cannot discard result of addition operation (+)",
+	["SUB"] = "Cannot discard result of subtraction operation (-)",
+	["MUL"] = "Cannot discard result of multiplication operation (*)",
+	["DIV"] = "Cannot discard result of division operation (/)",
+	["MOD"] = "Cannot discard result of modulus operation (%)",
+	["EXP"] = "Cannot discard result of exponential operation (^)",
+
+	["EQ"] = "Cannot discard result of equal to comparison (==)",
+	["NEQ"] = "Cannot discard result of not equal to comparison (!=)",
+	["GEQ"] = "Cannot discard result of greater than or equal to comparison (>=)",
+	["LEQ"] = "Cannot discard result of less than than or equal to comparison (<=)",
+	["GTH"] = "Cannot discard result of greater than comparison (>)",
+	["LTH"] = "Cannot discard result of less than comparison (<)",
+
+	["TRG"] = "Cannot discard result of triggered (~) operation",
+	["DLT"] = "Cannot discard result of delta ($) operator",
+	["IWC"] = "Cannot discard result of connected (->) operator",
+
+	["VAR"] = "Cannot discard variable"
+}
+
 function Compiler:InstrSEQ(args)
 	-- args = { "seq", trace, subexpressions... }
 	self:PushPrfCounter()
@@ -345,10 +422,17 @@ function Compiler:InstrSEQ(args)
 				if extra and extra.nodiscard then
 					self:Warning("The return value of this function cannot be discarded", args[i + 2])
 				end
-			elseif instr == "GET" then
-				self:Warning("Cannot discard the value of an index (Remove pointless indexing)", args[i + 2])
+			elseif ExprWarnings[instr] then
+				self:Warning(ExprWarnings[instr], args[i + 2])
 			end
+
 			stmts[#stmts + 1] = stmt
+		end
+	end
+
+	for varname, var in pairs(self.Scope) do
+		if var ~= true and var.var_tok then
+			self:Warning("Unused variable [" .. varname .. "]", var.var_tok)
 		end
 	end
 
@@ -386,6 +470,8 @@ function Compiler:InstrFOR(args)
 
 	self:PushScope()
 	self:SetLocalVariableType(var, "n", args)
+	self.Scope[var].var_tok = nil -- TODO: Remove this when a solution for unused for loop variables is determined.
+	-- E2 can't use _ as a variable identifier and has no non-variable binding for loop, so warning users for what they can't control isn't very nice.
 
 	local stmt = self:EvaluateStatement(args, 5)
 	self:PopScope()
@@ -395,7 +481,6 @@ end
 
 function Compiler:InstrWHL(args)
 	-- args = { "whl", trace, condition expression, loop body, skip condition check first time? }
-
 
 	local skipCondFirstTime = args[5]
 
@@ -576,7 +661,13 @@ function Compiler:InstrASS(args)
 	-- args = { "ass", trace, variable name, assigned expression }
 	local op = args[3]
 	local ex, tp = self:Evaluate(args, 2)
-	local ScopeID = self:SetGlobalVariableType(op, tp, args)
+
+	local ScopeID = self:SetGlobalVariableType(op, tp, args, true)
+	if ScopeID == 0 and self.outputs[op] then
+		-- Mark output variable as being used to prevent warnings.
+		self.Scopes[ScopeID][op].var_tok = nil
+	end
+
 	local rt = self:GetOperator(args, "ass", { tp })
 
 	if ScopeID == 0 and self.dvars[op] then
@@ -659,6 +750,7 @@ end
 
 -- generic code for all binary non-boolean operators
 for _, operator in ipairs({ "add", "sub", "mul", "div", "mod", "exp", "eq", "neq", "geq", "leq", "gth", "lth", "band", "band", "bor", "bxor", "bshl", "bshr" }) do
+
 	Compiler["Instr" .. operator:upper()] = function(self, args)
 		-- args = { operator, trace, left expression, right expression }
 		local ex1, tp1 = self:Evaluate(args, 1)
@@ -787,7 +879,11 @@ function Compiler:InstrVAR(args)
 	-- args = { "var", trace, variable name }
 	self.prfcounter = self.prfcounter + 1.0
 	local name = args[3]
-	local tp, ScopeID = self:GetVariableType(args, name)
+	local tp, ScopeID, initialized = self:GetVariableType(args, name)
+
+	if ScopeID == 0 and not initialized then
+		self:Warning("Use of variable [" .. name .. "] before initialization", args)
+	end
 
 	return {function(self)
 		return self.Scopes[ScopeID][name]
@@ -825,6 +921,9 @@ function Compiler:InstrFEA(args)
 	self:PushScope()
 
 	self:SetLocalVariableType(keyvar, keytype, args)
+	self.Scope[keyvar].var_tok = nil -- TODO: Remove this when a solution for unused for loop variables is determined.
+	-- E2 can't use _ as a variable identifier and has no non-variable binding for loop, so warning users for what they can't control isn't very nice.
+
 	self:SetLocalVariableType(valvar, valtype, args)
 
 	local stmt = self:EvaluateStatement(args, 6)

--- a/lua/entities/gmod_wire_expression2/base/optimizer.lua
+++ b/lua/entities/gmod_wire_expression2/base/optimizer.lua
@@ -15,6 +15,8 @@ local optimizerDebug = CreateConVar("wire_expression2_optimizer_debug", 0,
     "Print an E2's abstract syntax tree after optimization"
 )
 
+---@return boolean ok
+---@return table ast
 function Optimizer.Execute(root)
     local ok, result = xpcall(Optimizer.Process, E2Lib.errorHandler, root)
     if ok and optimizerDebug:GetBool() then
@@ -25,6 +27,7 @@ end
 
 Optimizer.Passes = {}
 
+---@return table ast
 function Optimizer.Process(tree)
     E2Lib.AST.visitChildren(tree, Optimizer.Process)
 

--- a/lua/entities/gmod_wire_expression2/base/preprocessor.lua
+++ b/lua/entities/gmod_wire_expression2/base/preprocessor.lua
@@ -5,20 +5,37 @@
 
 AddCSLuaFile()
 
-E2Lib.PreProcessor = {}
-local PreProcessor = E2Lib.PreProcessor
+---@class PreProcessor
+---@field blockcomment boolean # Whether preprocessor is inside a block comment
+---@field multilinestring boolean # Whether preprocessor is inside a multiline string
+---@field readline integer
+---@field warnings Warning[]
+local PreProcessor = {}
 PreProcessor.__index = PreProcessor
 
+E2Lib.PreProcessor = PreProcessor
+
+---@return boolean ok
+---@return table? directives
+---@return string? newcode
+---@return PreProcessor self
 function PreProcessor.Execute(...)
 	-- instantiate PreProcessor
 	local instance = setmetatable({}, PreProcessor)
 
 	-- and pcall the new instance's Process method.
-	return xpcall(instance.Process, E2Lib.errorHandler, instance, ...)
+	local ok, directives, newcode = xpcall(instance.Process, E2Lib.errorHandler, instance, ...)
+	return ok, directives, newcode, instance
 end
 
 function PreProcessor:Error(message, column)
 	error(message .. " at line " .. self.readline .. ", char " .. (column or 1), 0)
+end
+
+---@param message string
+---@param column integer?
+function PreProcessor:Warning(message, column)
+	self.warnings[#self.warnings + 1] = { message = message, line = self.readline, char = column or 1 }
 end
 
 local type_map = {
@@ -30,9 +47,15 @@ local type_map = {
 	wl = "xwl",
 	number = "n",
 }
-local function gettype(tp)
+
+function PreProcessor:GetType(tp, column)
 	tp = tp:Trim():lower()
 	local up = tp:upper()
+
+	if tp == "normal" then
+		self:Warning("Use of deprecated type [normal]", column)
+	end
+
 	return type_map[tp] or (wire_expression_types[up] and wire_expression_types[up][1]) or tp
 end
 
@@ -171,16 +194,17 @@ end
 local function handleIO(name)
 	return function(self, value)
 		local ports = self.directives[name]
-		local retval, columns = self:ParsePorts(value, #name + 2)
+		local retval, columns, lines = self:ParsePorts(value, #name + 2)
 
 		for i, key in ipairs(retval[1]) do
 			if ports[3][key] then
 				self:Error("Directive (@" .. name .. ") contains multiple definitions of the same variable", columns[i])
 			else
 				local index = #ports[1] + 1
-				ports[1][index] = key
-				ports[2][index] = retval[2][i]
-				ports[3][key] = retval[2][i]
+				ports[1][index] = key -- Index: Name
+				ports[2][index] = retval[2][i] -- Index: Type
+				ports[3][key] = retval[2][i] -- Name: Type
+				ports[5][key] = { lines[i], columns[i] } -- Name: { Line, Column }
 			end
 		end
 	end
@@ -200,6 +224,10 @@ local directive_handlers = {
 	["model"] = function(self, value)
 		if not self.ignorestuff then
 			if self.directives.model == nil then
+				if not util.IsValidModel(value) then
+					self:Warning("Directive (@model) has an invalid model: " .. value)
+				end
+
 				self.directives.model = value
 			else
 				self:Error("Directive (@model) must not be specified twice")
@@ -297,6 +325,7 @@ function PreProcessor:Process(buffer, directives, ent)
 	-- entity is needed for autoupdate
 	self.ent = ent
 	self.ifdefStack = {}
+	self.warnings = {}
 
 	local lines = string.Explode("\n", buffer)
 
@@ -304,9 +333,9 @@ function PreProcessor:Process(buffer, directives, ent)
 		self.directives = {
 			name = nil,
 			model = nil,
-			inputs = { {}, {}, {}, {} }, -- 1: names, 2: types, 3: names=types lookup, 4: descriptions
-			outputs = { {}, {}, {}, {} }, -- 1: names, 2: types, 3: names=types lookup, 4: descriptions
-			persist = { {}, {}, {} },
+			inputs = { {}, {}, {}, {}, {} }, -- 1: names, 2: types, 3: names=types lookup, 4: descriptions, 5: names={line, column} lookup
+			outputs = { {}, {}, {}, {}, {} }, -- 1: names, 2: types, 3: names=types lookup, 4: descriptions, 5: names={line, column} lookup
+			persist = { {}, {}, {}, nil, {} },
 			delta = { {}, {}, {} },
 			trigger = { nil, {} },
 		}
@@ -336,9 +365,7 @@ function PreProcessor:Process(buffer, directives, ent)
 end
 
 function PreProcessor:ParsePorts(ports, startoffset)
-	local names = {}
-	local types = {}
-	local columns = {}
+	local names, types, columns, lines = {}, {}, {}, {}
 
 	-- Preprocess [Foo Bar]:entity into [Foo,Bar]:entity so we don't have to deal with split-up multi-variable definitions in the main loop
 	ports = ports:gsub("%[.-%]", function(s)
@@ -391,10 +418,14 @@ function PreProcessor:ParsePorts(ports, startoffset)
 				self:Error("Variable type [" .. E2Lib.limitString(vtype, 10) .. "] must be lowercase", column + i + 1)
 			end
 
-			if vtype == "number" then vtype = "normal" end
+			if vtype == "normal" then
+				self:Warning("Variable type [normal] is deprecated (use number instead)", column + i + 1)
+			else
+				if vtype == "number" then vtype = "normal" end
 
-			if not wire_expression_types[vtype:upper()] then
-				self:Error("Unknown variable type [" .. E2Lib.limitString(vtype, 10) .. "] specified for variable(s) (" .. E2Lib.limitString(namestring, 10) .. ")", column + i + 1)
+				if not wire_expression_types[vtype:upper()] then
+					self:Error("Unknown variable type [" .. E2Lib.limitString(vtype, 10) .. "] specified for variable(s) (" .. E2Lib.limitString(namestring, 10) .. ")", column + i + 1)
+				end
 			end
 		elseif character == "" then
 			-- type is not specified -> default to NORMAL
@@ -408,10 +439,11 @@ function PreProcessor:ParsePorts(ports, startoffset)
 		for i = #types + 1, #names do
 			types[i] = vtype:upper()
 			columns[i] = column
+			lines[i] = self.readline
 		end
 	end
 
-	return { names, types }, columns
+	return { names, types }, columns, lines
 end
 
 function PreProcessor:ConvertDescriptions(portstbl)
@@ -437,11 +469,11 @@ function PreProcessor:GetFunction(args, type)
 	local thistype, colon, name, argtypes = args:match("([^:]-)(:?)([^:(]+)%(([^)]*)%)")
 	if not thistype or (thistype ~= "") ~= (colon ~= "") then self:Error("Malformed " .. type .. " argument " .. args) end
 
-	thistype = gettype(thistype)
+	thistype = self:GetType(thistype)
 
 	local tps = {thistype .. colon}
 	for _, argtype in ipairs(string.Explode(",", argtypes)) do
-		argtype = gettype(argtype)
+		argtype = self:GetType(argtype)
 		table.insert(tps, argtype)
 	end
 	local pars = table.concat(tps)

--- a/lua/entities/gmod_wire_expression2/base/tokenizer.lua
+++ b/lua/entities/gmod_wire_expression2/base/tokenizer.lua
@@ -18,6 +18,7 @@ AddCSLuaFile()
 ---@field col integer
 ---@field line integer
 ---@field code string?
+---@field warnings Warning[]
 local Tokenizer = {}
 Tokenizer.__index = Tokenizer
 
@@ -55,7 +56,6 @@ for k, v in pairs(TokenVariant) do
 end
 
 Tokenizer.VariantLookup = VariantLookup
-
 
 ---@class Token
 ---@field variant TokenVariant
@@ -107,12 +107,16 @@ function Token:display()
 	end
 end
 
+---@return boolean ok
+---@return Token[]
+---@return Tokenizer self
 function Tokenizer.Execute(code)
 	-- instantiate Tokenizer
 	local instance = setmetatable({}, Tokenizer)
 
 	-- and pcall the new instance's Process method.
-	return xpcall(Tokenizer.Process, E2Lib.errorHandler, instance, code)
+	local ok, tokens = xpcall(Tokenizer.Process, E2Lib.errorHandler, instance, code)
+	return ok, tokens, instance
 end
 
 function Tokenizer:Reset()
@@ -120,10 +124,19 @@ function Tokenizer:Reset()
 	self.col = 1
 	self.line = 1
 	self.code = nil
+	self.warnings = {}
 end
 
+---@param message string
+---@param offset integer?
 function Tokenizer:Error(message, offset)
 	error(message .. " at line " .. self.line .. ", char " .. (self.col + (offset or 0)), 0)
+end
+
+---@param message string
+---@param offset integer?
+function Tokenizer:Warning(message, offset)
+	self.warnings[#self.warnings + 1] = { message = message, line = self.line, char = (self.col + (offset or 0)) }
 end
 
 local Escapes = {
@@ -197,8 +210,10 @@ function Tokenizer:Next()
 		elseif match == "false" then
 			return Token.new(TokenVariant.Boolean, false)
 		elseif match == "k" or match == "j" then
+			self:Warning("Avoid using quaternion literal '" .. match .. "' on its own. (Use 1" .. match .. " instead)")
 			return Token.new(TokenVariant.Quat, "1" .. match)
 		elseif match == "i" then
+			-- self:Warning("Avoid using complex literal 'i' on its own. (Use 1i instead)")
 			return Token.new(TokenVariant.Complex, "1i")
 		else
 			return Token.new(TokenVariant.LowerIdent, match)
@@ -239,11 +254,12 @@ function Tokenizer:Next()
 					break
 				else -- Escape
 					local c = self:At()
-					c = Escapes[c] or c
 
-					if not c then
-						-- self:Error("Invalid escape \\" .. c)
-						c = '\\'
+					if not Escapes[c] then
+						self:Warning("Invalid escape \\" .. c)
+						c = '\\' .. c
+					else
+						c = Escapes[c]
 					end
 
 					self:NextChar(true)
@@ -347,6 +363,7 @@ function Tokenizer:ConsumePattern(pattern, ws)
 	return match
 end
 
+---@return Token[]
 function Tokenizer:Process(code)
 	self:Reset()
 

--- a/lua/entities/gmod_wire_expression2/core/core.lua
+++ b/lua/entities/gmod_wire_expression2/core/core.lua
@@ -248,18 +248,22 @@ end)
 
 __e2setcost(1) -- approximation
 
+[nodiscard]
 e2function number first()
 	return self.entity.first and 1 or 0
 end
 
+[nodiscard]
 e2function number duped()
 	return self.entity.duped and 1 or 0
 end
 
+[nodiscard]
 e2function number inputClk()
 	return self.triggerinput and 1 or 0
 end
 
+[nodiscard]
 e2function string inputClkName()
 	return self.triggerinput or ""
 end
@@ -280,6 +284,7 @@ registerCallback("destruct", function(self)
 end)
 
 --- Returns 1 if it is being called on the last execution of the expression gate before it is removed or reset. This execution must be requested with the runOnLast(1) command.
+[nodiscard]
 e2function number last()
 	return self.data.last and 1 or 0
 end
@@ -298,11 +303,13 @@ local function dupefinished( TimedPasteData, TimedPasteDataCurrent )
 end
 hook.Add("AdvDupe_FinishPasting", "E2_dupefinished", dupefinished )
 
+[nodiscard]
 e2function number dupefinished()
 	return self.entity.dupefinished and 1 or 0
 end
 
 --- Returns 1 if this is the last() execution and caused by the entity being removed.
+[nodiscard]
 e2function number removing()
 	return self.entity.removing and 1 or 0
 end
@@ -374,29 +381,35 @@ local round  = math.Round
 
 __e2setcost(1) -- approximation
 
+[nodiscard]
 e2function number ops()
 	return round(self.prfbench)
 end
 
+[nodiscard]
 e2function number entity:ops()
 	if not IsValid(this) or this:GetClass() ~= "gmod_wire_expression2" or not this.context then return 0 end
 	return round(this.context.prfbench)
 end
 
+[nodiscard]
 e2function number opcounter()
 	return ceil(self.prf + self.prfcount)
 end
 
+[nodiscard]
 e2function number cpuUsage()
 	return self.timebench
 end
 
+[nodiscard]
 e2function number entity:cpuUsage()
 	if not IsValid(this) or this:GetClass() ~= "gmod_wire_expression2" or not this.context then return 0 end
 	return this.context.timebench
 end
 
 --- If used as a while loop condition, stabilizes the expression around <maxexceed> hardquota used.
+[nodiscard]
 e2function number perf()
 	if self.prf >= e2_tickquota*0.95-200 then return 0 end
 	if self.prf + self.prfcount >= e2_hardquota then return 0 end
@@ -404,6 +417,7 @@ e2function number perf()
 	return 1
 end
 
+[nodiscard]
 e2function number perf(number n)
 	n = math.Clamp(n, 0, 100)
 	if self.prf >= e2_tickquota*n*0.01 then return 0 end
@@ -416,6 +430,7 @@ e2function number perf(number n)
 	return 1
 end
 
+[nodiscard]
 e2function number minquota()
 	if self.prf < e2_softquota then
 		return floor(e2_softquota - self.prf)
@@ -424,6 +439,7 @@ e2function number minquota()
 	end
 end
 
+[nodiscard]
 e2function number maxquota()
 	if self.prf < e2_tickquota then
 		local tickquota = e2_tickquota - self.prf
@@ -439,14 +455,17 @@ e2function number maxquota()
 	end
 end
 
+[nodiscard]
 e2function number softQuota()
 	return e2_softquota
 end
 
+[nodiscard]
 e2function number hardQuota()
 	return e2_hardquota
 end
 
+[nodiscard]
 e2function number timeQuota()
 	return e2_timequota
 end

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -1033,7 +1033,7 @@ function E2Lib.compileScript(code, owner, run)
 	status,tree = E2Lib.Optimizer.Execute(tree)
 	if not status then return false, tree end
 
-	local status, script, inst = E2Lib.Compiler.Execute(tree, directives.inputs[3], directives.outputs[3], directives.persist[3], dvars, {})
+	local status, script, inst = E2Lib.Compiler.Execute(tree, directives.inputs, directives.outputs, directives.persist, dvars, {})
 	if not status then return false, script end
 
 	local ctx = makeContext(owner or game.GetWorld())

--- a/lua/entities/gmod_wire_expression2/core/selfaware.lua
+++ b/lua/entities/gmod_wire_expression2/core/selfaware.lua
@@ -4,10 +4,12 @@
 
 __e2setcost(1) -- temporary
 
+[nodiscard]
 e2function entity entity()
 	return self.entity
 end
 
+[nodiscard]
 e2function entity owner()
 	return self.player
 end
@@ -34,6 +36,7 @@ end
 __e2setcost(10)
 
 -- Returns an array of all entities wired to the output
+[nodiscard]
 e2function array ioOutputEntities( string output )
 	local ret = {}
 	if (self.entity.Outputs[output]) then
@@ -45,6 +48,7 @@ e2function array ioOutputEntities( string output )
 end
 
 -- Returns the entity the input is wired to
+[nodiscard]
 e2function entity ioInputEntity( string input )
 	if (self.entity.Inputs[input] and self.entity.Inputs[input].Src and IsValid(self.entity.Inputs[input].Src)) then return self.entity.Inputs[input].Src end
 end
@@ -134,6 +138,7 @@ e2function void entity:setName( string name )
 end
 
 -- Get the name of another E2 or compatible entity or component name of wiremod components
+[nodiscard]
 e2function string entity:getName()
 	if not IsValid(this) then return self:throw("Invalid entity!", "") end
 	if this.GetGateName then
@@ -152,6 +157,7 @@ end)
 __e2setcost(1)
 
 -- This is the prototype for everything that can be compared using the == operator
+[nodiscard]
 e2function number changed(value)
 	local chg = self.data.changed
 
@@ -162,6 +168,7 @@ e2function number changed(value)
 end
 
 -- vectors can be of gmod type Vector, so we need to treat them separately
+[nodiscard]
 e2function number changed(vector value)
 	local chg = self.data.changed
 
@@ -181,6 +188,7 @@ e2function number changed(vector value)
 end
 
 -- This is the prototype for all table types.
+[nodiscard]
 e2function number changed(angle value)
 	local chg = self.data.changed
 
@@ -232,14 +240,17 @@ end)
 __e2setcost( 5 )
 
 local getHash = E2Lib.getHash
+[nodiscard]
 e2function number hash()
 	return getHash( self, self.entity.original )
 end
 
+[nodiscard]
 e2function number hashNoComments()
 	return getHash( self, self.entity.buffer )
 end
 
+[nodiscard]
 e2function number hash( string str )
 	return getHash( self, str )
 end

--- a/lua/entities/gmod_wire_expression2/core/timer.lua
+++ b/lua/entities/gmod_wire_expression2/core/timer.lua
@@ -81,14 +81,18 @@ e2function void stoptimer(string rv1)
 end
 
 __e2setcost(1)
+
+[nodiscard]
 e2function number clk()
 	return self.data.timer.runner == "interval" and 1 or 0
 end
 
+[nodiscard]
 e2function number clk(string rv1)
 	return self.data.timer.runner == rv1 and 1 or 0
 end
 
+[nodiscard]
 e2function string clkName()
 	return self.data.timer.runner or ""
 end
@@ -113,14 +117,17 @@ end
 
 /******************************************************************************/
 
+[nodiscard]
 e2function number curtime()
 	return CurTime()
 end
 
+[nodiscard]
 e2function number realtime()
 	return RealTime()
 end
 
+[nodiscard]
 e2function number systime()
 	return SysTime()
 end
@@ -182,6 +189,7 @@ end
 
 __e2setcost(2)
 -- Returns the time in seconds
+[nodiscard]
 e2function number time()
 	return os.time()
 end
@@ -190,6 +198,7 @@ end
 -- The table structure must be the same as in the above date functions
 -- If any values are missing or of the wrong type, that value is ignored (it will be nil)
 local validkeys = {hour = true, min = true, day = true, sec = true, yday = true, wday = true, month = true, year = true, isdst = true}
+[nodiscard]
 e2function number time(table data)
 	local args = {}
 

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -175,8 +175,8 @@ function ENT:Execute()
 	end
 
 	self.GlobalScope.vclk = {}
-	for k, v in pairs(self.globvars) do
-		self.GlobalScope[k] = fixDefault(wire_expression_types2[v][2])
+	for k, var in pairs(self.globvars) do
+		self.GlobalScope[k] = fixDefault(wire_expression_types2[var.type][2])
 	end
 
 	if self.context.prfcount + self.context.prf - e2_softquota > e2_hardquota then
@@ -418,8 +418,8 @@ function ENT:ResetContext()
 		self.globvars[k] = nil
 	end
 
-	for k, v in pairs(self.globvars) do
-		self.GlobalScope[k] = fixDefault(wire_expression_types2[v][2])
+	for k, var in pairs(self.globvars) do
+		self.GlobalScope[k] = fixDefault(wire_expression_types2[var.type][2])
 	end
 
 	for k, v in pairs(self.Inputs) do

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -281,7 +281,7 @@ function ENT:CompileCode(buffer, files, filepath)
 	status,tree = E2Lib.Optimizer.Execute(tree)
 	if not status then self:Error(tree) return end
 
-	local status, script, inst = E2Lib.Compiler.Execute(tree, self.inports[3], self.outports[3], self.persists[3], dvars, self.includes)
+	local status, script, inst = E2Lib.Compiler.Execute(tree, self.inports, self.outports, self.persists, dvars, self.includes)
 	if not status then self:Error(script) return end
 
 	self.script = script


### PR DESCRIPTION
Added a lot more warnings and did some nice touch ups to work with the internals in this PR.
Hopefully the warnings will lead to less mishaps with uninitialized variables and having random expressions everywhere.

* Made Parser, Tokenizer and Preprocessor all output warnings (not just the compiler)

* Add emmylua annotations to the returns of the compiler/parser/optimizer/preprocessor

* Made preprocessor return a fifth entry for directives, pointing to the line and column where persist/outputs/inputs variables were defined. (Used in compiler later)

* Tagged proper functions in core, timer and selfaware as `nodiscard`

* Compiler now takes inputs/outputs/persists as the whole table, not the third index (potentially breaking for third party addons using the compiler for some reason).

* Fix invalid escape not properly replacing with a backslash and the invalid char

## New Warnings

* Add a warning for using a `@persist` or `@outputs` variable before assigning to it

* Add a warning for unused variables

* Added warnings for discarding every other expression than GET (comparison, logical, binary ops, variables, literals, etc).

* Added warning in parser for using quaternion literals (k, j) without number beforehand (Ignored complex literals for now since they are more commonly seen as i) Soft resolves #812

* Added warning for using `normal` (deprecated for number) in directives (Not in parser, for now)

* Added a warning for using an invalid model in `@model`

* Added a warning for invalid escape in string
