### PR TITLE
Fix setAng imprecision

### DIFF
--- a/lua/wire/wireshared.lua
+++ b/lua/wire/wireshared.lua
@@ -969,7 +969,6 @@ function WireLib.setAng(ent, ang)
 	if abs(ang.pitch) == huge or abs(ang.yaw) == huge or abs(ang.roll) == huge then return false end -- SetAngles'ing inf crashes the server
 
 	ang = Angle(ang)
-	ang:Normalize()
 
 	return ent:SetAngles(ang)
 end


### PR DESCRIPTION
Fixes #2484 

Tested `setAng( ang(0, 2^32, 0) )` with this change and it doesn't need normalize to avoid crashes now.