### PR TITLE
E2 Permissions Escalation Fix and `@disabled` rework

### DIFF
--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -153,7 +153,14 @@ if CLIENT then
 
 		local txt = data.txt
 		local class = getWireName( self ) .. " [" .. self:EntIndex() .. "]"
-		local name = "(" .. self:GetPlayerName() .. ")"
+
+		local name
+		if CPPI then
+			local owner = self:CPPIGetOwner()
+			name = string.format("(%s)", (owner and owner:IsPlayer()) and owner:GetName() or "World")
+		else
+			name = "(" .. self:GetPlayerName() .. ")"
+		end
 
 		local w_body, 	h_body = self:GetWorldTipBodySize()
 		local w_class, 	h_class = surface.GetTextSize( class )

--- a/lua/entities/gmod_wire_expression2/base/preprocessor.lua
+++ b/lua/entities/gmod_wire_expression2/base/preprocessor.lua
@@ -485,5 +485,7 @@ function PreProcessor:PP_endif(args)
 end
 
 function PreProcessor:PP_error(args)
-	self:Error(args)
+	if not self:Disabled() then
+		self:Error(args)
+	end
 end

--- a/lua/entities/gmod_wire_expression2/base/preprocessor.lua
+++ b/lua/entities/gmod_wire_expression2/base/preprocessor.lua
@@ -247,10 +247,6 @@ local directive_handlers = {
 		WireLib.Expression2Upload( self.ent:GetPlayer(), self.ent, self.ent.filepath )
 	end,
 
-	["disabled"] = function(self, value)
-		self:Error(value, 1)
-	end,
-
 	-- Maybe it can have multiple levels in the future but I think one is fine for now.
 	["strict"] = function(self)
 		self.directives.strict = true
@@ -486,4 +482,8 @@ function PreProcessor:PP_endif(args)
 	if state == nil then self:Error("Found #endif outside #ifdef/#ifndef block") end
 
 	if args:Trim() ~= "" then self:Error("Must not pass an argument to #endif") end
+end
+
+function PreProcessor:PP_error(args)
+	self:Error(args)
 end

--- a/lua/entities/gmod_wire_expression2/base/preprocessor.lua
+++ b/lua/entities/gmod_wire_expression2/base/preprocessor.lua
@@ -521,3 +521,9 @@ function PreProcessor:PP_error(args)
 		self:Error(args)
 	end
 end
+
+function PreProcessor:PP_warning(args)
+	if not self:Disabled() then
+		self:Warning(args)
+	end
+end

--- a/lua/entities/gmod_wire_expression2/base/preprocessor.lua
+++ b/lua/entities/gmod_wire_expression2/base/preprocessor.lua
@@ -59,10 +59,10 @@ function PreProcessor:GetType(tp, column)
 	return type_map[tp] or (wire_expression_types[up] and wire_expression_types[up][1]) or tp
 end
 
-function PreProcessor:HandlePPCommand(comment)
+function PreProcessor:HandlePPCommand(comment, col)
 	local command, args = comment:match("^([^ ]*) ?(.*)$")
 	local handler = self["PP_" .. command]
-	if handler then return handler(self, args) end
+	if handler then return handler(self, args, col) end
 end
 
 function PreProcessor:FindComments(line)
@@ -160,7 +160,7 @@ function PreProcessor:RemoveComments(line)
 							ret = ret .. line:sub(lastpos)
 						else
 							ret = ret .. line:sub(lastpos, pos - 1)
-							self:HandlePPCommand(line:sub(pos + 1))
+							self:HandlePPCommand(line:sub(pos + 1), pos)
 						end
 
 						if self.description_cache then
@@ -476,7 +476,7 @@ function PreProcessor:GetFunction(args, type)
 	return wire_expression2_funcs[name .. "(" .. pars .. ")"]
 end
 
-function PreProcessor:PP_ifdef(args)
+function PreProcessor:PP_ifdef(args, col)
 	local func = self:GetFunction(args, "#ifdef")
 
 	if self:Disabled() then
@@ -486,7 +486,7 @@ function PreProcessor:PP_ifdef(args)
 	end
 end
 
-function PreProcessor:PP_ifndef(args)
+function PreProcessor:PP_ifndef(args, col)
 	local func = self:GetFunction(args, "#ifndef")
 
 	if self:Disabled() then
@@ -496,11 +496,11 @@ function PreProcessor:PP_ifndef(args)
 	end
 end
 
-function PreProcessor:PP_else(args)
+function PreProcessor:PP_else(args, col)
 	local state = table.remove(self.ifdefStack)
-	if state == nil then self:Error("Found #else outside #ifdef/#ifndef block") end
+	if state == nil then self:Error("Found #else outside #ifdef/#ifndef block", col) end
 
-	if args:Trim() ~= "" then self:Error("Must not pass an argument to #else") end
+	if args:Trim() ~= "" then self:Error("Must not pass an argument to #else", col) end
 
 	if self:Disabled() then
 		table.insert(self.ifdefStack, false)
@@ -509,21 +509,21 @@ function PreProcessor:PP_else(args)
 	end
 end
 
-function PreProcessor:PP_endif(args)
+function PreProcessor:PP_endif(args, col)
 	local state = table.remove(self.ifdefStack)
-	if state == nil then self:Error("Found #endif outside #ifdef/#ifndef block") end
+	if state == nil then self:Error("Found #endif outside #ifdef/#ifndef block", col) end
 
-	if args:Trim() ~= "" then self:Error("Must not pass an argument to #endif") end
+	if args:Trim() ~= "" then self:Error("Must not pass an argument to #endif", col) end
 end
 
-function PreProcessor:PP_error(args)
+function PreProcessor:PP_error(args, col)
 	if not self:Disabled() then
-		self:Error(args)
+		self:Error(args, col)
 	end
 end
 
-function PreProcessor:PP_warning(args)
+function PreProcessor:PP_warning(args, col)
 	if not self:Disabled() then
-		self:Warning(args)
+		self:Warning(args, col)
 	end
 end

--- a/lua/entities/gmod_wire_expression2/base/preprocessor.lua
+++ b/lua/entities/gmod_wire_expression2/base/preprocessor.lua
@@ -247,8 +247,8 @@ local directive_handlers = {
 		WireLib.Expression2Upload( self.ent:GetPlayer(), self.ent, self.ent.filepath )
 	end,
 
-	["disabled"] = function(self)
-		self:Error("Disabled for security reasons. Remove @disabled to enable.", 1)
+	["disabled"] = function(self, value)
+		self:Error(value, 1)
 	end,
 
 	-- Maybe it can have multiple levels in the future but I think one is fine for now.

--- a/lua/entities/gmod_wire_expression2/cl_init.lua
+++ b/lua/entities/gmod_wire_expression2/cl_init.lua
@@ -95,7 +95,8 @@ function ENT:GetWorldTipBodySize()
 	local data = self:GetOverlayData()
 	if not data then return 100, 20 end
 
-	local w_total,h_total = wtfgarry( data.txt )
+	local txt = data.txt .. "\nauthor: " .. self:GetPlayerName()
+	local w_total,h_total = wtfgarry(txt)
 	h_total = h_total + 18
 
 	local prfbench = data.prfbench
@@ -130,7 +131,7 @@ function ENT:DrawWorldTipBody( pos )
 	local data = self:GetOverlayData()
 	if not data then return end
 
-	local txt = data.txt
+	local txt = data.txt .. "\nauthor: " .. self:GetPlayerName()
 	local err = data.error -- this isn't used (yet), might do something with it later
 
 	local white = Color(255,255,255,255)

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -634,10 +634,10 @@ function MakeWireExpression2(player, Pos, Ang, model, buffer, name, inputs, outp
 		buffer = string.Replace(string.Replace(buffer, string.char(163), "\""), string.char(128), "\n")
 
 		-- Check codeAuthor actually exists, it wont be present on old dupes
-		-- No need to check if buffer already has an @disabled directive, as chips with compiler errors can't be duped
+		-- No need to check if buffer already has a dupe related #error directive, as chips with compiler errors can't be duped
 		if codeAuthor and player:SteamID() ~= codeAuthor.steamID then
 			buffer = string.format(
-				"@disabled Dupe pasted with code authored by %s (%s). Please review the contents of the E2 before removing this directive\n",
+				"#error Dupe pasted with code authored by %s (%s). Please review the contents of the E2 before removing this directive\n\n",
 				codeAuthor.name, codeAuthor.steamID
 			) .. buffer
 		end
@@ -653,7 +653,7 @@ function MakeWireExpression2(player, Pos, Ang, model, buffer, name, inputs, outp
 
 		self.filepath = filepath
 	else
-		self.buffer = "@disabled You tried to dupe an E2 with compile errors!\n#Unfortunately, no code can be saved when duping an E2 with compile errors.\n#Fix your errors and try again."
+		self.buffer = "#error You tried to dupe an E2 with compile errors!\n#Unfortunately, no code can be saved when duping an E2 with compile errors.\n#Fix your errors and try again."
 
 		self.inc_files = {}
 		self.dupevars = {}

--- a/lua/wire/client/text_editor/modes/e2.lua
+++ b/lua/wire/client/text_editor/modes/e2.lua
@@ -63,6 +63,7 @@ local colors = {
 	["operator"]  = { Color(224, 224, 224), false}, -- white
 	["comment"]   = { Color(128, 128, 128), false}, -- grey
 	["ppcommand"] = { Color(240,  96, 240), false}, -- purple
+	["ppcommandargs"] = { Color(128, 128, 128), false}, -- same as comment
 	["typename"]  = { Color(240, 160,  96), false}, -- orange
 	["constant"]  = { Color(240, 160, 240), false}, -- pink
 	["userfunction"] = { Color(102, 122, 102), false}, -- dark grayish-green
@@ -545,7 +546,11 @@ function EDITOR:SyntaxColorLine(row)
 
 				if E2Lib.PreProcessor["PP_"..self.tokendata:sub(2)] then
 					-- there is a preprocessor command by that name => mark as such
-					tokenname = "ppcommand"
+					addToken("ppcommand", self.tokendata)
+					self.tokendata = ""
+
+					self:NextPattern(".*")
+					tokenname = "ppcommandargs"
 				elseif self.tokendata == "#include" then
 					tokenname = "keyword"
 				else

--- a/lua/wire/client/text_editor/wire_expression2_editor.lua
+++ b/lua/wire/client/text_editor/wire_expression2_editor.lua
@@ -98,6 +98,7 @@ local colors = {
 	["operator"] = Color(224, 224, 224), -- white
 	["comment"] = Color(128, 128, 128), -- grey
 	["ppcommand"] = Color(240, 96, 240), -- purple
+	["ppcommandargs"] = Color(128, 128, 128), -- same as comment
 	["typename"] = Color(240, 160, 96), -- orange
 	["constant"] = Color(240, 160, 240), -- pink
 	["userfunction"] = Color(102, 122, 102), -- dark grayish-green

--- a/lua/wire/client/text_editor/wire_expression2_editor.lua
+++ b/lua/wire/client/text_editor/wire_expression2_editor.lua
@@ -1412,9 +1412,16 @@ Text here]# ]]
 				local label = vgui.Create("DLabel", panel)
 				local idx = v:EntIndex()
 
-				local str = string.format("Name: %s\nEntity ID: '%d'\nOwner: %s",name,idx,nick)
+				local ownerStr
+				if CPPI and v:CPPIGetOwner():GetName() ~= nick then
+					ownerStr = string.format("Owner: %s | Code Author: %s", v:CPPIGetOwner():GetName(), nick)
+				else
+					ownerStr = "Owner: " .. nick
+				end
+
+				local str = string.format("Name: %s\nEntity ID: '%d'\n%s", name, idx, ownerStr)
 				if LocalPlayer():IsAdmin() then
-					str = string.format("Name: %s\nEntity ID: '%d'\n%i ops, %i%% %s\ncpu time: %ius\nOwner: %s",name,idx,0,0,"",0,nick)
+					str = string.format("Name: %s\nEntity ID: '%d'\n%i ops, %i%% %s\ncpu time: %ius\n%s", name, idx, 0, 0, "", 0, ownerStr)
 				end
 
 				label:SetText(str)
@@ -1445,7 +1452,13 @@ Text here]# ]]
 
 							local hardtext = (prfcount / e2_hardquota > 0.33) and "(+" .. tostring(math.Round(prfcount / e2_hardquota * 100)) .. "%)" or ""
 
-							label:SetText(string.format("Name: %s\nEntity ID: '%d'\n%i ops, %i%% %s\ncpu time: %ius\nOwner: %s",name,idx,prfbench,prfbench / e2_softquota * 100,hardtext,timebench*1000000,nick))
+							label:SetText(string.format(
+								"Name: %s\nEntity ID: '%d'\n%i ops, %i%% %s\ncpu time: %ius\n%s",
+								name, idx,
+								prfbench, prfbench / e2_softquota * 100, hardtext,
+								timebench * 1000000,
+								ownerStr
+							))
 						end
 					end
 				end

--- a/lua/wire/stools/expression2.lua
+++ b/lua/wire/stools/expression2.lua
@@ -415,7 +415,7 @@ if SERVER then
 				-- Note that the SENT and CPPI owners aren't set here to allow the original owner to still access their chip
 			end
 
-			-- This is needed when formatting the @disabled directive on dupe
+			-- This is needed when formatting the #error directive on dupe
 			toent.code_author = {
 				name = ply:GetName(),
 				steamID = ply:SteamID()

--- a/lua/wire/stools/expression2.lua
+++ b/lua/wire/stools/expression2.lua
@@ -20,8 +20,7 @@ TOOL.ClientConVar = {
 	modelsize = "",
 	scriptmodel = "",
 	select = "",
-	autoindent = 1,
-	friendwrite = 0,
+	autoindent = 1
 }
 
 TOOL.MaxLimitName = "wire_expressions"
@@ -408,9 +407,19 @@ if SERVER then
 
 			local filepath = ret[3]
 
-			if ply ~= toent.player and toent.player:GetInfoNum("wire_expression2_friendwrite", 0) ~= 1 then
-				code = "@disabled for security reasons. Remove this line (Ctrl+Shift+L) and left-click the chip to enable. 'wire_expression2_friendwrite 1' disables security.\n" .. code
+			if ply ~= toent.player then
+				toent.player = ply
+				toent:SetPlayer(ply)
+				toent:SetNWEntity("player", ply)
+
+				-- Note that the SENT and CPPI owners aren't set here to allow the original owner to still access their chip
 			end
+
+			-- This is needed when formatting the @disabled directive on dupe
+			toent.code_author = {
+				name = ply:GetName(),
+				steamID = ply:SteamID()
+			}
 
 			toent:Setup(code, includes, nil, nil, filepath)
 		end


### PR DESCRIPTION
This reimplements my original perms escalation fix from last year, and improves upon `@disabled` by turning it into a preprocessor form of `error()`.

It also adds the directive when an E2 is pasted from a dupe that has code authored by someone other than the player duplicating.

Additionally, I saw that `:SetPlayer()` wasn't being called from the `Wire_Expression2_Player_Authed` hook while I was searching for all instances of setting `chip.player` so I've added a call to it there.

~~Still a draft as I need to implement the two owners into both the tooltip and remote uploader, and I need to test the dupe protection in multiplayer~~