### PR TITLE
Fix syntax error in Holoemitters

### DIFF
--- a/lua/entities/gmod_wire_holoemitter.lua
+++ b/lua/entities/gmod_wire_holoemitter.lua
@@ -257,7 +257,7 @@ function ENT:TriggerInput( name, value )
 			self:SetNWBool(name,value ~= 0)
 		else
 			-- Other data
-			if (self.bools[name]) then value ~= 0 end
+			if (self.bools[name]) then value = value ~= 0 end
 			self.Data[name] = value
 		end
 	end


### PR DESCRIPTION
Looks like some brave soul went through and removed all Garry Operators, but accidentally left a syntax error behind.
```
addons/wire/lua/entities/gmod_wire_holoemitter.lua:260: '=' expected near '~='
```

This should clear it up. The diff against the original line (pre-refactor):
```diff
- if (self.bools[name]) then value = !(value == 0 and true) or false end
+ if (self.bools[name]) then value = value ~= 0 end
```

Thanks