### PR TITLE
Add `event`s to Expression 2

### DIFF
--- a/data/expression2/tests/parsing.txt
+++ b/data/expression2/tests/parsing.txt
@@ -64,7 +64,7 @@ do { continue } while (A)
 
 try {} catch(Err) {}
 
-yeet tick(A:array) {}
+event tick(A) {}
 
 A++
 A--

--- a/data/expression2/tests/parsing.txt
+++ b/data/expression2/tests/parsing.txt
@@ -64,7 +64,7 @@ do { continue } while (A)
 
 try {} catch(Err) {}
 
-event tick(A) {}
+event tick() {}
 
 A++
 A--

--- a/data/expression2/tests/parsing.txt
+++ b/data/expression2/tests/parsing.txt
@@ -64,6 +64,8 @@ do { continue } while (A)
 
 try {} catch(Err) {}
 
+yeet tick(A:array) {}
+
 A++
 A--
 A += 1

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -601,7 +601,7 @@ function Compiler:InstrCALL(args)
 	exprs[#exprs + 1] = tps
 
 	if rt[4] then
-		if rt[4].deprecated ~= true then
+		if rt[4].deprecated ~= nil and rt[4].deprecated ~= true then
 			-- Deprecation message (string)
 			self:Warning("Use of deprecated function: " .. args[3] .. "(" .. tps_pretty(tps) .. "): '" .. rt[4].deprecated .. "'", args)
 		elseif rt[4].deprecated then

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -603,7 +603,12 @@ function Compiler:InstrCALL(args)
 	exprs[#exprs + 1] = tps
 
 	if rt[4] and rt[4].deprecated then
-		self:Warning("Use of deprecated function: " .. args[3] .. "(" .. tps_pretty(tps) .. ")", args)
+		if rt[4].deprecated ~= true then
+			-- Deprecation message
+			self:Warning("Use of deprecated function: " .. args[3] .. "(" .. tps_pretty(tps) .. "): '" .. rt[4].deprecated .. "'", args)
+		else
+			self:Warning("Use of deprecated function: " .. args[3] .. "(" .. tps_pretty(tps) .. ")", args)
+		end
 	end
 
 	return exprs, rt[2], rt[4]

--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -36,6 +36,7 @@ Stmt10 ← (FunctionStmt / ReturnStmt)? Stmt11
 Stmt11 ← ("#include" String)? Stmt12
 Stmt12 ← ("try" Block "catch" "(" Var ")" Block)? Stmt13
 Stmt13 ← ("do" Block "while" Cond)? Expr1
+Stmt14 ← ("yeet" Fun "(" FunctionArgs Block)
 
 FunctionStmt ← "function" FunctionHead "(" FunctionArgs Block
 FunctionHead ← (Type Type ":" Fun / Type ":" Fun / Type Fun / Fun)
@@ -811,6 +812,29 @@ function Parser:Stmt13()
 		loopdepth = loopdepth - 1
 
 		return whl
+	end
+
+	return self:Stmt14()
+end
+
+function Parser:Stmt14()
+	if self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.Yeet) then
+		local trace = self:GetTokenTrace()
+
+		local name = self:AcceptRoamingToken(TokenVariant.LowerIdent)
+		if not name then
+			self:Error("Expected event name after 'yeet' keyword")
+		end
+		local name = self:GetTokenData()
+
+		if not self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.LParen) then
+			self:Error("Left parenthesis (() must appear after event name")
+		end
+
+		local temp, args = {}, {}
+		self:FunctionArgs(temp, args)
+
+		return self:Instruction(trace, "yeet", name, args, self:Block("yeet block"))
 	end
 
 	return self:Expr1()

--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -36,7 +36,7 @@ Stmt10 ← (FunctionStmt / ReturnStmt)? Stmt11
 Stmt11 ← ("#include" String)? Stmt12
 Stmt12 ← ("try" Block "catch" "(" Var ")" Block)? Stmt13
 Stmt13 ← ("do" Block "while" Cond)? Expr1
-Stmt14 ← ("yeet" Fun "(" FunctionArgs Block)
+Stmt14 ← ("event" Fun "(" FunctionArgs Block)
 
 FunctionStmt ← "function" FunctionHead "(" FunctionArgs Block
 FunctionHead ← (Type Type ":" Fun / Type ":" Fun / Type Fun / Fun)
@@ -818,12 +818,12 @@ function Parser:Stmt13()
 end
 
 function Parser:Stmt14()
-	if self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.Yeet) then
+	if self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.Event) then
 		local trace = self:GetTokenTrace()
 
 		local name = self:AcceptRoamingToken(TokenVariant.LowerIdent)
 		if not name then
-			self:Error("Expected event name after 'yeet' keyword")
+			self:Error("Expected event name after 'event' keyword")
 		end
 		local name = self:GetTokenData()
 
@@ -834,7 +834,7 @@ function Parser:Stmt14()
 		local temp, args = {}, {}
 		self:FunctionArgs(temp, args)
 
-		return self:Instruction(trace, "yeet", name, args, self:Block("yeet block"))
+		return self:Instruction(trace, "event", name, args, self:Block("event block"))
 	end
 
 	return self:Expr1()

--- a/lua/entities/gmod_wire_expression2/core/chat.lua
+++ b/lua/entities/gmod_wire_expression2/core/chat.lua
@@ -22,6 +22,8 @@ hook.Add("PlayerSay","Exp2TextReceiving", function(ply, text, teamchat)
 
 	chipHideChat = false
 	local hideCurrent = false
+	E2Lib.triggerEvent("chat", { ply, text, teamchat and 1 or 0 })
+
 	for e,_ in pairs(ChatAlert) do
 		if IsValid(e) then
 			chipHideChat = nil
@@ -48,6 +50,7 @@ end)
 __e2setcost(3)
 
 --- If <activate> == 0, the chip will no longer run on chat events, otherwise it makes this chip execute when someone chats. Only needs to be called once, not in every execution.
+[nodiscard, deprecated = "Use the chat event instead"]
 e2function void runOnChat(activate)
 	if activate ~= 0 then
 		ChatAlert[self.entity] = true
@@ -57,11 +60,13 @@ e2function void runOnChat(activate)
 end
 
 --- Returns 1 if the chip is being executed because of a chat event. Returns 0 otherwise.
+[nodiscard, deprecated = "Use the chat event instead"]
 e2function number chatClk()
 	return self.data.runByChat and 1 or 0
 end
 
 --- Returns 1 if the chip is being executed because of a chat event by player <ply>. Returns 0 otherwise.
+[nodiscard, deprecated = "Use the chat event instead"]
 e2function number chatClk(entity ply)
 	if not IsValid(ply) then return self:throw("Invalid player!", 0) end
 	local cause = self.data.runByChat
@@ -76,6 +81,7 @@ end
 --[[************************************************************************]]--
 
 --- Returns the last player to speak.
+[nodiscard, deprecated = "Use the chat event instead"]
 e2function entity lastSpoke()
 	local entry = TextList.last
 	if not entry then return nil end
@@ -88,6 +94,7 @@ e2function entity lastSpoke()
 end
 
 --- Returns the last message in the chat log.
+[nodiscard, deprecated = "Use the chat event instead"]
 e2function string lastSaid()
 	local entry = TextList.last
 	if not entry then return "" end
@@ -104,6 +111,7 @@ e2function number lastSaidWhen()
 end
 
 --- Returns 1 if the last message was sent in the team chat, 0 otherwise.
+[nodiscard, deprecated = "Use the chat event instead"]
 e2function number lastSaidTeam()
 	local entry = TextList.last
 	if not entry then return 0 end
@@ -112,6 +120,7 @@ e2function number lastSaidTeam()
 end
 
 --- Returns what the player <this> last said.
+[nodiscard, deprecated = "Use the chat event instead"]
 e2function string entity:lastSaid()
 	if not IsValid(this) then return self:throw("Invalid entity!", "") end
 	if not this:IsPlayer() then return self:throw("Not a player", "") end
@@ -134,6 +143,7 @@ e2function number entity:lastSaidWhen()
 end
 
 --- Returns 1 if the last message was sent in the team chat, 0 otherwise.
+[nodiscard, deprecated = "Use the chat event instead"]
 e2function number entity:lastSaidTeam()
 	if not IsValid(this) then return self:throw("Invalid entity!", 0) end
 	if not this:IsPlayer() then return self:throw("Not a player", 0) end
@@ -143,3 +153,6 @@ e2function number entity:lastSaidTeam()
 
 	return entry[4] and 1 or 0
 end
+
+-- Ply: entity, Msg: string, Team: number
+E2Lib.registerEvent("chat", { "e", "s", "n" })

--- a/lua/entities/gmod_wire_expression2/core/core.lua
+++ b/lua/entities/gmod_wire_expression2/core/core.lua
@@ -258,24 +258,28 @@ e2function number duped()
 	return self.entity.duped and 1 or 0
 end
 
-[nodiscard]
+[nodiscard, deprecated = "Use the input event instead"]
 e2function number inputClk()
 	return self.triggerinput and 1 or 0
 end
 
-[nodiscard]
+[nodiscard, deprecated = "Use the input event instead"]
 e2function string inputClkName()
 	return self.triggerinput or ""
 end
+
+E2Lib.registerEvent("input", {"s"})
 
 -- This MUST be the first destruct hook!
 registerCallback("destruct", function(self)
 	local entity = self.entity
 	if entity.error then return end
 	if not entity.script then return end
-	if not self.data.runOnLast then return end
 
 	self.resetting = false
+	entity:ExecuteEvent("removed", { entity.removing and 0 or 1 })
+
+	if not self.data.runOnLast then return end
 	self.data.runOnLast = false
 
 	self.data.last = true
@@ -284,10 +288,13 @@ registerCallback("destruct", function(self)
 end)
 
 --- Returns 1 if it is being called on the last execution of the expression gate before it is removed or reset. This execution must be requested with the runOnLast(1) command.
-[nodiscard]
+[nodiscard, deprecated = "Use the removed event instead"]
 e2function number last()
 	return self.data.last and 1 or 0
 end
+
+-- number (whether it is being reset or just removed)
+E2Lib.registerEvent("removed", { "n" })
 
 -- dupefinished()
 -- Made by Divran
@@ -309,12 +316,13 @@ e2function number dupefinished()
 end
 
 --- Returns 1 if this is the last() execution and caused by the entity being removed.
-[nodiscard]
+[nodiscard, deprecated = "Use the removed event instead"]
 e2function number removing()
 	return self.entity.removing and 1 or 0
 end
 
 --- If <activate> != 0, the chip will run once when it is removed, setting the last() flag when it does.
+[nodiscard, deprecated = "Use the removed event instead"]
 e2function void runOnLast(activate)
 	if self.data.last then return end
 	self.data.runOnLast = activate ~= 0

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -427,8 +427,8 @@ local Keyword = {
 	Catch = 17,
 	-- ``do``
 	Do = 18,
-	-- ``yeet``
-	Yeet = 19
+	-- ``event``
+	Event = 19
 }
 
 E2Lib.Keyword = Keyword

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -1,6 +1,10 @@
 AddCSLuaFile()
 
-E2Lib = {}
+E2Lib = {
+	Env = {
+		Events = {}
+	}
+}
 
 local type = type
 local function checkargtype(argn, value, argtype)
@@ -422,7 +426,9 @@ local Keyword = {
 	-- ``catch``
 	Catch = 17,
 	-- ``do``
-	Do = 18
+	Do = 18,
+	-- ``yeet``
+	Yeet = 19
 }
 
 E2Lib.Keyword = Keyword

--- a/lua/entities/gmod_wire_expression2/core/extloader.lua
+++ b/lua/entities/gmod_wire_expression2/core/extloader.lua
@@ -26,7 +26,7 @@ if ENT then
 		local chips = ents.FindByClass( "gmod_wire_expression2" )
 		for _, chip in ipairs( chips ) do
 			if not chip.error then
-				chip:PCallHook( "destruct" )
+				chip:Destruct()
 			end
 			chip.script = nil
 		end

--- a/lua/entities/gmod_wire_expression2/core/extpp.lua
+++ b/lua/entities/gmod_wire_expression2/core/extpp.lua
@@ -207,7 +207,8 @@ end
 
 local valid_attributes = {
 	["deprecated"] = true,
-	["nodiscard"] = true
+	["nodiscard"] = true,
+	["noreturn"] = true
 }
 
 function E2Lib.ExtPP.Pass2(contents)
@@ -226,7 +227,7 @@ function E2Lib.ExtPP.Pass2(contents)
 
 	-- This flag helps determine whether the preprocessor changed, so we can tell the environment about it.
 	local changed = false
-	for a_begin, attributes, h_begin, ret, thistype, colon, name, args, whitespace, equals, h_end in contents:gmatch("()(%[?[%l%d,_ =\"]*%]?)\r?\n?[ \t]*()e2function%s+(" .. p_typename .. ")%s+([a-z0-9]-)%s*(:?)%s*(" .. p_func_operator .. ")%(([^)]*)%)(%s*)(=?)()") do
+	for a_begin, attributes, h_begin, ret, thistype, colon, name, args, whitespace, equals, h_end in contents:gmatch("()(%[?[%w,_ =\"]*%]?)[\r\n\t ]*()e2function%s+(" .. p_typename .. ")%s+([a-z0-9]-)%s*(:?)%s*(" .. p_func_operator .. ")%(([^)]*)%)(%s*)(=?)()") do
 		-- Convert attributes to a lookup table passed to registerFunction
 		attributes = attributes ~= "" and attributes or nil
 		-- attributes = attributes ~= ""

--- a/lua/entities/gmod_wire_expression2/core/extpp.lua
+++ b/lua/entities/gmod_wire_expression2/core/extpp.lua
@@ -205,6 +205,11 @@ local function compact(lua)
 	return ( lua:gsub("\n\t*", " ") )
 end
 
+local valid_attributes = {
+	["deprecated"] = true,
+	["nodiscard"] = true
+}
+
 function E2Lib.ExtPP.Pass2(contents)
 	-- We add some stuff to both ends of the string so we can look for %W (non-word characters) at the ends of the patterns.
 	local prelude = "local tempcosts, registeredfunctions = {}, {};"
@@ -221,7 +226,7 @@ function E2Lib.ExtPP.Pass2(contents)
 
 	-- This flag helps determine whether the preprocessor changed, so we can tell the environment about it.
 	local changed = false
-	for a_begin, attributes, h_begin, ret, thistype, colon, name, args, whitespace, equals, h_end in contents:gmatch("()(%[?[%l%d,_ =\"]*%]?)\r?\n?()e2function%s+(" .. p_typename .. ")%s+([a-z0-9]-)%s*(:?)%s*(" .. p_func_operator .. ")%(([^)]*)%)(%s*)(=?)()") do
+	for a_begin, attributes, h_begin, ret, thistype, colon, name, args, whitespace, equals, h_end in contents:gmatch("()(%[?[%w%d,_ =\"]*%]?)[\r\n]*()e2function%s+(" .. p_typename .. ")%s+([a-z0-9]-)%s*(:?)%s*(" .. p_func_operator .. ")%(([^)]*)%)(%s*)(=?)()") do
 		-- Convert attributes to a lookup table passed to registerFunction
 		attributes = attributes ~= "" and attributes or nil
 		-- attributes = attributes ~= ""
@@ -238,6 +243,7 @@ function E2Lib.ExtPP.Pass2(contents)
 			local lookup = {}
 			for _, tag in ipairs(attributes) do
 				local k = tag:lower():Trim()
+
 				if k:find("=", 1, true) then
 					-- [xyz = 567, event = "Tick"]
 					-- e2function number foo()
@@ -246,6 +252,9 @@ function E2Lib.ExtPP.Pass2(contents)
 
 					lookup[key] = value
 				else
+					if not valid_attributes[k] then
+						ErrorNoHalt("Invalid attribute fed to ExtPP: " .. k)
+					end
 					lookup[ tag:lower():Trim() ] = "true"
 				end
 			end

--- a/lua/entities/gmod_wire_expression2/core/files.lua
+++ b/lua/entities/gmod_wire_expression2/core/files.lua
@@ -325,7 +325,15 @@ end)
 --- Uploading ---
 
 local function file_execute( ent, filename, status )
-	if !IsValid( ent ) or !run_on.file.ents[ent] then return end
+	if IsValid(ent) then
+		if status == FILE_OK then
+			ent:ExecuteEvent("fileLoaded", {filename, uploads[ent.player].data})
+		else
+			ent:ExecuteEvent("fileErrored", {filename, status})
+		end
+	elseif !run_on.file.ents[ent] then
+		return
+	end
 
 	run_on.file.run = 1
 	run_on.file.name = filename
@@ -467,3 +475,6 @@ net.Receive("wire_expression2_file_list", function(netlen, ply)
 	run_on.list.run = 0
 	run_on.list.dir = ""
 end )
+
+E2Lib.registerEvent("fileErrored", {"s", "n"})
+E2Lib.registerEvent("fileLoaded", {"s", "s"})

--- a/lua/entities/gmod_wire_expression2/core/gametick.lua
+++ b/lua/entities/gmod_wire_expression2/core/gametick.lua
@@ -12,6 +12,7 @@ end)
 __e2setcost(1)
 
 --- If <activate> != 0 the expression will execute once every game tick
+[nodiscard, deprecated = "Use the tick event instead"]
 e2function void runOnTick(activate)
     if activate ~= 0 then
         registered_chips[self.entity] = true
@@ -21,6 +22,7 @@ e2function void runOnTick(activate)
 end
 
 --- Returns 1 if the current execution was caused by "runOnTick"
+[nodiscard, deprecated = "Use the tick event instead"]
 e2function number tickClk()
 	return self.data.tickrun and 1 or 0
 end

--- a/lua/entities/gmod_wire_expression2/core/gametick.lua
+++ b/lua/entities/gmod_wire_expression2/core/gametick.lua
@@ -42,8 +42,12 @@ local function Expression2TickClock()
 		entity:Execute()
 		entity.context.data.tickrun = nil
 	end
+
+	E2Lib.triggerEvent("tick")
 end
 hook.Add("Think", "Expression2TickClock", Expression2TickClock)
 timer.Create("Expression2TickClock", 5, 0, function()
 	hook.Add("Think", "Expression2TickClock", Expression2TickClock)
 end)
+
+E2Lib.registerEvent("tick")

--- a/lua/entities/gmod_wire_expression2/core/http.lua
+++ b/lua/entities/gmod_wire_expression2/core/http.lua
@@ -45,10 +45,14 @@ e2function void httpRequest( string url )
 		preq.success = 1
 
 		local ent = self.entity
-		if IsValid(ent) and run_on.ents[ent] then
-			self.data.httpClk = preq
-			ent:Execute()
-			self.data.httpClk = nil
+		if IsValid(ent) then
+			if run_on.ents[ent] then
+				self.data.httpClk = preq
+				ent:Execute()
+				self.data.httpClk = nil
+			else
+				ent:ExecuteEvent("httpLoaded", { contents or "", size, preq.url })
+			end
 		end
 
 	end, function( err )
@@ -62,10 +66,14 @@ e2function void httpRequest( string url )
 		preq.success = 0
 
 		local ent = self.entity
-		if IsValid(ent) and run_on.ents[ent] then
-			self.data.httpClk = preq
-			ent:Execute()
-			self.data.httpClk = nil
+		if IsValid(ent) then
+			if run_on.ents[ent] then
+				self.data.httpClk = preq
+				ent:Execute()
+				self.data.httpClk = nil
+			else
+				ent:ExecuteEvent("httpErrored", { err, preq.url })
+			end
 		end
 	end)
 end
@@ -123,3 +131,9 @@ end
 registerCallback( "destruct", function( self )
 	run_on.ents[self.entity] = nil
 end )
+
+-- error: string, url: string
+E2Lib.registerEvent("httpErrored", { "s", "s" })
+
+-- body: string, size: number, url: string
+E2Lib.registerEvent("httpLoaded", { "s", "n", "s" })

--- a/lua/entities/gmod_wire_expression2/core/init.lua
+++ b/lua/entities/gmod_wire_expression2/core/init.lua
@@ -177,7 +177,9 @@ end
 --- E2Lib.registerEvent("propSpawned", { "e" }, nil)
 ---@param name string
 ---@param args string[]?
-function E2Lib.registerEvent(name, args)
+---@param constructor fun(self: table)? # Constructor to run when E2 initially starts listening to this event. Passes E2 context
+---@param destructor fun(self: table)? # Destructor to run when E2 stops listening to this event. Passes E2 context
+function E2Lib.registerEvent(name, args, constructor, destructor)
 	-- Ensure event starts with lowercase letter
 	name = name:sub(1, 1):lower() .. name:sub(2)
 	-- assert(not E2Lib.Env.Events[name], "Possible addon conflict: Trying to override existing E2 event '" .. name .. "'")
@@ -185,6 +187,9 @@ function E2Lib.registerEvent(name, args)
 	E2Lib.Env.Events[name] = {
 		name = name,
 		args = args or {},
+
+		constructor = constructor,
+		destructor = destructor,
 
 		listening = {}
 	}

--- a/lua/entities/gmod_wire_expression2/core/init.lua
+++ b/lua/entities/gmod_wire_expression2/core/init.lua
@@ -133,10 +133,12 @@ function wire_expression2_CallHook(hookname, ...)
 	return ret_array
 end
 
-function registerCallback(event, callback)
+function E2Lib.registerCallback(event, callback)
 	if not wire_expression_callbacks[event] then wire_expression_callbacks[event] = {} end
 	table.insert(wire_expression_callbacks[event], callback)
 end
+
+registerCallback = E2Lib.registerCallback
 
 local tempcost
 
@@ -169,6 +171,32 @@ function E2Lib.registerConstant(name, value, literal)
 	if not value and not literal then value = _G[name] end
 
 	wire_expression2_constants[name] = value
+end
+
+--- Example:
+--- E2Lib.registerEvent("propSpawned", { "e" }, nil)
+---@param name string
+---@param args string[]?
+function E2Lib.registerEvent(name, args)
+	name = name:lower()
+	-- assert(not E2Lib.Env.Events[name], "Possible addon conflict: Trying to override existing E2 event '" .. name .. "'")
+
+	E2Lib.Env.Events[name] = {
+		name = name,
+		args = args,
+
+		listening = {}
+	}
+end
+
+---@param name string
+---@param args table?
+function E2Lib.triggerEvent(name, args)
+	assert(E2Lib.Env.Events[name], "E2Lib.triggerEvent on nonexisting event: '" .. name .. "'")
+
+	for ent in pairs(E2Lib.Env.Events[name].listening) do
+		ent:ExecuteEvent(name, args)
+	end
 end
 
 -- ---------------------------------------------------------------

--- a/lua/entities/gmod_wire_expression2/core/init.lua
+++ b/lua/entities/gmod_wire_expression2/core/init.lua
@@ -196,7 +196,12 @@ function E2Lib.triggerEvent(name, args)
 	assert(E2Lib.Env.Events[name], "E2Lib.triggerEvent on nonexisting event: '" .. name .. "'")
 
 	for ent in pairs(E2Lib.Env.Events[name].listening) do
-		ent:ExecuteEvent(name, args)
+		-- wtf
+		if ent.ExecuteEvent then
+			ent:ExecuteEvent(name, args)
+		else
+			E2Lib.Env.Events[name].listening[ent] = nil
+		end
 	end
 end
 

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -321,10 +321,12 @@ end
 
 hook.Add("PlayerBindDown", "Exp2KeyReceivingDown", function(player, binding, button)
 	triggerKey(player,binding,button,true)
+	E2Lib.triggerEvent("keyPressed", {player, keys_lookup[button], 1, binding})
 end)
 
 hook.Add("PlayerBindUp", "Exp2KeyReceivingUp", function(player, binding, button)
 	triggerKey(player,binding,button,false)
+	E2Lib.triggerEvent("keyPressed", {player, keys_lookup[button], 0, binding})
 end)
 
 local function toggleRunOnKeys(self,ply,on,filter)
@@ -383,6 +385,7 @@ end
 __e2setcost(1)
 
 --- Returns user if the chip is being executed because of a key event.
+[nodiscard, deprecated = "Use the keyPressed event instead"]
 e2function entity keyClk()
 	if not self.data.runOnKeys then return nil end
 	return self.data.runOnKeys.runByKey
@@ -390,6 +393,7 @@ end
 
 --- Returns 1 or -1 if the chip is being executed because of a key event by player <ply>
 --- depending of whether the key was just pressed or released
+[nodiscard, deprecated = "Use the keyPressed event instead"]
 e2function number keyClk(entity ply)
 	if not self.data.runOnKeys then return 0 end
 	if not IsValid(ply) then return 0 end
@@ -399,16 +403,21 @@ e2function number keyClk(entity ply)
 end
 
 -- Returns the key which caused the keyClk event to trigger
+[nodiscard, deprecated = "Use the keyPressed event instead"]
 e2function string keyClkPressed()
 	if not self.data.runOnKeys then return "" end
 	return self.data.runOnKeys.pressedKey
 end
 
 -- Returns the bind which caused the keyClk event to trigger (if any)
+[nodiscard, deprecated = "Use the keyPressed event instead"]
 e2function string keyClkPressedBind()
 	if not self.data.runOnKeys then return "" end
 	return self.data.runOnKeys.pressedBind
 end
+
+-- Player, Key, UporDown, KeyBind
+E2Lib.registerEvent("keyPressed", {"e", "s", "n", "s"})
 
 -- Use Support --
 

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -442,6 +442,15 @@ e2function entity useClk()
 	return self.data.runByUse or NULL
 end
 
+E2Lib.registerEvent("chipUsed", { "e" }, function(self)
+	self.entity:SetUseType(SIMPLE_USE)
+	self.entity.Use = function(selfent, activator)
+		self.entity:ExecuteEvent("chipUsed", { activator })
+	end
+end, function(self)
+	self.entity.Use = nil
+end)
+
 
 -- isTyping
 local plys = {}
@@ -660,6 +669,8 @@ end
 
 hook.Add("PlayerInitialSpawn","Exp2RunOnJoin", function(ply)
 	lastJoined = ply
+	E2Lib.triggerEvent("playerConnected", { ply })
+
 	for e,_ in pairs(spawnAlert) do
 		if IsValid(e) then
 			e.context.data.runBySpawn = true
@@ -673,6 +684,8 @@ end)
 
 hook.Add("PlayerDisconnected","Exp2RunOnLeave", function(ply)
 	lastLeft = ply
+	E2Lib.triggerEvent("playerDisconnected", { ply })
+
 	for e,_ in pairs(leaveAlert) do
 		if IsValid(e) then
 			e.context.data.runByLeave = true
@@ -718,6 +731,9 @@ e2function entity lastDisconnectedPlayer()
 	return lastLeft
 end
 
+E2Lib.registerEvent("playerConnected", { "e" })
+E2Lib.registerEvent("playerDisconnected", { "e" })
+
 ----- Death+Respawns by Vurv -----
 
 local DeathAlert = {}
@@ -744,6 +760,8 @@ hook.Add("PlayerDeath","Exp2PlayerDetDead",function(victim,inflictor,attacker)
 	}
 	DeathList[victim] = entry -- victim's death is saved as their most recent death
 	DeathList.last = entry -- the most recent death's table is stored here for later use.
+
+	E2Lib.triggerEvent("playerDeath", { victim, inflictor, attacker })
 	for e2 in next,DeathAlert do
 		if IsValid(e2) then
 			e2.context.data.runByDeath = true
@@ -762,6 +780,8 @@ hook.Add("PlayerSpawn","Exp2PlayerDetRespn",function(player)
 	}
 	RespawnList[player] = entry
 	RespawnList.last = entry
+
+	E2Lib.triggerEvent("playerSpawn", { player })
 	for e2 in next,RespawnAlert do
 		if IsValid(e2) then
 			e2.context.data.runByRespawned = true
@@ -850,6 +870,11 @@ end
 e2function entity lastSpawnedPlayer()
 	return RespawnList.last.ply
 end
+
+E2Lib.registerEvent("playerSpawn", { "e" })
+E2Lib.registerEvent("playerDeath", { "e", "e", "e" })
+
+
 --******************************************--
 
 

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -422,7 +422,7 @@ E2Lib.registerEvent("keyPressed", {"e", "s", "n", "s"})
 -- Use Support --
 
 __e2setcost(50)
---- Makes the chip "Use"able
+[nodiscard, deprecated = "Use the chipUsed event instead"]
 e2function void runOnUse(value)
 	if value ~= 0 then
 		self.entity:SetUseType( SIMPLE_USE )
@@ -437,7 +437,7 @@ e2function void runOnUse(value)
 end
 
 __e2setcost(1)
---- Returns the entity who is using the chip
+[nodiscard, deprecated = "Use the chipUsed event instead"]
 e2function entity useClk()
 	return self.data.runByUse or NULL
 end
@@ -699,6 +699,7 @@ end)
 
 __e2setcost(3)
 
+[deprecated = "Use the playerConnected event instead"]
 e2function void runOnPlayerConnect(activate)
 	if activate ~= 0 then
 		spawnAlert[self.entity] = true
@@ -707,14 +708,17 @@ e2function void runOnPlayerConnect(activate)
 	end
 end
 
+[nodiscard, deprecated = "Use the playerConnected event instead"]
 e2function number playerConnectClk()
 	return self.data.runBySpawn and 1 or 0
 end
 
+[nodiscard, deprecated = "Use the playerConnected event instead"]
 e2function entity lastConnectedPlayer()
 	return lastJoined
 end
 
+[deprecated = "Use the playerDisconnected event instead"]
 e2function void runOnPlayerDisconnect(activate)
 	if activate ~= 0 then
 		leaveAlert[self.entity] = true
@@ -723,10 +727,12 @@ e2function void runOnPlayerDisconnect(activate)
 	end
 end
 
+[nodiscard, deprecated = "Use the playerDisconnected event instead"]
 e2function number playerDisconnectClk()
 	return self.data.runByLeave and 1 or 0
 end
 
+[nodiscard, deprecated = "Use the playerDisconnected event instead"]
 e2function entity lastDisconnectedPlayer()
 	return lastLeft
 end
@@ -795,16 +801,17 @@ end)
 
 __e2setcost(5)
 
---- If active is 0, the chip will no longer run on death.
+[deprecated = "Use the playerDeath event instead"]
 e2function void runOnDeath(number active)
 	DeathAlert[self.entity] = active~=0 and true or nil
 end
 
--- Give 1 or 0 depending on whether the chip was run by a death event.
+[nodiscard, deprecated = "Use the playerDeath event instead"]
 e2function number deathClk()
 	return self.data.runByDeath and 1 or 0
 end
 
+[nodiscard, deprecated = "Use the playerDeath event instead"]
 e2function number lastDeathTime()
 	return DeathList.last.timestamp or 0
 end
@@ -826,47 +833,58 @@ local function getRespawnEntry(self, ply, key)
 	return entry[key]
 end
 
+[nodiscard, deprecated = "Use the playerDeath event instead"]
 e2function number lastDeathTime(entity ply) -- When the player provided last died.
 	return getDeathEntry(self, ply,"timestamp") or 0
 end
 
+[nodiscard, deprecated = "Use the playerDeath event instead"]
 e2function entity lastDeathVictim()
 	return DeathList.last.victim
 end
 
+[nodiscard, deprecated = "Use the playerDeath event instead"]
 e2function entity lastDeathInflictor()
 	return DeathList.last.inflictor
 end
 
+[nodiscard, deprecated = "Use the playerDeath event instead"]
 e2function entity lastDeathInflictor(entity ply)
 	return getDeathEntry(self, ply,"inflictor") or NULL
 end
 
+[nodiscard, deprecated = "Use the playerDeath event instead"]
 e2function entity lastDeathAttacker()
 	return DeathList.last.attacker
 end
 
+[nodiscard, deprecated = "Use the playerDeath event instead"]
 e2function entity lastDeathAttacker(entity ply)
 	return getDeathEntry(self, ply,"attacker") or NULL
 end
 
 -- Respawn Functions
+[nodiscard, deprecated = "Use the playerSpawn event instead"]
 e2function number spawnClk()
 	return self.data.runByRespawned and 1 or 0
 end
 
+[deprecated = "Use the playerSpawn event instead"]
 e2function void runOnSpawn(number activate) -- If 1, make the chip run on a player respawning. Not joining.
 	RespawnAlert[self.entity] = active~=0 and true or nil
 end
 
+[nodiscard, deprecated = "Use the playerSpawn event instead"]
 e2function number lastSpawnTime()
 	return RespawnList.last.timestamp or 0
 end
 
+[nodiscard, deprecated = "Use the playerSpawn event instead"]
 e2function number lastSpawnTime(entity ply)
 	return getRespawnEntry(self, ply,"timestamp") or 0
 end
 
+[nodiscard, deprecated = "Use the playerSpawn event instead"]
 e2function entity lastSpawnedPlayer()
 	return RespawnList.last.ply
 end

--- a/lua/entities/gmod_wire_expression2/core/wirelink.lua
+++ b/lua/entities/gmod_wire_expression2/core/wirelink.lua
@@ -433,7 +433,6 @@ e2function number wirelink:operator[](address) = e2function number wirelink:read
 
 __e2setcost(20) -- temporary
 
---- XWL[N,vector]=V
 e2function vector wirelink:operator[T](address, vector value)
 	if not validWirelink(self, this) then return value end
 
@@ -444,7 +443,6 @@ e2function vector wirelink:operator[T](address, vector value)
 	return value
 end
 
---- V=XWL[N,vector]
 e2function vector wirelink:operator[T](address)
 	if not validWirelink(self, this) then return Vector(0, 0, 0) end
 
@@ -456,14 +454,12 @@ e2function vector wirelink:operator[T](address)
 	)
 end
 
---- XWL[N,string]=S
 e2function string wirelink:operator[T](address, string value)
 	if not validWirelink(self, this) or not this.WriteCell then return "" end
 	WriteStringZero(this, address, value)
 	return value
 end
 
---- S=XWL[N,string]
 e2function string wirelink:operator[T](address)
 	if not validWirelink(self, this) or not this.ReadCell then return "" end
 	return ReadStringZero(this, address)

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -590,7 +590,10 @@ function ENT:TriggerInput(key, value)
 		end
 
 		self.context.triggerinput = key
-		if self.trigger[1] or self.trigger[2][key] then self:Execute() end
+		if self.trigger[1] or self.trigger[2][key] then
+			self:Execute()
+			self:ExecuteEvent("input", { key })
+		end
 		self.context.triggerinput = nil
 	end
 end

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -127,6 +127,11 @@ function ENT:Destruct()
 	self:PCallHook("destruct")
 
 	for evt in pairs(self.registered_events) do
+		if E2Lib.Env.Events[evt].destructor then
+			-- If the event has a destructor to run when the E2 is removed and listening to the event.
+			E2Lib.Env.Events[evt].destructor(self.context)
+		end
+
 		E2Lib.Env.Events[evt].listening[self] = nil
 	end
 end
@@ -562,6 +567,10 @@ function ENT:Setup(buffer, includes, restore, forcecompile, filepath)
 
 	-- Register events only after E2 has executed once
 	for evt, _ in pairs(self.registered_events) do
+		if E2Lib.Env.Events[evt].constructor then
+			-- If the event has a constructor to run when the E2 is made and listening to the event.
+			E2Lib.Env.Events[evt].constructor(self.context)
+		end
 		E2Lib.Env.Events[evt].listening[self] = true
 	end
 

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -134,10 +134,6 @@ end
 function ENT:Execute()
 	if self.error or not self.context or self.context.resetting then return end
 
-	for k, v in pairs(self.tvars) do
-		self.GlobalScope[k] = fixDefault(wire_expression_types2[v][2])
-	end
-
 	self:PCallHook('preexecute')
 
 	self.context:PushScope()
@@ -202,19 +198,15 @@ function ENT:ExecuteEvent(evt, args)
 	assert(evt, "Expected event name, got nil (or false)")
 	if self.error or not self.context or self.context.resetting then return end
 
-	local block = self.registered_events[evt]
-	if not block then return end
-
-	for k, v in pairs(self.tvars) do
-		self.GlobalScope[k] = fixDefault(wire_expression_types2[v][2])
-	end
+	local handler = self.registered_events[evt]
+	if not handler then return end
 
 	self:PCallHook("preexecute")
 	self.context:PushScope()
 
 	local bench = SysTime()
 
-	local ok, msg = pcall(block[1], self.context, block)
+	local ok, msg = pcall(handler, self.context, args)
 
 	if not ok then
 		local _catchable, msg, trace = E2Lib.unpackException(msg)
@@ -359,7 +351,6 @@ function ENT:CompileCode(buffer, files, filepath)
 	self.registered_events = inst.registered_events
 
 	self.dvars = inst.dvars
-	self.tvars = inst.tvars
 	self.funcs = inst.funcs
 	self.funcs_ret = inst.funcs_ret
 	self.globvars = inst.GlobalScope

--- a/lua/wire/client/text_editor/modes/e2.lua
+++ b/lua/wire/client/text_editor/modes/e2.lua
@@ -67,6 +67,7 @@ local colors = {
 	["typename"]  = { Color(240, 160,  96), false}, -- orange
 	["constant"]  = { Color(240, 160, 240), false}, -- pink
 	["userfunction"] = { Color(102, 122, 102), false}, -- dark grayish-green
+	["eventname"] = { Color(74, 194, 116), false} -- green
 }
 
 function EDITOR:GetSyntaxColor(name)
@@ -411,7 +412,7 @@ function EDITOR:SyntaxColorLine(row)
 
 		if self:NextPattern( "%w+" ) then -- event <name>
 			local eventname = self.tokendata:match( "%w+" )
-			addToken("typename", eventname)
+			addToken("eventname", eventname)
 
 			self.tokendata = ""
 		end

--- a/lua/wire/client/text_editor/modes/e2.lua
+++ b/lua/wire/client/text_editor/modes/e2.lua
@@ -26,12 +26,16 @@ local keywords = {
 	["else"]     = { [true] = true },
 	["break"]    = { [true] = true },
 	["continue"] = { [true] = true },
-	--["function"] = { [true] = true },
+	["function"] = { [true] = true },
 	["return"] = { [true] = true },
 	["local"]  = { [true] = true },
 	["try"]    = { [true] = true },
-	["do"] = { [true] = true }
+	["do"] = { [true] = true },
+	["event"] = { [true] = true },
+	["#include"] = { [true] = true }
 }
+
+EDITOR.Keywords = keywords
 
 -- fallback for nonexistant entries:
 setmetatable(keywords, { __index=function(tbl,index) return {} end })

--- a/lua/wire/client/text_editor/texteditor.lua
+++ b/lua/wire/client/text_editor/texteditor.lua
@@ -1983,6 +1983,22 @@ end
 -- By Divran
 ---------------------------------------------------------------------------------------------------------
 
+local AC_COLOR_CONSTANT = Color(204, 137, 204)
+local AC_COLOR_CONSTANT_SELECTED = Color(168, 113, 168, 192)
+
+local AC_COLOR_FUNCTION = Color(65, 105, 255)
+local AC_COLOR_FUNCTION_SELECTED = Color(49, 80, 169, 192)
+
+local AC_COLOR_VARIABLE = Color(137, 204, 137)
+local AC_COLOR_VARIABLE_SELECTED = Color(113, 168, 113, 192)
+
+local AC_COLOR_EVENT = Color(64, 168, 100)
+local AC_COLOR_EVENT_SELECTED = Color(43, 112, 67, 192)
+
+local AC_COLOR_KEYWORD = Color(137, 204, 204)
+local AC_COLOR_KEYWORD_SELECTED = Color(113, 168, 168, 192)
+
+
 function EDITOR:IsVarLine()
 	local line = self.Rows[self.Caret[1]]
 	local word = line:match( "^@(%w+)" )
@@ -2070,10 +2086,15 @@ local tbl = {}
 -----------------------------------------------------------
 
 local function GetTableForConstant( str )
-	return { nice_str = function( t ) return t.data[1] end,
-			str = function( t ) return t.data[1] end,
-			replacement = function( t ) return t.data[1] end,
-			data = { str } }
+	return {
+		nice_str = function( t ) return t.data[1] end,
+		str = function( t ) return t.data[1] end,
+		replacement = function( t ) return t.data[1] end,
+		data = { str },
+
+		selected_color = AC_COLOR_CONSTANT_SELECTED,
+		color = AC_COLOR_CONSTANT
+	}
 end
 
 local function FindConstants( self, word )
@@ -2093,7 +2114,43 @@ local function FindConstants( self, word )
 	return suggestions
 end
 
-tbl[1] = function( self )
+local function FindKeywords(self, word)
+	local suggestions, count = {}, 0
+	for kw in pairs(self.CurrentMode.Keywords) do
+		if kw:sub(1, #word) == word then
+			count = count + 1
+			local function get() return kw end
+
+			suggestions[count] = {
+				nice_str = get, str = get, data = { kw },
+
+				replacement = function(self, editor)
+					return kw, #kw
+				end,
+
+				selected_color = AC_COLOR_KEYWORD_SELECTED,
+				color = AC_COLOR_KEYWORD,
+
+				description = function() return "The keyword " .. kw end
+			}
+		end
+	end
+
+	return suggestions
+end
+
+tbl[1] = function(self)
+	if self.ac_event then return end
+
+	local word, symbol = self:AC_GetCurrentWord()
+
+	if not word or word == "" then return end
+	if word:sub(1, 1):lower() ~= word:sub(1, 1) then return end
+
+	return FindKeywords(self, word)
+end
+
+tbl[2] = function( self )
 	if self.ac_event then return end
 
 	local word = self:AC_GetCurrentWord()
@@ -2108,7 +2165,8 @@ end
 --------------------
 
 local function GetTableForFunction()
-	return { nice_str = function( t ) return t.data[2] end,
+	return {
+		nice_str = function( t ) return t.data[2] end,
 			str = function( t ) return t.data[1] end,
 			replacement = function( t, editor )
 				local caret = editor:CopyPosition( editor.Caret )
@@ -2127,7 +2185,11 @@ local function GetTableForFunction()
 					return E2Helper.Descriptions[t.data[1]]
 				end
 			end,
-			data = {} }
+			data = {},
+
+			selected_color = AC_COLOR_FUNCTION_SELECTED,
+			color = AC_COLOR_FUNCTION
+		}
 end
 
 local function FindFunctions( self, has_colon, word )
@@ -2183,7 +2245,7 @@ local function FindFunctions( self, has_colon, word )
 	return suggestions
 end
 
-tbl[2] = function( self )
+tbl[3] = function( self )
 	if self.ac_event then return end
 
 	local word, symbolinfront = self:AC_GetCurrentWord()
@@ -2213,10 +2275,14 @@ end
 -----------------------------------------------------------
 
 local function GetTableForVariables( str )
-	return { nice_str = function( t ) return t.data[1] end,
-			str = function( t ) return t.data[1] end,
-			replacement = function( t ) return t.data[1] end,
-			data = { str } }
+	return {
+		nice_str = function( t ) return t.data[1] end,
+		str = function( t ) return t.data[1] end,
+		replacement = function( t ) return t.data[1] end,
+		data = { str },
+		selected_color = AC_COLOR_VARIABLE_SELECTED,
+		color = AC_COLOR_VARIABLE
+	}
 end
 
 
@@ -2269,7 +2335,7 @@ local function FindVariables( self, word )
 	return suggestions
 end
 
-tbl[3] = function( self )
+tbl[4] = function( self )
 	if self.ac_event then return end
 
 	local word = self:AC_GetCurrentWord()
@@ -2342,11 +2408,10 @@ function EDITOR:AC_Check( notimer )
 	self.AC_HasSuggestions = false
 
 	local suggestions = {}
-	for i=1,#self.AC_AutoCompletion do
-		local _suggestions = self.AC_AutoCompletion[i]( self )
-		if _suggestions ~= nil and #_suggestions > 0 then
-			suggestions = _suggestions
-			break
+	for i, ac in ipairs(self.AC_AutoCompletion) do
+		local _suggestions = ac( self )
+		if _suggestions and #_suggestions > 0 then
+			suggestions = table.Add(suggestions, _suggestions)
 		end
 	end
 
@@ -2414,17 +2479,27 @@ local function FindEvents(self, word)
 				data.display = name .. "(" .. table.concat(data.args, ",") .. ")"
 			end
 
-			local function repl() return data.replacement end
+			local function repl(self, editor)
+				local caret = editor:CopyPosition( editor.Caret )
+				caret[2] = caret[2] + 1
+				return data.replacement, #data.replacement
+			end
+
 			local function get() return data.display end
 
-			suggestions[count] = { nice_str = get, str = get, replacement = repl, data = { name } }
+			suggestions[count] = {
+				nice_str = get, str = get, replacement = repl, data = { name },
+
+				selected_color = AC_COLOR_EVENT_SELECTED,
+				color = AC_COLOR_EVENT
+			}
 		end
 	end
 
 	return suggestions
 end
 
-tbl[4] = function(self)
+tbl[5] = function(self)
 	if not self.ac_event then return end
 
 	local word, symbol = self:AC_GetCurrentWord()
@@ -2651,7 +2726,7 @@ function EDITOR:AC_FillInfoList( suggestion )
 		desc = "Description:\n" .. desc
 	end
 
-	if #others > 0 then -- If there are other functions with the same name...
+	if others and #others > 0 then -- If there are other functions with the same name...
 		desc = (desc or "") .. ((desc and desc ~= "") and "\n" or "") .. "Others with the same name:"
 
 		-- Loop through the "others" table to add all of them
@@ -2665,7 +2740,7 @@ function EDITOR:AC_FillInfoList( suggestion )
 			label:SetText( "" )
 			label.Paint = function( pnl )
 				local w,h = pnl:GetSize()
-				surface_SetDrawColor(65, 105, 255)
+				surface_SetDrawColor(v.color)
 				surface_DrawRect(0, 0, w, h)
 				surface_SetFont(self.CurrentFont)
 				surface_SetTextPos( 6, h/2-nameh/2 )
@@ -2727,9 +2802,9 @@ function EDITOR:AC_FillList()
 		txt.Paint = function( pnl, w, h )
 			local backgroundColor
 			if panel.Selected == pnl.count then
-				backgroundColor = Color(49, 80, 169, 192)
+				backgroundColor = suggestion.selected_color
 			else
-				backgroundColor = Color(65, 105, 225, 255)
+				backgroundColor = suggestion.color
 			end
 			surface_SetDrawColor(backgroundColor)
 			surface_DrawRect(0, 0, w, h)

--- a/lua/wire/client/text_editor/wire_expression2_editor.lua
+++ b/lua/wire/client/text_editor/wire_expression2_editor.lua
@@ -102,6 +102,7 @@ local colors = {
 	["typename"] = Color(240, 160, 96), -- orange
 	["constant"] = Color(240, 160, 240), -- pink
 	["userfunction"] = Color(102, 122, 102), -- dark grayish-green
+	["eventname"] = Color(74, 194, 116), -- green
 	["dblclickhighlight"] = Color(0, 100, 0) -- dark green
 }
 

--- a/lua/wire/stools/expression2.lua
+++ b/lua/wire/stools/expression2.lua
@@ -450,7 +450,7 @@ if SERVER then
 		if canhas(player) then return end
 		if E2.error then return end
 		if hook.Run( "CanTool", player, WireLib.dummytrace( E2 ), "wire_expression2", "halt execution" ) then
-			E2:PCallHook("destruct")
+			E2:Destruct()
 			E2:Error("Execution halted (Triggered by: " .. player:Nick() .. ")", "Execution halted")
 			if E2.player ~= player then
 				WireLib.AddNotify(player, "Expression halted.", NOTIFY_GENERIC, 5, math.random(1, 5))


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/56230599/195732018-5c889c96-5b28-4d85-bb23-2c891a0f8648.png)

This PR adds events to E2. The hope is these will make the current confusing/limited/awful `clk` system obsolete.

## Event List
Pretty small right now, but eventually it should be 1:1 with the current clk setups.
- [x] tickClk() -> `tick()`
- [x] fileClk() -> `fileErrored(sn)` & `fileLoaded(ss)`
- [x] fileListClk() -> ❌ Niche usecase, can be done later if needed. Also want to replace the file functions with lambda ones in the future.
- [x] inputClk() -> `input(s)`
- [x] keyClk() -> `keyPressed(esns)`
- [x] chatClk() -> `chat(ssn)`
- [x] dsClk() -> ❌ Niche usecase, can be done later if needed.
- [x] egpQueueClk() -> ❌ Niche usecase, can be done later if needed.
- [x] httpClk() -> `httpErrored(ss)` & `httpLoaded(sns)`
- [x] deathClk() -> `playerDeath(eee)`
- [x] spawnClk() -> `playerSpawn(e)`
- [x] clk() -> ❌ Will not be replaced. Planning on reimplementing the timer library with function lambdas.
- [x] playerConnectClk() -> `playerConnected(e)`
- [x] playerDisconnectClk() -> `playerDisconnected(e)`
- [x] last() -> `removed(n)`
- [x] removing() -> `removed(n)`
- [x] useClk() -> `chipUsed(e)`

## Lua Api

These events can be called on every E2 chip with `E2Lib.triggerEvent(name: string, args: any[])`. There is a new method on the E2 `ENT`, being `ENT:ExecuteEvent(name: string, args: any[])` (this is what triggerEvent calls on every single chip subscribed)

To register an event, use `E2Lib.registerEvent(name: string, args: string[])`, for example
```lua
E2Lib.registerEvent("fileErrored", {"s", "n"}) -- string, number
E2Lib.registerEvent("fileLoaded", {"s", "s"}) -- string, string
```

There are constructors and destructors for handling hook creation/deletion.
```lua
E2Lib.registerEvent("chipUsed", { "e" }, function(self)
	self.entity:SetUseType(SIMPLE_USE)
	self.entity.Use = function(selfent, activator)
		self.entity:ExecuteEvent("chipUsed", { activator })
	end
end, function(self)
	self.entity.Use = nil
end)
```

## Potential Todos
This is practically done, but there's some QoL stuff that could be done.
* ✅ Autocomplete support
* ❌ E2Helper docs
* ✅ Separate highlight color (right now it's the same color as a type)
* ❌ A way to remove events at runtime? (Would require events to become runtime constructs, which right now they are compile time. Potentially could just have them able to disable themselves temporarily.)
* ❌ A way to trigger events by an E2? (Can be done later.)

## Deprecation messages
This also shows you messages if any are provided for deprecation notices.
Nicer for dev so you don't need to jump between the function and the e2helper.

This is kind of unrelated to the PR, but I made the changes to avoid a ton of messages asking why all of the most common runOn* are deprecated now..

![image](https://user-images.githubusercontent.com/56230599/195768060-c755951d-4bb6-4d47-beca-87c069a0d15f.png)

## Extra autocompletion
There's now autocompletion for keywords and events. Autocompletion entries are now colored for their type (constant, function, variable, event, keyword).