### PR TITLE
Add concmd and convar hook

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/console.lua
+++ b/lua/entities/gmod_wire_expression2/core/console.lua
@@ -71,6 +71,10 @@ local function checkConCmd(self, cmd)
 		end
 	end
 
+    if hook.Run( "Expression2_CanConCmd", ply, cmd ) == false then
+        return self:throw("Command '" .. cmd .. "' was blocked by the server. ", false)
+    end
+
 	return true
 end
 
@@ -86,6 +90,11 @@ local function checkConVar(self, var)
 	if table.IsEmpty(whitelist) then return true end
 
 	if whitelist[var] == nil then return self:throw("Convar '" .. var .. "' is not whitelisted w/ wire_expression2_convar_whitelist ", false) end
+
+    if hook.Run("Expression2_CanConVar", ply, var) == false then
+        return self:throw("Convar '" .. var .. "' was blocked by the server. ", false)
+    end
+
 	return true
 end
 


### PR DESCRIPTION
These hooks would allow servers to block specific commands, could be used to block abuse of certain commands to preventing staff from running malicious scripts without them knowing.

I don't see a real downside of these hooks.
