### PR TITLE
Add `noreturn` function attribute

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -595,8 +595,12 @@ function Compiler:InstrCALL(args)
 	exprs[1] = rt[1]
 	exprs[#exprs + 1] = tps
 
-	if rt[4] and rt[4].deprecated then
-		self:Warning("Use of deprecated function: " .. args[3] .. "(" .. tps_pretty(tps) .. ")", args)
+	if rt[4] then
+		if rt[4].deprecated then
+			self:Warning("Use of deprecated function: " .. args[3] .. "(" .. tps_pretty(tps) .. ")", args)
+		elseif rt[4].noreturn then
+			self.Scope.Dead = true
+		end
 	end
 
 	return exprs, rt[2], rt[4]

--- a/lua/entities/gmod_wire_expression2/core/core.lua
+++ b/lua/entities/gmod_wire_expression2/core/core.lua
@@ -330,6 +330,8 @@ end
 
 do
 	local raise = E2Lib.raiseException
+
+	[noreturn]
 	e2function void error( string reason )
 		raise(reason, 2, self.trace)
 	end
@@ -347,6 +349,7 @@ end
 
 __e2setcost(100) -- approximation
 
+[noreturn]
 e2function void reset()
 	if self.data.last or self.entity.first then error("exit", 0) end
 

--- a/lua/entities/gmod_wire_expression2/core/extpp.lua
+++ b/lua/entities/gmod_wire_expression2/core/extpp.lua
@@ -221,7 +221,7 @@ function E2Lib.ExtPP.Pass2(contents)
 
 	-- This flag helps determine whether the preprocessor changed, so we can tell the environment about it.
 	local changed = false
-	for a_begin, attributes, h_begin, ret, thistype, colon, name, args, whitespace, equals, h_end in contents:gmatch("()(%[?[%l%d,_ =\"]*%]?)\r?\n?()e2function%s+(" .. p_typename .. ")%s+([a-z0-9]-)%s*(:?)%s*(" .. p_func_operator .. ")%(([^)]*)%)(%s*)(=?)()") do
+	for a_begin, attributes, h_begin, ret, thistype, colon, name, args, whitespace, equals, h_end in contents:gmatch("()(%[?[%l%d,_ =\"]*%]?)\r?\n?[ \t]*()e2function%s+(" .. p_typename .. ")%s+([a-z0-9]-)%s*(:?)%s*(" .. p_func_operator .. ")%(([^)]*)%)(%s*)(=?)()") do
 		-- Convert attributes to a lookup table passed to registerFunction
 		attributes = attributes ~= "" and attributes or nil
 		-- attributes = attributes ~= ""


### PR DESCRIPTION
Like C++'s `noreturn`, Typescript/Rust/etc's `never` / `!` type.

Also changed the ExtPP pattern to not break when attributes are used on an indented e2function :p

Fixes #2461

![image](https://user-images.githubusercontent.com/56230599/198816581-805be813-3a36-4485-b8c0-c0b523306820.png)