### PR TITLE
Allow users to define a custom background color for the Expression 2 Editor

### DIFF
--- a/lua/wire/client/text_editor/modes/e2.lua
+++ b/lua/wire/client/text_editor/modes/e2.lua
@@ -66,6 +66,7 @@ local colors = {
 	["typename"]  = { Color(240, 160,  96), false}, -- orange
 	["constant"]  = { Color(240, 160, 240), false}, -- pink
 	["userfunction"] = { Color(102, 122, 102), false}, -- dark grayish-green
+	["background"] = { Color(32,32,32), false} -- dark-grey
 }
 
 function EDITOR:GetSyntaxColor(name)

--- a/lua/wire/client/text_editor/texteditor.lua
+++ b/lua/wire/client/text_editor/texteditor.lua
@@ -366,8 +366,9 @@ function EDITOR:PaintLine(row)
 
 	local width, height = self.FontWidth, self.FontHeight
 
+	local backgroundColor = self:GetSyntaxColor("background") or Color(32, 32, 32)
 	if row == self.Caret[1] and self.TextEntry:HasFocus() then
-		surface_SetDrawColor(48, 48, 48, 255)
+		surface_SetDrawColor(backgroundColor.r+10, backgroundColor.g+10, backgroundColor.b+10, 255)
 		surface_DrawRect(self.LineNumberWidth + 5, (row - self.Scroll[1]) * height, self:GetWide() - (self.LineNumberWidth + 5), height)
 	end
 
@@ -619,10 +620,11 @@ function EDITOR:Paint()
 		self.Caret = self:CursorToCaret()
 	end
 
-	surface_SetDrawColor(0, 0, 0, 255)
+	local backgroundColor = self:GetSyntaxColor("background") or Color(32, 32, 32)
+	surface_SetDrawColor(backgroundColor.r - 28,backgroundColor.g - 28,backgroundColor.b - 28)
 	surface_DrawRect(0, 0, self.LineNumberWidth + 4, self:GetTall())
 
-	surface_SetDrawColor(32, 32, 32, 255)
+	surface_SetDrawColor(backgroundColor)
 	surface_DrawRect(self.LineNumberWidth + 5, 0, self:GetWide() - (self.LineNumberWidth + 5), self:GetTall())
 
 	self.Scroll[1] = math_floor(self.ScrollBar:GetScroll() + 1)

--- a/lua/wire/client/text_editor/wire_expression2_editor.lua
+++ b/lua/wire/client/text_editor/wire_expression2_editor.lua
@@ -101,7 +101,8 @@ local colors = {
 	["typename"] = Color(240, 160, 96), -- orange
 	["constant"] = Color(240, 160, 240), -- pink
 	["userfunction"] = Color(102, 122, 102), -- dark grayish-green
-	["dblclickhighlight"] = Color(0, 100, 0) -- dark green
+	["dblclickhighlight"] = Color(0, 100, 0), -- dark green
+	["background"] = Color(32, 32, 32) -- dark-grey
 }
 
 local colors_defaults = {}


### PR DESCRIPTION
The title explains it all. Wasn't able to get it working for CPU/GPU/etc so I just added a check to replace it with the default color.