### PR TITLE
fix legacy serialized data

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/serialization.lua
+++ b/lua/entities/gmod_wire_expression2/core/serialization.lua
@@ -104,13 +104,13 @@ typeSanitizers = {
 
 	-- Two sanitizers to help out with making older serialized data from before #2399 usable
 	["v"] = function ( self, glonOutputObject, safeGlonObjectMap )
-		if type(glonOutputObject) ~= "vector" then
+		if type(glonOutputObject) ~= "Vector" then
 			return Vector( glonOutputObject[1], glonOutputObject[2], glonOutputObject[3] )
 		end
 		return glonOutputObject
 	end,
 	["a"] = function ( self, glonOutputObject, safeGlonObjectMap )
-		if type(glonOutputObject) ~= "angle" then
+		if type(glonOutputObject) ~= "Angle" then
 			return Angle( glonOutputObject[1], glonOutputObject[2], glonOutputObject[3] )
 		end
 		return glonOutputObject

--- a/lua/entities/gmod_wire_expression2/core/serialization.lua
+++ b/lua/entities/gmod_wire_expression2/core/serialization.lua
@@ -101,6 +101,21 @@ local function sanitizeGlonOutput ( self, glonOutputObject, objectType, safeGlon
 end
 
 typeSanitizers = {
+
+	-- Two sanitizers to help out with making older serialized data from before #2399 usable
+	["v"] = function ( self, glonOutputObject, safeGlonObjectMap )
+		if type(glonOutputObject) ~= "vector" then
+			return Vector( glonOutputObject[1], glonOutputObject[2], glonOutputObject[3] )
+		end
+		return glonOutputObject
+	end,
+	["a"] = function ( self, glonOutputObject, safeGlonObjectMap )
+		if type(glonOutputObject) ~= "angle" then
+			return Angle( glonOutputObject[1], glonOutputObject[2], glonOutputObject[3] )
+		end
+		return glonOutputObject
+	end,
+
 	["r"] = function ( self, glonOutputObject, safeGlonObjectMap )
 				if safeGlonObjectMap["r"][glonOutputObject] then
 					return safeGlonObjectMap["r"][glonOutputObject]


### PR DESCRIPTION
`vonDecodeTable` will produce cursed frankenstein vectors and angles when used on data serialized before #2399.  These are completely useless and will error the chip 99% of the time when you try to do anything with them.

This PR fixes those.

Tested and working with von data; probably fixes similar issues with glon and json too since this code gets run for all of them.