### PR TITLE
E2 discard (`_`) parameters

### DIFF
--- a/data/expression2/tests/parsing.txt
+++ b/data/expression2/tests/parsing.txt
@@ -65,6 +65,17 @@ do { continue } while (A)
 try {} catch(Err) {}
 
 event tick() {}
+event chat(_:entity, _:string, _) {}
+
+for (_ = 1, 5) {}
+foreach (K:number, _:entity = table()) {}
+foreach (_, _:entity = table()) {}
+
+function unimplemented(_) {}
+unimplemented(5)
+
+try {} catch(_) {}
+
 
 A++
 A--

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -982,9 +982,12 @@ function Compiler:InstrFUNCTION(args)
 
 	local VariadicType
 	for _, D in pairs(Args) do
-		local Name, Type, Variadic = D[1], wire_expression_types[D[2]][1], D[3]
+		local Name, Type, Variadic, Discard = D[1], wire_expression_types[D[2]][1], D[3], D[4]
 		VariadicType = Variadic and Type
-		self:SetLocalVariableType(Name, Type, args)
+
+		if not Discard then
+			self:SetLocalVariableType(Name, Type, args)
+		end
 	end
 
 	if VariadicType then
@@ -1343,7 +1346,9 @@ function Compiler:InstrEVENT(args)
 	self:InitScope()
 	self:PushScope()
 		for k, typeid in ipairs(event.args) do
-			self:SetLocalVariableType(hargs[k][1], typeid, args)
+			if not hargs[k][4] --[[ ensure it isn't a discard parameter ]] then
+				self:SetLocalVariableType(hargs[k][1], typeid, args)
+			end
 		end
 
 		local block = self:EvaluateStatement(args, 3)

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -157,16 +157,18 @@ function Compiler:LoadScopes(Scopes)
 	self.Scope = Scopes[3]
 end
 
+-- Should not be used with discard (_) variables
 function Compiler:SetLocalVariableType(name, type, instance, binding)
 	local var = self.Scope[name]
 	if var and var.type ~= type then
 		self:Error("Variable (" .. E2Lib.limitString(name, 10) .. ") of type [" .. tps_pretty({ var.type }) .. "] cannot be assigned value of type [" .. tps_pretty({ type }) .. "]", instance)
 	end
 
-	self.Scope[name] = { type = type, var_tok = name ~= "_" and instance, initialized = true, binding = binding }
+	self.Scope[name] = { type = type, var_tok = instance, initialized = true, binding = binding }
 	return self.ScopeID
 end
 
+-- Should not be used with discard (_) variables
 ---@param initialized boolean
 function Compiler:SetGlobalVariableType(name, type, instance, initialized)
 	for i = self.ScopeID, 0, -1 do

--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -893,6 +893,8 @@ function Parser:FunctionArgs(Temp, Args)
 
 			if self:AcceptRoamingToken(TokenVariant.Ident) or self:AcceptRoamingToken(TokenVariant.LowerIdent) then
 				self:FunctionArg(Temp, Args)
+			elseif self:AcceptRoamingToken(TokenVariant.Discard) then
+				self:FunctionArg(Temp, Args, true)
 			elseif self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.LSquare) then
 				self:FunctionArgList(Temp, Args)
 			end
@@ -908,7 +910,7 @@ function Parser:FunctionArgs(Temp, Args)
 	end
 end
 
-function Parser:FunctionArg(Temp, Args)
+function Parser:FunctionArg(Temp, Args, Discard)
 	local Type = "normal"
 
 	local Name = self:GetTokenData()
@@ -937,9 +939,8 @@ function Parser:FunctionArg(Temp, Args)
 		self:Error("Invalid type specified")
 	end
 
-
-	Temp[Name] = true
-	Args[#Args + 1] = { Name, Type, false }
+	Temp[Name] = not Discard
+	Args[#Args + 1] = { Name, Type, false, Discard }
 end
 
 function Parser:FunctionArgList(Temp, Args)
@@ -959,6 +960,9 @@ function Parser:FunctionArgList(Temp, Args)
 
 				Temp[Name] = true
 				Vars[#Vars + 1] = Name
+
+			elseif self:AcceptRoamingToken(TokenVariant.Discard) then
+				Vars[#Vars + 1] = "_"
 			elseif self:AcceptRoamingToken(TokenVariant.Grammar, Grammar.RSquare) then
 				break
 
@@ -995,7 +999,7 @@ function Parser:FunctionArgList(Temp, Args)
 		end
 
 		for I = 1, #Vars do
-			Args[#Args + 1] = { Vars[I], Type, false }
+			Args[#Args + 1] = { Vars[I], Type, false, Vars[I] == "_" }
 		end
 
 	else
@@ -1679,6 +1683,10 @@ function Parser:ExprError()
 			self:Error("Else-if keyword (elseif) must be part of an if-statement")
 		elseif self:AcceptRoamingToken(TokenVariant.Keyword, Keyword.Else) then
 			self:Error("Else keyword (else) must be part of an if-statement")
+
+
+		elseif self:AcceptRoamingToken(TokenVariant.Discard) then
+			self:Error("Discard (_) can only be used to discard function parameter")
 
 		else
 			self:Error("Unexpected token found (" .. self.readtoken:display() .. ")")

--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -320,7 +320,7 @@ function Parser:Stmt3()
 			self:Error("Left parenthesis (() must appear before condition")
 		end
 
-		if not self:AcceptRoamingToken(TokenVariant.Ident) then
+		if not self:AcceptRoamingToken(TokenVariant.Ident) and not self:AcceptRoamingToken(TokenVariant.Discard) then
 			self:Error("Variable expected for the numeric index")
 		end
 
@@ -365,7 +365,7 @@ function Parser:Stmt4()
 			self:Error("Left parenthesis missing (() after foreach statement")
 		end
 
-		if not self:AcceptRoamingToken(TokenVariant.Ident) then
+		if not self:AcceptRoamingToken(TokenVariant.Ident) and not self:AcceptRoamingToken(TokenVariant.Discard) then
 			self:Error("Variable expected to hold the key")
 		end
 		local keyvar = self:GetTokenData()
@@ -391,7 +391,7 @@ function Parser:Stmt4()
 			self:Error("Comma (,) expected after key variable")
 		end
 
-		if not self:AcceptRoamingToken(TokenVariant.Ident) then
+		if not self:AcceptRoamingToken(TokenVariant.Ident) and not self:AcceptRoamingToken(TokenVariant.Discard) then
 			self:Error("Variable expected to hold the value")
 		end
 		local valvar = self:GetTokenData()
@@ -776,7 +776,7 @@ function Parser:Stmt12()
 				self:Error("Left parenthesis (() expected after catch keyword")
 			end
 
-			if not self:AcceptRoamingToken(TokenVariant.Ident) then
+			if not self:AcceptRoamingToken(TokenVariant.Ident) and not self:AcceptRoamingToken(TokenVariant.Discard) then
 				self:Error("Variable expected after left parenthesis (() in catch statement")
 			end
 			local var_name = self:GetTokenData()

--- a/lua/entities/gmod_wire_expression2/base/tokenizer.lua
+++ b/lua/entities/gmod_wire_expression2/base/tokenizer.lua
@@ -43,8 +43,9 @@ local TokenVariant = {
 	LowerIdent = 11, -- function_name
 
 	Ident = 12, -- VariableName
+	Discard = 13, -- _
 
-	Constant = 13, -- _CONST
+	Constant = 14, -- _CONST
 }
 
 Tokenizer.Variant = TokenVariant
@@ -223,6 +224,13 @@ function Tokenizer:Next()
 	match = self:ConsumePattern("^[A-Z][a-zA-Z0-9_]*")
 	if match then
 		return Token.new(TokenVariant.Ident, match)
+	end
+
+	if self:ConsumePattern("^_") then
+		-- A discard is used to signal intent that something is intentionally not used.
+		-- This is mainly to avoid warnings for unused variables from events or functions.
+		-- You are not allowed to actually use the discard anywhere but in a signature, since you can have multiple in the signature.
+		return Token.new(TokenVariant.Discard, "_")
 	end
 
 	match = self:ConsumePattern("^_[A-Z0-9_]*")

--- a/lua/wire/client/text_editor/modes/e2.lua
+++ b/lua/wire/client/text_editor/modes/e2.lua
@@ -583,7 +583,7 @@ function EDITOR:SyntaxColorLine(row)
 				self.tokendata = spaces
 			end
 
-		elseif self:NextPattern("^[A-Z][a-zA-Z0-9_]*") then
+		elseif AcceptIdent(self) then
 			if self.tokendata == "This" then
 				tokenname = "typename"
 			else

--- a/lua/wire/client/text_editor/modes/e2.lua
+++ b/lua/wire/client/text_editor/modes/e2.lua
@@ -96,6 +96,10 @@ local function addToken(tokenname, tokendata)
 	end
 end
 
+local function AcceptIdent(self)
+	return self:NextPattern("^[A-Z][a-zA-Z0-9_]*") or self:NextPattern("^_")
+end
+
 function EDITOR:CommentSelection(removecomment)
 	local sel_start, sel_caret = self:MakeSelection( self:Selection() )
 	local mode = self:GetParent().BlockCommentStyleConVar:GetInt()
@@ -352,7 +356,7 @@ function EDITOR:SyntaxColorLine(row)
 				local dots = self:SkipPattern( "%.%.%." )
 				if dots then addToken( "operator", dots ) end
 
-				local invalidInput = self:SkipPattern( "[^A-Z:%[]*" )
+				local invalidInput = self:SkipPattern( "[^A-Z:%[_]*" )
 				if invalidInput then addToken( "notfound", invalidInput ) end
 
 				if self:NextPattern( "%[" ) then -- Found a [
@@ -360,7 +364,7 @@ function EDITOR:SyntaxColorLine(row)
 					addToken( "operator", self.tokendata )
 					self.tokendata = ""
 
-					while self:NextPattern( "[A-Z][a-zA-Z0-9_]*" ) do -- If we found a variable
+					while AcceptIdent(self) do -- If we found a variable
 						addToken( "variable", self.tokendata )
 						self.tokendata = ""
 
@@ -372,7 +376,7 @@ function EDITOR:SyntaxColorLine(row)
 						addToken( "operator", "]" )
 						self.tokendata = ""
 					end
-				elseif self:NextPattern( "[A-Z][a-zA-Z0-9_]*" ) then -- If we found a variable
+				elseif AcceptIdent(self) then -- If we found a variable
 					-- Color the variable
 					addToken( "variable", self.tokendata )
 					self.tokendata = ""
@@ -434,7 +438,7 @@ function EDITOR:SyntaxColorLine(row)
 				local dots = self:SkipPattern( "%.%.%." )
 				if dots then addToken( "operator", dots ) end
 
-				local invalidInput = self:SkipPattern( "[^A-Z:%[]*" )
+				local invalidInput = self:SkipPattern( "[^A-Z:%[_]*" )
 				if invalidInput then addToken( "notfound", invalidInput ) end
 
 				if self:NextPattern( "%[" ) then -- Found a [
@@ -442,7 +446,7 @@ function EDITOR:SyntaxColorLine(row)
 					addToken( "operator", self.tokendata )
 					self.tokendata = ""
 
-					while self:NextPattern( "[A-Z][a-zA-Z0-9_]*" ) do -- If we found a variable
+					while AcceptIdent(self) do -- If we found a variable
 						addToken( "variable", self.tokendata )
 						self.tokendata = ""
 
@@ -454,7 +458,7 @@ function EDITOR:SyntaxColorLine(row)
 						addToken( "operator", "]" )
 						self.tokendata = ""
 					end
-				elseif self:NextPattern( "[A-Z][a-zA-Z0-9_]*" ) then -- If we found a variable
+				elseif AcceptIdent(self) then -- If we found a variable
 					-- Color the variable
 					addToken( "variable", self.tokendata )
 					self.tokendata = ""


### PR DESCRIPTION
This PR adds discard (`_`) parameters as identifiers that signal intentionally ignoring a value. This solves the issue of getting warnings from not using certain params from events, and the bandaid fix of ignoring unused for/foreach values.

```golo
event chat(E:entity, _:string, _) {
    print(E)
}

function test(_:string, [_ _ _ _ _]:number, S:string) {
    print("Unused", S)
}

function t(_) {}

test("", 2, 3, 4, 5, 2, "Hello")

for (_ = 1, 5) {}
foreach (_:number, _:number = table()) {}
try {} catch (_) {}
```

This does not support using discard as a variable, so you can't do something like
```golo
local _ = 55
```

Maybe that could be implemented in the future, but you could easily just comment that out. This was a necessary fix for event parameters.

Right now this doesn't affect anything at runtime, so using this will make no difference as just ignoring the variable. In the future, this could be used for optimizations and to better signal intent. [This feature was heavily inspired by Rust's underscore](https://stackoverflow.com/questions/48361537/why-do-underscore-prefixed-variables-exist)