### PR TITLE
Add wire forcer hook

### DIFF
--- a/lua/entities/gmod_wire_forcer.lua
+++ b/lua/entities/gmod_wire_forcer.lua
@@ -80,6 +80,9 @@ function ENT:Think()
 	elseif convar_value==2 then
 		if not IsValid(self:GetPlayer()) or gamemode.Call( "GravGunPickupAllowed", self:GetPlayer(), ent )==false then return end
 	end
+
+	local canRun = hook.Run( "Wire_ForcerCanUse", self:GetPlayer(), ent )
+	if canRun == false then return end
 	
 	if ent:GetMoveType() == MOVETYPE_VPHYSICS then
 		local phys = ent:GetPhysicsObject()

--- a/lua/entities/gmod_wire_forcer.lua
+++ b/lua/entities/gmod_wire_forcer.lua
@@ -81,8 +81,7 @@ function ENT:Think()
 		if not IsValid(self:GetPlayer()) or gamemode.Call( "GravGunPickupAllowed", self:GetPlayer(), ent )==false then return end
 	end
 
-	local canRun = hook.Run( "Wire_ForcerCanUse", self:GetPlayer(), ent )
-	if canRun == false then return end
+	if hook.Run( "Wire_ForcerCanUse", self:GetPlayer(), ent ) == false then return end
 	
 	if ent:GetMoveType() == MOVETYPE_VPHYSICS then
 		local phys = ent:GetPhysicsObject()


### PR DESCRIPTION
More often than not I've been wanting to prevent the wire forcer from applying to certain entities, such as players or check for CPPI ownership. I feel like others could have this issue too so i propose a hook to allow easy access to the wire forcer logic.