### PR TITLE
Fix for default camera angle on client side movement

### DIFF
--- a/lua/entities/gmod_wire_cameracontroller.lua
+++ b/lua/entities/gmod_wire_cameracontroller.lua
@@ -37,28 +37,6 @@ local function doRotate(curpos,curang,ply,parent,AutoMove,LocalMove,distance,off
 	return curpos, curang
 end
 
-local function getAngOffset(ply, LocalMove)
-	local coffset = Angle(0, 90, 0)
-	local offset = Angle(0, 0, 0)
-
-	if LocalMove then
-		offset = -coffset	--chairs are always oriented 90 degrees yaw from forward, subtract 90 to get dynamic forward
-	else
-		local veh = ply:GetVehicle()
-		if IsValid(veh) then
-			local ang = veh:GetAngles()
-			local up = veh:GetUp()
-			
-			ang:RotateAroundAxis(up, 90)
-			angpy = Angle(ang.p, ang.y, 0)	--spin ang to forward, then remove roll
-
-			offset = angpy - coffset	--difference between forward and initial 90yaw offset
-		end
-	end
-
-	return offset
-end
-
 if CLIENT then
 
 	--------------------------------------------------
@@ -760,7 +738,22 @@ function ENT:EnableCam( ply )
 
 		self:ColorByLinkStatus(self.LINK_STATUS_ACTIVE)
 
-		self.AngOffset = getAngOffset(ply, self.LocalMove)
+		local veh = ply:GetVehicle()
+		if self.AutoMove and IsValid(veh) then	--calculate angle offset to make free look face forward
+			local coffset = Angle(0, 90, 0)
+
+			if self.LocalMove then
+				self.AngOffset = -coffset	--chairs are always oriented 90 degrees yaw from forward, subtract 90 to get dynamic forward
+			else
+				local ang = veh:GetAngles()
+				local up = veh:GetUp()
+				
+				ang:RotateAroundAxis(up, 90)
+				angpy = Angle(ang.p, ang.y, 0)	--spin ang to forward, then remove roll
+
+				self.AngOffset = angpy - coffset	--difference between forward and initial 90yaw offset
+			end
+		end
 
 		self:SyncSettings( ply )
 	else -- No player specified, activate cam for everyone not already active

--- a/lua/entities/gmod_wire_cameracontroller.lua
+++ b/lua/entities/gmod_wire_cameracontroller.lua
@@ -573,8 +573,8 @@ function ENT:UpdateOutputs()
 		local curpos = pos
 		local curang = ang
 		
-		local offset = self.AngOffset or nil
-		curpos, curang = doRotate(curpos,curang,ply,parent,self.AutoMove,self.LocalMove,self.Distance)
+		local offset = self.CamAngOffset or nil
+		curpos, curang = doRotate(curpos,curang,ply,parent,self.AutoMove,self.LocalMove,self.Distance, offset)
 
 		-- AutoUnclip
 		if self.AutoUnclip then
@@ -753,7 +753,13 @@ function ENT:EnableCam( ply )
 
 		self:ColorByLinkStatus(self.LINK_STATUS_ACTIVE)
 
-		self.AngOffset = getAngOffset(ply, self.AutoMove)
+		local veh = ply:GetVehicle()
+		if IsValid(veh) then
+			local ang = veh:GetAngles()
+			self.CamAngOffset = Angle(ang.p,ang.y,0)
+		else
+			self.CamAngOffset = Angle(0,0,0)
+		end
 
 		self:SyncSettings( ply )
 	else -- No player specified, activate cam for everyone not already active

--- a/lua/entities/gmod_wire_cameracontroller.lua
+++ b/lua/entities/gmod_wire_cameracontroller.lua
@@ -574,7 +574,7 @@ function ENT:UpdateOutputs()
 		local curang = ang
 		
 		local offset = self.AngOffset or nil
-		curpos, curang = doRotate(curpos,curang,ply,parent,self.AutoMove,self.LocalMove,self.Distance,offset)
+		curpos, curang = doRotate(curpos,curang,ply,parent,self.AutoMove,self.LocalMove,self.Distance)
 
 		-- AutoUnclip
 		if self.AutoUnclip then

--- a/lua/entities/gmod_wire_cameracontroller.lua
+++ b/lua/entities/gmod_wire_cameracontroller.lua
@@ -44,7 +44,7 @@ local function getAngOffset(ply, LocalMove)
 	if LocalMove then
 		offset = -coffset	--chairs are always oriented 90 degrees yaw from forward, subtract 90 to get dynamic forward
 	else
-		local veh = LocalPlayer():GetVehicle()
+		local veh = ply:GetVehicle()
 		if IsValid(veh) then
 			local ang = veh:GetAngles()
 			local up = veh:GetUp()
@@ -753,13 +753,7 @@ function ENT:EnableCam( ply )
 
 		self:ColorByLinkStatus(self.LINK_STATUS_ACTIVE)
 
-		local veh = ply:GetVehicle()
-		if IsValid(veh) then
-			local ang = veh:GetAngles()
-			self.CamAngOffset = Angle(ang.p,ang.y,0)
-		else
-			self.CamAngOffset = Angle(0,0,0)
-		end
+		self.CamAngOffset = getAngOffset(ply, self.LocalMove)
 
 		self:SyncSettings( ply )
 	else -- No player specified, activate cam for everyone not already active

--- a/lua/entities/gmod_wire_cameracontroller.lua
+++ b/lua/entities/gmod_wire_cameracontroller.lua
@@ -338,9 +338,16 @@ if CLIENT then
 				zoomdistance = 0
 			end
 
-			local veh = LocalPlayer():GetVehicle()
-			if IsValid(veh) then
-				angoffset = veh:GetAngles()
+			if AutoMove then  --if using Clientside movement, add an offset to the camera
+				if LocalMove then
+					angoffset = Angle(0,-90,0)	--chairs are always oriented 90 degrees yaw from forward, subtract 90 to get dynamic forward
+				else
+					local veh = LocalPlayer():GetVehicle()
+					if IsValid(veh) then
+						local ang = veh:GetAngles()
+						angoffset = Angle(-ang.roll, ang.yaw, 0)	--add the chair yaw ang to get static forward
+					end
+				end
 			end
 		else
 			WaitingForID = nil


### PR DESCRIPTION
Something that's bothered me for years about cam controllers is that using client side movement automatically resets your view to (0, 90, 0) no matter where the chair is pointed, since it uses localeyeangles and chairs are oriented sideways for some unfathomable reason. That means every time you get into a vehicle you have to move your mouse back to where you should be pointed.

I finally decided to make a quick fix for this, which points your camera back in the direction of your chair by adding a constant offset angle to your localeyeangles depending on where the chair is pointed when you get back in. So far it has worked pretty well for me, tested with/without relative motion on, but I'm also pretty certain that it's going to cause some bug or another that I haven't caught yet.

Give this fix a shot and tell me what you think