### PR TITLE
Extend validation menu

### DIFF
--- a/lua/autorun/wire_load.lua
+++ b/lua/autorun/wire_load.lua
@@ -58,6 +58,7 @@ if SERVER then
 	AddCSLuaFile("wire/client/customspawnmenu.lua")
 
 	-- text editor
+	AddCSLuaFile("wire/client/text_editor/issue_viewer.lua")
 	AddCSLuaFile("wire/client/text_editor/texteditor.lua")
 	AddCSLuaFile("wire/client/text_editor/wire_expression2_editor.lua")
 	AddCSLuaFile("wire/client/text_editor/modes/e2.lua")
@@ -113,6 +114,7 @@ if CLIENT then
 	include("wire/client/wiremenus.lua")
 	include("wire/client/text_editor/texteditor.lua")
 	include("wire/client/wire_expression2_browser.lua")
+	include("wire/client/text_editor/issue_viewer.lua")
 	include("wire/client/text_editor/wire_expression2_editor.lua")
 	include("wire/client/wire_filebrowser.lua")
 	include("wire/client/wire_listeditor.lua")

--- a/lua/wire/client/text_editor/issue_viewer.lua
+++ b/lua/wire/client/text_editor/issue_viewer.lua
@@ -111,8 +111,9 @@ function PANEL:Init()
         return n
     end
     
+    local IssuesView_BackgroundColor = Color(32, 32, 32)
     function self.IssuesView:Paint(w, h)
-        surface_SetDrawColor(Color(32, 32, 32))
+        surface_SetDrawColor(IssuesView_BackgroundColor)
         surface_DrawRect(0, 0, w, h)
     end
     

--- a/lua/wire/client/text_editor/issue_viewer.lua
+++ b/lua/wire/client/text_editor/issue_viewer.lua
@@ -84,6 +84,7 @@ function PANEL:Init()
     self.ValidationButton = self:Add("DButton")
     self.ValidationButton:SetText("")
     self.ValidationButton:Dock(TOP)
+    self.ValidationButton:DockMargin(2, 0, 2, 0)
     self.ValidationButton:SetSize(0, 28)
 
     self.IssuesView = self:Add("DTree")
@@ -137,7 +138,7 @@ function PANEL:Init()
         surface_DrawRect(0, 0, w, h)
 
         surface_SetDrawColor(base.ValidationColorOutline)
-        surface_DrawOutlinedRect(0, 0, w, h, 1)
+        surface_DrawOutlinedRect(0, 0, w, h, 2)
         
         draw_SimpleText(base.ValidationText, "DermaDefault", w / 2, h / 2, color_white, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
         if base.ShowWhatPopupDoes > 0 then

--- a/lua/wire/client/text_editor/issue_viewer.lua
+++ b/lua/wire/client/text_editor/issue_viewer.lua
@@ -1,0 +1,292 @@
+local PANEL = {}
+
+local surface_DrawRect = surface.DrawRect
+local surface_DrawOutlinedRect = surface.DrawOutlinedRect
+local surface_SetDrawColor = surface.SetDrawColor
+local surface_DrawLine = surface.DrawLine
+
+local draw_SimpleText = draw.SimpleText
+
+local gui_MouseY = gui.MouseY
+
+function PANEL:Init()
+    local base = self
+    
+    self.Files = {}
+
+    self:Dock(BOTTOM)
+    self:DockMargin(-2, -3, -2, -3)
+    self:SetSize(24,28)
+
+    self.Dragger = self:Add("DButton")
+    self.Dragger:Dock(TOP)
+    self.Dragger:SetSize(0,6)
+    self.Dragger:SetText("")
+    self.Dragger:SetCursor("sizens")
+
+    self.Dragger.Held = false
+    self.Dragger.MouseY = 0
+    self.Dragger.OldSize = 192
+
+    self.CollapseSize = 37
+    self.PanelHeight = 192
+
+    function self.Dragger:Paint(w, h)
+        if self.Hovered or self.Held then
+            surface_SetDrawColor(base.ValidationColorDragger)
+        else
+            surface_SetDrawColor(48, 48, 48, 255)
+        end
+
+        surface_DrawRect(0, 0, w, h)
+    end
+
+    function self.Dragger:Think()
+        if not self.Held then 
+            if self.UnheldDueToCollapse then
+                self.UnheldDueToCollapse = false
+                self.Hovered = false
+                base:SetTall(base.CollapseSize)
+            end
+            return
+        end
+
+        local sizing = self.MouseY - gui.MouseY()
+        local tall_request = self.OldSize + sizing
+
+        if tall_request > base.CollapseSize + 16 then
+            base:Expand(true)
+        else
+            base:Collapse(true)
+        end
+        if not base.IsCollapsed then
+            base:SetTall(self.OldSize + sizing)
+        end
+    end
+
+    function self.Dragger:OnMousePressed(btn)
+        if btn ~= MOUSE_LEFT then return end
+
+        self.OldSize = base:GetTall()
+        self.MouseY = gui_MouseY()
+
+        self:MouseCapture(true)
+        self.Held = true
+    end
+
+    function self.Dragger:OnMouseReleased(btn)
+        if btn ~= MOUSE_LEFT then return end
+        
+        self:MouseCapture(false)
+        self.Held = false
+    end
+
+    self.ValidationButton = self:Add("DButton")
+    self.ValidationButton:SetText("")
+    self.ValidationButton:Dock(TOP)
+    self.ValidationButton:SetSize(0, 28)
+
+    self.IssuesView = self:Add("DTree")
+    self.IssuesView:Dock(FILL)
+    self.IssuesView:DockMargin(2, 0, 2, 3)
+    
+    self.IssuesView:Hide()
+    self.IssuesView.OldAddNode = self.IssuesView.AddNode
+    function self.IssuesView:AddNode(text)
+        local n = self:OldAddNode(text)
+        n.Label:SetTextColor(color_white)
+        n.Paint = function(node, w, h)
+            if self:GetSelectedItem() == node then
+                surface_SetDrawColor(100, 100, 100, 75)
+                surface_DrawRect(0, 0, w, h)
+
+                return
+            end
+            if node.Label.Hovered then
+                surface_SetDrawColor(100, 100, 100, 25)
+                surface_DrawRect(0, 0, w, h)
+            end
+        end
+        n.Label.Paint = function(_, _, _) end
+        return n
+    end
+    
+    function self.IssuesView:Paint(w, h)
+        surface_SetDrawColor(Color(32, 32, 32))
+        surface_DrawRect(0, 0, w, h)
+    end
+    
+    self.ValidationText = "Code Validator"
+    self:SetValidationColors(Color(180, 180, 180))
+    
+    self.OnMousePressed = nil
+    
+    self.ShowWhatPopupDoes = 0
+
+    function self.ValidationButton:Paint(w, h)
+        local validation_color
+
+        if self.Hovered and not base.Dragger.Held then
+            validation_color = base.ValidationColorHovered
+        else
+            validation_color = base.ValidationColorBackground
+        end
+
+        surface_SetDrawColor(validation_color)
+        surface_DrawRect(0, 0, w, h)
+
+        surface_SetDrawColor(base.ValidationColorOutline)
+        surface_DrawOutlinedRect(0, 0, w, h, 1)
+        
+        draw_SimpleText(base.ValidationText, "DermaDefault", w / 2, h / 2, color_white, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
+        if base.ShowWhatPopupDoes > 0 then
+            draw_SimpleText((base.IsCollapsed and "Show" or "Hide") .. " Code Problems", "DermaDefault", 36, h / 2, Color(255, 255, 255, base.ShowWhatPopupDoes * 255), TEXT_ALIGN_LEFT, TEXT_ALIGN_CENTER )
+        end
+    end
+    
+    function self.ValidationButton:OnMousePressed(btn)
+        if base.OnMousePressed ~= nil then
+            base:OnMousePressed(btn)
+        end
+    end
+
+    function self.IssuesView:DoClick()
+        if base.OnIssueClicked ~= nil then
+            base:OnIssueClicked(self:GetSelectedItem())
+        end
+    end
+
+    function self.IssuesView:DoRightClick(node)
+        local menu = DermaMenu()
+
+        local copy = menu:AddOption(
+            "Copy to clipboard", 
+            function() 
+                SetClipboardText(node.Label:GetText()) 
+            end
+        )
+
+        menu:Open()
+    end
+    
+    self.TogglePopupButton = self.ValidationButton:Add("DButton")
+    self.TogglePopupButton:Dock(LEFT)
+    self.TogglePopupButton:SetSize(36, 0)
+    self.TogglePopupButton:SetText("")
+    self.IsCollapsed = true
+    
+    function self.TogglePopupButton:Paint(w, h)
+
+        surface_SetDrawColor(color_white)
+        local centerX, centerY = w / 2, h / 2
+        local arrowWidth, arrowHeight = 6, 3 * (base.IsCollapsed and -1 or 1)
+        
+        surface_DrawLine(centerX - arrowWidth, centerY - arrowHeight, centerX, centerY + arrowHeight)
+        surface_DrawLine(centerX + arrowWidth, centerY - arrowHeight, centerX, centerY + arrowHeight)
+    end
+    
+    function self.TogglePopupButton:DoClick()
+        base:Toggle()
+    end
+    function self.TogglePopupButton:Think()
+        local isHovered = self:IsHovered() and 1 or -1
+        base.ShowWhatPopupDoes = math.Clamp(base.ShowWhatPopupDoes + (0.025 * isHovered), 0, 1)
+    end
+end
+
+function PANEL:Paint(w, h) 
+
+end
+function PANEL:GetValue()
+    return self.ValidationText
+end
+
+function PANEL:Collapse(triggered_by_drag)
+    if self.IsCollapsed then return end
+
+    if triggered_by_drag then 
+        self.Dragger.Held = false
+        self.Dragger:MouseCapture(false)
+        self.Dragger.UnheldDueToCollapse = true
+    end
+    self.Dragger.OldSize = self:GetTall()
+    self:SetTall(self.CollapseSize)
+
+    self.IssuesView:Hide()
+    self.IsCollapsed = true
+end
+function PANEL:Expand(triggered_by_drag)
+    if not self.IsCollapsed then return end
+
+    self:SetTall(self.Dragger.OldSize)
+
+    self.IssuesView:Show()
+    self.IsCollapsed = false
+end
+function PANEL:Toggle()
+    if self.IsCollapsed then
+        self:Expand()
+    else
+        self:Collapse()
+    end
+end
+
+function PANEL:SetValidationColors(color)
+    self.ValidationColorBackground = color
+    local h, s, v = ColorToHSV(color)
+    
+    self.ValidationColorOutline = HSVToColor(h, s, v / 1.2)
+    self.ValidationColorHovered = HSVToColor(h, s, v + 0.073)
+    self.ValidationColorDepressed = HSVToColor(h, s, v - 0.073)
+    self.ValidationColorDragger = HSVToColor(h, s, v + 0.2)
+end
+
+function PANEL:SetText(text)
+    self.ValidationText = text
+end
+
+function PANEL:SetBGColor(r, g, b, a)
+    self:SetValidationColors(Color(r, g, b, a))
+end
+
+function PANEL:Update(errors, warnings, header_text, header_color)
+    self.ValidationText = header_text or self.ValidationText
+    if header_color ~= nil then self:SetValidationColors(header_color) end
+    
+    self.Errors = errors
+    self.Warnings = warnings
+    
+    local tree = self.IssuesView
+    tree:Clear()
+
+    local failed = false
+
+    if warnings ~= nil and not table.IsEmpty(warnings) then
+        for k, v in ipairs(warnings) do
+            if v.message ~= nil then
+                local node = tree:AddNode(v.message .. (v.line ~= nil and string.format(" [%d:%d]", v.line, v.char) or ""))
+                node:SetIcon("icon16/error.png")
+                node.line = v.line
+                node.char = v.char
+            end
+        end
+        failed = true
+    end
+
+    if errors ~= nil and not table.IsEmpty(errors) then
+        for k, v in ipairs(errors) do
+            local node = tree:AddNode(v.message .. (v.line ~= nil and string.format(" [%d:%d]", v.line, v.char) or ""))
+            node:SetIcon("icon16/cancel.png")
+            node.line = v.line
+            node.char = v.char
+        end
+        failed = true
+    end
+
+    if not failed then
+        local node = tree:AddNode("No problems were found in the code.")
+        node:SetIcon("icon16/accept.png")
+    end
+end
+
+vgui.Register("Wire.IssueViewer", PANEL, "DPanel")

--- a/lua/wire/client/text_editor/wire_expression2_editor.lua
+++ b/lua/wire/client/text_editor/wire_expression2_editor.lua
@@ -897,7 +897,7 @@ function Editor:InitComponents()
 		end
 	end
 	self.C.Val.OnIssueClicked = function(panel, issue)
-		if issue.line ~= nil and issue.char ~= nil  then
+		if issue.line ~= nil and issue.char ~= nil then
 			self:GetCurrentEditor():SetCaret({issue.line, issue.char})
 		end
 	end

--- a/lua/wire/client/text_editor/wire_expression2_editor.lua
+++ b/lua/wire/client/text_editor/wire_expression2_editor.lua
@@ -897,7 +897,9 @@ function Editor:InitComponents()
 		end
 	end
 	self.C.Val.OnIssueClicked = function(panel, issue)
-		self:GetCurrentEditor():SetCaret({issue.line, issue.char})
+		if issue.line ~= nil and issue.char ~= nil  then
+			self:GetCurrentEditor():SetCaret({issue.line, issue.char})
+		end
 	end
 	self.C.Btoggle:SetImage("icon16/application_side_contract.png")
 	function self.C.Btoggle.DoClick(button)

--- a/lua/wire/cpulib.lua
+++ b/lua/wire/cpulib.lua
@@ -113,20 +113,23 @@ if CLIENT then
   function CPULib.Validate(editor,source,fileName)
     CPULib.Compile(source,fileName,
       function()
-        editor.C.Val:SetBGColor(50, 128, 20, 180)
-        editor.C.Val:SetFGColor(255, 255, 255, 128)
-        editor.C.Val:SetText("   Success, "..(HCOMP.WritePointer or "?").." bytes compiled.")
+        editor.C.Val:Update(nil, nil, "   Success, "..(HCOMP.WritePointer or "?").." bytes compiled.", Color(50, 128, 20))
       end,
       function(error,errorPos)
-        editor.C.Val:SetBGColor(128, 20, 50, 180)
-        editor.C.Val:SetFGColor(255, 255, 255, 128)
-        editor.C.Val:SetText("   "..(error or "unknown error"))
+        local issue = (error or "unknown error")
 
-        if not errorPos then return end
+        local line, char = 0, 0
 
-        local textEditor = CPULib.SelectTab(editor,errorPos.File)
-        if not textEditor then return end
-        textEditor:SetCaret({errorPos.Line,errorPos.Col})
+        if errorPos then 
+          line = errorPos.Line
+          char = errorPos.Col
+
+          local textEditor = CPULib.SelectTab(editor,errorPos.File)
+          if not textEditor then return end
+          textEditor:SetCaret({errorPos.Line,errorPos.Col})
+        end
+
+        editor.C.Val:Update({{message = issue, line = line, char = char}}, nil, issue, Color(128, 20, 50))
       end,editor.EditorType)
   end
 


### PR DESCRIPTION
Replaces the previous validation button with a collapsible and scalable problems menu. This should make viewing multiple warnings at once significantly less painful to deal with. It also allows for multiple errors to be shown in the E2 editor if this is ever implemented. This implements my idea in #2392 and has also been made compatible with the other editors (CPU's, etc)

I had the idea to fully utilize the tree view and show every problem within every open file, but I chose not to implement that for now. May make this into another PR later down the road.

![WarningPanel](https://user-images.githubusercontent.com/13711445/196017407-7c603d09-194e-47da-8c36-6bd0862cf009.png)
