### PR TITLE
Print when player accesses E2 via prop protection

### DIFF
--- a/lua/wire/stools/expression2.lua
+++ b/lua/wire/stools/expression2.lua
@@ -171,6 +171,15 @@ if SERVER then
 			elseif hook.Run("CanTool", player, WireLib.dummytrace(chip), "wire_expression2") then -- The player has prop protection perms on the chip
 				self:Download(player, chip)
 				player:SetAnimation(PLAYER_ATTACK1)
+
+				local playerType = "player"
+				if player:IsAdmin() then
+					playerType = player:IsSuperAdmin() and "superadmin" or "admin"
+				end
+				BetterChatPrint(
+					chip.player,
+					string.format("The %s '%s' just accessed your chip '%s' via prop protection", playerType, player:Nick(), chip.name)
+				)
 			elseif (chip.alwaysAllow and chip.alwaysAllow[player]) or not IsValid(chip.player) then -- The player doesnt have prop protection perms, however the owner always allows for this chip (or they're invalid)
 				self:Download(player, chip)
 				player:SetAnimation(PLAYER_ATTACK1)
@@ -455,6 +464,15 @@ if SERVER then
 			WireLib.Expression2Download(player, E2)
 		elseif hook.Run("CanTool", player, WireLib.dummytrace(E2), "wire_expression2") then
 			WireLib.Expression2Download(player, E2)
+
+			local playerType = "player"
+			if player:IsAdmin() then
+				playerType = player:IsSuperAdmin() and "superadmin" or "admin"
+			end
+			BetterChatPrint(
+				E2.player,
+				string.format("The %s '%s' just accessed your chip '%s' via prop protection", playerType, player:Nick(), E2.name)
+			)
 		elseif (E2.alwaysAllow and E2.alwaysAllow[player]) or not IsValid(E2.player) then
 			WireLib.Expression2Download(player, E2)
 		else


### PR DESCRIPTION
In my recent View Requests rework PR #2419 I removed the admin bypass system, instead letting prop protection give access to chips.

However, this meant removing the bypass warnings which both someone on that PR and multiple people in a server's Discord have now asked for me to re-add.

This adds a new print to the `CanTool` clauses of E2 downloading flow that tells the owner their chip was accessed via prop protection, as well as the rank of the accessing player (`player`, `admin`, and `superadmin`).

Example:
`The admin 'Derpius' just accessed your chip 'Cool Mech' via prop protection`
