### PR TITLE
Constraint Core code facelift

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
@@ -45,7 +45,7 @@ end
 
 local function setupCounts(holder)
 	holder.allConstraints = holder.allConstraints or {}
-	holder.constraintCounts = holder.cosntraintCounts or {}
+	holder.constraintCounts = holder.constraintCounts or {}
 	holder.entityConstraints = holder.entityConstraints or {}
 	holder.totalConstraints = holder.totalConstraints or 0
 end

--- a/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
@@ -1,13 +1,39 @@
 E2Lib.RegisterExtension("constraintcore", false, "Allows the creation and manipulation of constraints between entities.")
 
+local function clearCreatedConstraints(self)
+	for _, constraint in pairs( self.data.allConstraints ) do
+		if constraint:IsValid() then
+			constraint:Remove()
+		end
+	end
+end
+
 registerCallback("construct", function(self)
+	self.data.allConstraints = {}
+	self.data.constraintCounts = {}
+	self.data.entityConstraints = {}
+
+	self.data.totalConstraints = 0
 	self.data.constraintUndos = true
+end)
+
+
+registerCallback("destruct", function(self)
+	clearCreatedConstraints(self)
 end)
 
 __e2setcost(1)
 e2function void enableConstraintUndo(state)
 	self.data.constraintUndos = state ~= 0
 end
+
+local Vector = Vector
+local IsValid = IsValid
+local math_min = math.min
+local math_max = math.max
+local table_insert = table.insert
+
+local emptyVector = Vector()
 
 local function checkEnts(self, ent1, ent2)
 	if not IsValid(ent1) and not ent1:IsWorld() then return self:throw("Invalid entity!", false) end
@@ -20,79 +46,260 @@ local function checkEnts(self, ent1, ent2)
 	if ent1:IsPlayer() or ent2:IsPlayer() then return self:throw("Cannot constrain players!", false) end
 	return true
 end
-local function addundo(self, prop, message)
-	self.player:AddCleanup( "constraints", prop )
-	if self.data.constraintUndos then
-		undo.Create("e2_"..message)
-			undo.AddEntity( prop )
-			undo.SetPlayer( self.player )
-		undo.Finish()
-	end
-end
-local function caps(text)
-	local capstext = text:sub(1,1):upper() .. text:sub(2):lower()
-	if capstext == "Nocollide" then return "NoCollide" end
-	if capstext == "Advballsocket" then return "AdvBallsocket" end
-	return capstext
+
+local cvFlags = {FCVAR_ARCHIVE}
+local maxWeld = CreateConVar( "wire_expression2_max_constraints_weld", "250", cvFlags )
+local maxRope = CreateConVar( "wire_expression2_max_constraints_rope", "250", cvFlags )
+local maxAxis = CreateConVar( "wire_expression2_max_constraints_axis", "250", cvFlags )
+local maxTotal = CreateConVar( "wire_expression2_max_constraints_total", "250", cvFlags )
+local maxSlider = CreateConVar( "wire_expression2_max_constraints_slider", "250", cvFlags )
+local maxElastic = CreateConVar( "wire_expression2_max_constraints_elastic", "250", cvFlags )
+local maxNocollide = CreateConVar( "wire_expression2_max_constraints_nocollide", "250", cvFlags )
+local maxHydraulic = CreateConVar( "wire_expression2_max_constraints_hydraulic", "250", cvFlags )
+local maxPerEntity = CreateConVar( "wire_expression2_max_consttraints_per_entity", "150", cvFlags )
+local maxBallsocket = CreateConVar( "wire_expression2_max_constraints_ballsocket", "250", cvFlags )
+local maxAdvBallsocket = CreateConVar( "wire_expression2_max_constraints_ballsocket_adv", "250", cvFlags )
+
+-- At what edict count will E2s be prevented from creating new rope-like constraints (elastic, rope, slider, hydraulic)
+local edictCutOff = CreateConVar( "wire_expression2_constraints_edict_cutoff", "7500", cvFlags )
+
+local countLookup = {
+	Weld = maxWeld,
+	Rope = maxRope,
+	Axis = maxAxis,
+	Slider = maxSlider,
+	Elastic = maxElastic,
+	NoCollide = maxNocollide,
+	Hydraulic = maxHydraulic,
+	Ballsocket = maxBallsocket,
+	AdvBallsocket = maxAdvBallsocket,
+}
+
+local function verifyConstraint(self, cons)
+	if cons ~= false then return true end
+	self:throw("Constraint creation failed!", false)
 end
 
-// All vectors are LOCAL positions relative to their corresponding entities
+local function setupEntConstraints(ent)
+	local entData = ent.E2Data
+
+	if not entData then
+		local Ropes = {}
+		ent.E2Data = {Ropes = Ropes}
+
+		return Ropes
+	end
+
+	local entRopes = entData.Ropes
+	if entRopes then return entRopes end
+
+	local Ropes = {}
+	entData.Ropes = Ropes
+
+	return Ropes
+end
+
+local function checkCount(self, consType, ent1, ent2)
+	local data = self.data
+	local typeCounts = data.constraintCounts
+
+	-- Total
+	local totalCount = data.totalConstraints
+	local totalLimit = maxTotal:GetInt()
+	if totalCount >= totalLimit then
+		return self:throw( "Total constraint limit reached!", false )
+	end
+
+	-- Type
+	local typeCount = typeCounts[consType] or 0
+	local typeLimit = countLookup[consType]:GetInt()
+	if typeCount >= typeLimit then
+		return self:throw( consType .. " limit reached!", false )
+	end
+
+	-- Ents
+	local entityLimit = maxPerEntity:GetInt()
+	local entCounts = data.entityConstraints
+
+	local ent1Count = entCounts[ent1] or 0
+	local ent2Count = entCounts[ent2] or 0
+	if math_max( ent1Count, ent2Count ) >= entityLimit then
+		return self:throw( "Entity limit reached!", false )
+	end
+
+	return true
+end
+
+local function checkEdicts(self)
+	local maxEdicts = edictCutOff:GetInt()
+	if ents.GetEdictCount() >= maxEdicts then
+		return self:throw( "Global edict limit reached!", false )
+	end
+
+	return true
+end
+
+local function addUndo(self, consType, cons, rope)
+	local data = self.data
+	local ply = self.player
+	local cleanupType = rope and "ropeconstraints" or "constraints"
+
+	ply:AddCleanup( cleanupType, cons )
+	if rope then ply:AddCleanup( cleanupType, rope ) end
+
+	if not data.constraintUndos then return end
+
+	undo.Create( "e2_" .. consType )
+		undo.SetPlayer( ply )
+		undo.AddEntity( cons )
+		if rope then undo.AddEntity( rope ) end
+	undo.Finish()
+end
+
+local function increment(self, consType, ent1, ent2, cons)
+	local data = self.data
+	local entCounts = data.entityConstraints
+	local typeCounts = data.constraintCounts
+	local totalCount = data.totalConstraints
+
+	-- Total
+	data.totalConstraints = totalCount + 1
+
+	-- Type
+	typeCounts[consType] = ( typeCounts[consType] or 0 ) + 1
+
+	-- Ents
+	entCounts[ent1] = ( entCounts[ent1] or 0 ) + 1
+	entCounts[ent2] = ( entCounts[ent2] or 0 ) + 1
+
+	-- Decrement relevant counts
+	cons:CallOnRemove( "wire_expression2_constraints_" .. self.entity:EntIndex(), function()
+		if not IsValid( self ) then return end
+
+		-- Total
+		data.totalConstraints = math_max( 0, data.totalConstraints - 1 )
+
+		-- Type
+		typeCounts[consType] = math_max( 0, typeCounts[consType] - 1 )
+
+		-- Ents
+		entCounts[cons.Ent1] = math_max( 0, entCounts[cons.Ent1] - 1 )
+		entCounts[cons.Ent2] = math_max( 0, entCounts[cons.Ent2] - 1 )
+	end )
+
+end
+
+local function postCreate(self, consType, ent1, ent2, cons, rope)
+	addUndo( self, consType, cons, rope )
+	increment( self, consType, ent1, ent2, cons )
+	table_insert( self.data.allConstraints, cons )
+end
+
+local function caps(text)
+	if text == "nocollide" then return "NoCollide" end
+	if text == "advballsocket" then return "AdvBallsocket" end
+	return text:sub(1,1):upper() .. text:sub(2):lower()
+end
+
+-- All vectors are LOCAL positions relative to their corresponding entities
 __e2setcost(30)
+
+
+-- == Axis ==
 
 --- Creates an axis between <ent1> and <ent2> at vector positions local to each ent.
 e2function void axis(entity ent1, vector v1, entity ent2, vector v2)
 	if not checkEnts(self, ent1, ent2) then return end
+	if not checkCount(self, "Axis") then return end
 	local vec1, vec2 = Vector(v1[1], v1[2], v1[3]), Vector(v2[1], v2[2], v2[3])
-	addundo(self, constraint.Axis(ent1, ent2, 0, 0, vec1, vec2, 0, 0, 0, 0), "axis")
+
+	local cons = constraint.Axis(ent1, ent2, 0, 0, vec1, vec2, 0, 0, 0, 0)
+	postCreate(self, "Axis", ent1, ent2, cons)
 end
 
 --- Creates an axis between <ent1> and <ent2> at vector positions local to each ent, with <friction> friction.
 e2function void axis(entity ent1, vector v1, entity ent2, vector v2, friction)
 	if not checkEnts(self, ent1, ent2) then return end
+	if not checkCount(self, "Axis") then return end
 	local vec1, vec2 = Vector(v1[1], v1[2], v1[3]), Vector(v2[1], v2[2], v2[3])
-	addundo(self, constraint.Axis(ent1, ent2, 0, 0, vec1, vec2, 0, 0, friction, 0), "axis")
+
+	local cons = constraint.Axis(ent1, ent2, 0, 0, vec1, vec2, 0, 0, friction, 0)
+	postCreate(self, "Axis", ent1, ent2, cons)
 end
 
 --- Creates an axis between <ent1> and <ent2> at vector positions local to each ent, with <friction> friction and <localaxis> rotation axis.
 e2function void axis(entity ent1, vector v1, entity ent2, vector v2, friction, vector localaxis)
 	if not checkEnts(self, ent1, ent2) then return end
+	if not checkCount(self, "Axis") then return end
 	local vec1, vec2, laxis = Vector(v1[1], v1[2], v1[3]), Vector(v2[1], v2[2], v2[3]), Vector(localaxis[1], localaxis[2], localaxis[3])
-	addundo(self, constraint.Axis(ent1, ent2, 0, 0, vec1, vec2, 0, 0, friction, 0, laxis), "axis")
+
+	local cons = constraint.Axis(ent1, ent2, 0, 0, vec1, vec2, 0, 0, friction, 0, laxis)
+	if not verifyConstraint(self, cons) then return end
+
+	postCreate(self, "Axis", ent1, ent2, cons)
 end
+
+
+-- == Ball Socket ==
 
 --- Creates a ballsocket between <ent1> and <ent2> at <v>, which is local to <ent1>
 e2function void ballsocket(entity ent1, vector v, entity ent2)
 	if not checkEnts(self, ent1, ent2) then return end
+	if not checkCount(self, "Ballsocket") then return end
 	local vec = Vector(v[1], v[2], v[3])
-	addundo(self, constraint.Ballsocket(ent1, ent2, 0, 0, vec, 0, 0, 0), "ballsocket")
+
+	local cons = constraint.Ballsocket(ent1, ent2, 0, 0, vec, 0, 0, 0)
+	if not verifyConstraint(self, cons) then return end
+
+	postCreate(self, "Ballsocket", ent1, ent2, cons)
 end
 
 --- Creates a ballsocket between <ent1> and <ent2> at <v>, which is local to <ent1>, with friction <friction>
 e2function void ballsocket(entity ent1, vector v, entity ent2, friction)
 	if not checkEnts(self, ent1, ent2) then return end
+	if not checkCount(self, "AdvBallsocket") then return end
 	local vec = Vector(v[1], v[2], v[3])
-	addundo(self, constraint.AdvBallsocket(ent1, ent2, 0, 0, vec, Vector(), 0, 0, -180, -180, -180, 180, 180, 180, friction, friction, friction, 0, 0), "ballsocket")
+
+	local cons = constraint.AdvBallsocket(ent1, ent2, 0, 0, vec, emptyVector, 0, 0, -180, -180, -180, 180, 180, 180, friction, friction, friction, 0, 0)
+	if not verifyConstraint(self, cons) then return end
+
+	postCreate(self, "AdvBallsocket", ent1, ent2, cons)
 end
 
 --- Creates an adv ballsocket between <ent1> and <ent2> at <v>, which is local to <ent1>, with many settings
 e2function void ballsocket(entity ent1, vector v, entity ent2, vector mins, vector maxs, vector frictions)
 	if not checkEnts(self, ent1, ent2) then return end
+	if not checkCount(self, "AdvBallsocket") then return end
 	local vec = Vector(v[1], v[2], v[3])
-	addundo(self, constraint.AdvBallsocket(ent1, ent2, 0, 0, vec, Vector(), 0, 0, mins[1], mins[2], mins[3], maxs[1], maxs[2], maxs[3], frictions[1], frictions[2], frictions[3], 0, 0), "ballsocket")
+
+	local cons = constraint.AdvBallsocket(ent1, ent2, 0, 0, vec, emptyVector, 0, 0, mins[1], mins[2], mins[3], maxs[1], maxs[2], maxs[3], frictions[1], frictions[2], frictions[3], 0, 0)
+	if not verifyConstraint(self, cons) then return end
+
+	postCreate(self, "AdvBallsocket", ent1, ent2, cons)
 end
 
 --- Creates an adv ballsocket between <ent1> and <ent2> at <v>, which is local to <ent1>, with many settings
 e2function void ballsocket(entity ent1, vector v, entity ent2, vector mins, vector maxs, vector frictions, rotateonly)
 	if not checkEnts(self, ent1, ent2) then return end
+	if not checkCount(self, "AdvBallsocket") then return end
 	local vec = Vector(v[1], v[2], v[3])
-	addundo(self, constraint.AdvBallsocket(ent1, ent2, 0, 0, vec, Vector(), 0, 0, mins[1], mins[2], mins[3], maxs[1], maxs[2], maxs[3], frictions[1], frictions[2], frictions[3], rotateonly, 0), "ballsocket")
+
+	local cons = constraint.AdvBallsocket(ent1, ent2, 0, 0, vec, emptyVector, 0, 0, mins[1], mins[2], mins[3], maxs[1], maxs[2], maxs[3], frictions[1], frictions[2], frictions[3], rotateonly, 0)
+	if not verifyConstraint(self, cons) then return end
+
+	postCreate(self, "AdvBallsocket", ent1, ent2, cons)
 end
 
 --- Creates an angular weld (angles are fixed, position isn't) between <ent1> and <ent2> at <v>, which is local to <ent1>
 e2function void weldAng(entity ent1, vector v, entity ent2)
 	if not checkEnts(self, ent1, ent2) then return end
+	if not checkCount(self, "AdvBallsocket") then return end
 	local vec = Vector(v[1], v[2], v[3])
-	addundo(self, constraint.AdvBallsocket(ent1, ent2, 0, 0, vec, Vector(), 0, 0, 0, -0, 0, 0, 0, 0, 0, 0, 0, 1, 0), "ballsocket")
+
+	local cons = constraint.AdvBallsocket(ent1, ent2, 0, 0, vec, emptyVector, 0, 0, 0, -0, 0, 0, 0, 0, 0, 0, 0, 1, 0)
+	if not verifyConstraint(self, cons) then return end
+
+	postCreate(self, "AdvBallsocket", ent1, ent2, cons)
 end
 
 
@@ -103,7 +310,7 @@ local function CalcElasticConsts(Phys1, Phys2, Ent1, Ent2)
 	elseif Ent2:IsWorld() then
 		minMass = Phys1:GetMass()
 	else
-		minMass = math.min( Phys1:GetMass(), Phys2:GetMass() )
+		minMass = math_min( Phys1:GetMass(), Phys2:GetMass() )
 	end
 
 	local const = minMass * 100
@@ -112,119 +319,153 @@ local function CalcElasticConsts(Phys1, Phys2, Ent1, Ent2)
 	return const, damp
 end
 
-// Note: Winch is just a rename of Hydraulic with the last parameter True.
+
+--  == Hydraulic ==
+
+-- Note: Winch is just a rename of Hydraulic with the last parameter True.
 --- Makes a winch constraint (stored at index <index>) between <ent1> and <ent2>, at vectors local to their respective ents, with <width> width.
 e2function void winch(index, entity ent1, vector v1, entity ent2, vector v2, width)
-	if not checkEnts(self, ent1, ent2) then return end
-	if !ent1.data then ent1.data = {} end
-	if !ent1.data.Ropes then ent1.data.Ropes = {} end
-	local vec1, vec2 = Vector(v1[1],v1[2],v1[3]), Vector(v2[1],v2[2],v2[3])
+	if not checkEnts( self, ent1, ent2 ) then return end
+	if not checkCount( self, "Hydraulic" ) then return end
+	if not checkEdicts( self ) then return end
+	local constraints = setupEntConstraints( ent1 )
+
+	local vec1, vec2 = Vector( v1[1], v1[2], v1[3] ), Vector( v2[1], v2[2], v2[3] )
 	if width < 0 or width > 50 then width = 1 end
 
-	if IsValid(ent1.data.Ropes[index]) then
-		ent1.data.Ropes[index]:Remove()
-	end
+	local existing = constraints[index]
+	if IsValid( existing ) then existing:Remove() end
 
 	local constant, dampen = CalcElasticConsts( ent1:GetPhysicsObject(), ent2:GetPhysicsObject(), ent1, ent2 )
-	ent1.data.Ropes[index] = constraint.Elastic( ent1, ent2, 0, 0, vec1, vec2, constant, dampen, 0, "cable/cable2", width, true )
-	addundo(self, ent1.data.Ropes[index], "winch")
+	local cons, rope = constraint.Elastic( ent1, ent2, 0, 0, vec1, vec2, constant, dampen, 0, "cable/cable2", width, true )
+	if not verifyConstraint( self, cons ) then return end
+
+	ropes[index] = cons
+	postCreate( self, "Hydraulic", ent1, ent2, cons, rope )
 end
 
 --- Makes a hydraulic constraint (stored at index <index>) between <ent1> and <ent2>, at vectors local to their respective ents, with <width> width.
 e2function void hydraulic(index, entity ent1, vector v1, entity ent2, vector v2, width)
-	if not checkEnts(self, ent1, ent2) then return end
-	if !ent1.data then ent1.data = {} end
-	if !ent1.data.Ropes then ent1.data.Ropes = {} end
-	local vec1, vec2 = Vector(v1[1],v1[2],v1[3]), Vector(v2[1],v2[2],v2[3])
+	if not checkEnts( self, ent1, ent2 ) then return end
+	if not checkCount( self, "Hydraulic" ) then return end
+	if not checkEdicts( self ) then return end
+	local ropes = setupRopes( ent1 )
+
+	local vec1, vec2 = Vector( v1[1], v1[2], v1[3] ), Vector( v2[1], v2[2], v2[3] )
 	if width < 0 or width > 50 then width = 1 end
 
-	if IsValid(ent1.data.Ropes[index]) then
-		ent1.data.Ropes[index]:Remove()
-	end
+	local existing = ropes[index]
+	if IsValid( existing ) then existing:Remove() end
 
 	local constant, dampen = CalcElasticConsts( ent1:GetPhysicsObject(), ent2:GetPhysicsObject(), ent1, ent2 )
-	ent1.data.Ropes[index] = constraint.Elastic( ent1, ent2, 0, 0, vec1, vec2, constant, dampen, 0, "cable/cable2", width, false )
-	addundo(self, ent1.data.Ropes[index], "hydraulic")
+	local cons, rope = constraint.Elastic( ent1, ent2, 0, 0, vec1, vec2, constant, dampen, 0, "cable/cable2", width, false )
+	if not verifyConstraint( self, cons ) then return end
+
+	ropes[index] = cons
+	postCreate( self, "Hydraulic", ent1, ent2, cons, rope )
 end
 
 --- Makes a hydraulic constraint (stored at index <index>) between <ent1> and <ent2>, at vectors local to their respective ents, constant and damping, with <width> width, <mat> material, and <stretch> stretch only option.
 e2function void hydraulic(index, entity ent1, vector v1, entity ent2, vector v2, constant, damping, string mat, width, stretch)
-	if not checkEnts(self, ent1, ent2) then return end
-	if not ent1.data then ent1.data = {} end
-	if not ent1.data.Ropes then ent1.data.Ropes = {} end
-	local vec1, vec2 = Vector(v1[1],v1[2],v1[3]), Vector(v2[1],v2[2],v2[3])
+	if not checkEnts( self, ent1, ent2 ) then return end
+	if not checkCount( self, "Hydraulic" ) then return end
+	if not checkEdicts( self ) then return end
+	local ropes = setupRopes( ent1 )
+
+	local vec1, vec2 = Vector( v1[1], v1[2], v1[3] ), Vector( v2[1], v2[2], v2[3] )
 	if width < 0 or width > 50 then width = 1 end
 
-	if IsValid(ent1.data.Ropes[index]) then
-		ent1.data.Ropes[index]:Remove()
-	end
+	local existing = ropes[index]
+	if IsValid( existing ) then existing:Remove() end
 
-	ent1.data.Ropes[index] = constraint.Elastic( ent1, ent2, 0, 0, vec1, vec2, constant, damping, 0, mat, width, tobool(stretch) )
-	addundo(self, ent1.data.Ropes[index], "hydraulic")
+	local cons, rope = constraint.Elastic( ent1, ent2, 0, 0, vec1, vec2, constant, damping, 0, mat, width, tobool( stretch ) )
+	if not verifyConstraint( self, cons ) then return end
+
+	ropes[index] = cons
+	postCreate( self, "Hydraulic", ent1, ent2, cons, rope )
 end
 
 --- Makes a hydraulic constraint (stored at index <index>) between <ent1> and <ent2>, at vectors local to their respective ents, constant, damping and relative damping, with <width> width, <mat> material, and <stretch> stretch only option.
 e2function void hydraulic(index, entity ent1, vector v1, entity ent2, vector v2, constant, damping, rdamping, string mat, width, stretch)
-	if not checkEnts(self, ent1, ent2) then return end
-	if not ent1.data then ent1.data = {} end
-	if not ent1.data.Ropes then ent1.data.Ropes = {} end
-	local vec1, vec2 = Vector(v1[1],v1[2],v1[3]), Vector(v2[1],v2[2],v2[3])
+	if not checkEnts( self, ent1, ent2 ) then return end
+	if not checkCount( self, "Hydraulic" ) then return end
+	if not checkEdicts( self ) then return end
+	local ropes = setupRopes( ent1 )
+
+	local vec1, vec2 = Vector( v1[1], v1[2], v1[3] ), Vector( v2[1], v2[2], v2[3] )
 	if width < 0 or width > 50 then width = 1 end
 
-	if IsValid(ent1.data.Ropes[index]) then
-		ent1.data.Ropes[index]:Remove()
-	end
+	local existing = ropes[index]
+	if IsValid( existing ) then existing:Remove() end
 
-	ent1.data.Ropes[index] = constraint.Elastic( ent1, ent2, 0, 0, vec1, vec2, constant, damping, rdamping, mat, width, tobool(stretch) )
-	addundo(self, ent1.data.Ropes[index], "hydraulic")
+	local cons, rope = constraint.Elastic( ent1, ent2, 0, 0, vec1, vec2, constant, damping, rdamping, mat, width, tobool( stretch ) )
+	if not verifyConstraint( self, cons ) then return end
+
+	ropes[index] = cons
+	postCreate( self, "Hydraulic", ent1, ent2, cons, rope )
 end
+
+
+-- == Rope ==
 
 --- Creates a rope between <ent1> and <ent2> at vector positions local to each ent.
 e2function void rope(index, entity ent1, vector v1, entity ent2, vector v2)
-	if not checkEnts(self, ent1, ent2) then return end
-	if not ent1.data then ent1.data = {} end
-	if not ent1.data.Ropes then ent1.data.Ropes = {} end
-	local vec1, vec2 = Vector(v1[1], v1[2], v1[3]), Vector(v2[1], v2[2], v2[3])
-	local length = (ent1:LocalToWorld(vec1) - ent2:LocalToWorld(vec2)):Length()
+	if not checkEnts( self, ent1, ent2 ) then return end
+	if not checkCount( self, "Rope" ) then return end
+	if not checkEdicts( self ) then return end
+	local ropes = setupRopes( ent1 )
 
-	if IsValid(ent1.data.Ropes[index]) then
-		ent1.data.Ropes[index]:Remove()
-	end
+	local vec1, vec2 = Vector( v1[1], v1[2], v1[3] ), Vector( v2[1], v2[2], v2[3] )
+	local length = ( ent1:LocalToWorld( vec1 ) - ent2:LocalToWorld( vec2 ) ):Length()
 
-	ent1.data.Ropes[index] = constraint.Rope( ent1, ent2, 0, 0, vec1, vec2, length, 0, 0, 1, "cable/rope", false )
-	addundo(self, ent1.data.Ropes[index], "rope")
+	local existing = ropes[index]
+	if IsValid( existing ) then existing:Remove() end
+
+	local cons, rope = constraint.Rope( ent1, ent2, 0, 0, vec1, vec2, length, 0, 0, 1, "cable/rope", false )
+	if not verifyConstraint( self, cons ) then return end
+
+	ropes[index] = cons
+	postCreate( self, "Rope", ent1, ent2, cons, rope )
 end
 
 --- Creates a rope between <ent1> and <ent2> at vector positions local to each ent, with <addlength> additional length, <width> width, and <mat> material.
 e2function void rope(index, entity ent1, vector v1, entity ent2, vector v2, addlength, width, string mat)
-	if not checkEnts(self, ent1, ent2) then return end
-	if not ent1.data then ent1.data = {} end
-	if not ent1.data.Ropes then ent1.data.Ropes = {} end
-	local vec1, vec2 = Vector(v1[1], v1[2], v1[3]), Vector(v2[1], v2[2], v2[3])
+	if not checkEnts( self, ent1, ent2 ) then return end
+	if not checkCount( self, "Rope" ) then return end
+	if not checkEdicts( self ) then return end
+	local ropes = setupRopes( ent1 )
+
+	local vec1, vec2 = Vector( v1[1], v1[2], v1[3] ), Vector( v2[1], v2[2], v2[3] )
 	local length = (ent1:LocalToWorld(vec1) - ent2:LocalToWorld(vec2)):Length()
 
-	if IsValid(ent1.data.Ropes[index]) then
-		ent1.data.Ropes[index]:Remove()
-	end
+	local existing = ropes[index]
+	if IsValid( existing ) then existing:Remove() end
 
-	ent1.data.Ropes[index] = constraint.Rope( ent1, ent2, 0, 0, vec1, vec2, length, addlength, 0, width, mat, false )
-	addundo(self, ent1.data.Ropes[index], "rope")
+	local cons, rope = constraint.Rope( ent1, ent2, 0, 0, vec1, vec2, length, addlength, 0, width, mat, false )
+	if not verifyConstraint( self, cons ) then return end
+
+	ropes[index] = cons
+	postCreate( self, "Rope", ent1, ent2, cons, rope )
 end
 
 --- Creates a rope between <ent1> and <ent2> at vector positions local to each ent, with <addlength> additional length, <width> width, and <mat> material.
 e2function void rope(index, entity ent1, vector v1, entity ent2, vector v2, addlength, width, string mat, rigid )
-	if not checkEnts(self, ent1, ent2) then return end
-	if not ent1.data then ent1.data = {} end
-	if not ent1.data.Ropes then ent1.data.Ropes = {} end
-	local vec1, vec2 = Vector(v1[1], v1[2], v1[3]), Vector(v2[1], v2[2], v2[3])
-	local length = (ent1:LocalToWorld(vec1) - ent2:LocalToWorld(vec2)):Length()
+	if not checkEnts( self, ent1, ent2 ) then return end
+	if not checkCount( self, "Rope" ) then return end
+	if not checkEdicts( self ) then return end
+	local ropes = setupRopes( ent1 )
 
-	if IsValid(ent1.data.Ropes[index]) then
-		ent1.data.Ropes[index]:Remove()
-	end
+	local vec1, vec2 = Vector( v1[1], v1[2], v1[3] ), Vector( v2[1], v2[2], v2[3] )
+	local length = ( ent1:LocalToWorld( vec1 ) - ent2:LocalToWorld( vec2 ) ):Length()
 
-	ent1.data.Ropes[index] = constraint.Rope( ent1, ent2, 0, 0, vec1, vec2, length, addlength, 0, width, mat, tobool(rigid) )
-	addundo(self, ent1.data.Ropes[index], "rope")
+	local existing = ropes[index]
+	if IsValid( existing ) then existing:Remove() end
+
+	local cons, rope = constraint.Rope( ent1, ent2, 0, 0, vec1, vec2, length, addlength, 0, width, mat, tobool( rigid ) )
+	if not verifyConstraint( self, cons ) then return end
+
+	ropes[index] = cons
+	postCreate( self, "Rope", ent1, ent2, cons, rope )
 end
 
 __e2setcost(5)
@@ -234,15 +475,16 @@ e2function void entity:setLength(index, length)
 	if not IsValid(this) then return end
 	if not isOwner(self, this) then return false end
 	if length < 0 then length = 0 end
-	if this.data.Ropes then
-		local con = this.data.Ropes[index]
-		if IsValid(con) then
-			if con.Type == "Rope" then
-				con:SetKeyValue("addlength", length)
-			else
-				con:Fire("SetSpringLength", length, 0)
-			end
-		end
+
+	local ropes = setupRopes(ent1)
+
+	local cons = ropes[index]
+	if not IsValid(cons) then return end
+
+	if cons.Type == "Rope" then
+		cons:SetKeyValue("addlength", length)
+	else
+		cons:Fire("SetSpringLength", length, 0)
 	end
 end
 
@@ -251,12 +493,14 @@ e2function void entity:setConstant(index, constant)
 	if not IsValid(this) then return end
 	if not isOwner(self, this) then return false end
 	if constant < 0 then constant = 0 end
-	if this.data.Ropes then
-		local con = this.data.Ropes[index]
-		if IsValid(con) then
-			con:Fire("SetSpringConstant", constant, 0)
-		end
-	end
+
+	local ropes = setupRopes(ent1)
+	if not ropes then return end
+
+	local cons = ropes[index]
+	if not IsValid(con) then return end
+
+	con:Fire("SetSpringConstant", constant, 0)
 end
 
 --- Sets a hydraulic/winch stored at index <index> inside <this> (the first entity) to be <constant> constant and <dampen> damping.
@@ -265,65 +509,97 @@ e2function void entity:setConstant(index, constant, damping)
 	if not isOwner(self, this) then return false end
 	if constant < 0 then constant = 0 end
 	if damping < 0 then damping = 0 end
-	if this.data.Ropes then
-		local con = this.data.Ropes[index]
-		if IsValid(con) then
-			con:Fire("SetSpringConstant", constant, 0)
-			con:Fire("SetSpringDamping", damping, 0)
-		end
-	end
+
+	local ropes = setupRopes(this)
+	if not this.data.Ropes then return end
+
+	local cons = ropes[index]
+	if not IsValid(cons) then return end
+
+	con:Fire("SetSpringConstant", constant, 0)
+	con:Fire("SetSpringDamping", damping, 0)
 end
 
---- Sets a hydraulic/winch stored at index <index> inside <this> (the first entity) to be <dampen> damping.
+--- Sets a hydraulic/winch stored at index <index> inside <this> to be <dampen> damping.
 e2function void entity:setDamping(index, damping)
 	if not IsValid(this) then return end
 	if not isOwner(self, this) then return false end
 	if damping < 0 then damping = 0 end
-	if this.data.Ropes then
-		local con = this.data.Ropes[index]
-		if IsValid(con) then
-			con:Fire("SetSpringDamping", damping, 0)
-		end
-	end
+
+	local ropes = setupRopes(this)
+	if not ropes then return end
+
+	local cons = this.data.Ropes[index]
+	if not IsValid(con) then return end
+
+	con:Fire("SetSpringDamping", damping, 0)
 end
 
 __e2setcost(30)
 
+
+-- == Sliders ==
+
 --- Creates a slider between <ent1> and <ent2> at vector positions local to each ent.
 e2function void slider(entity ent1, vector v1, entity ent2, vector v2)
 	if not checkEnts(self, ent1, ent2) then return end
+	if not checkCount(self, "Slider") then return end
+	if not checkEdicts(self) then return end
 	local vec1, vec2 = Vector(v1[1], v1[2], v1[3]), Vector(v2[1], v2[2], v2[3])
-	addundo(self, constraint.Slider(ent1, ent2, 0, 0, vec1, vec2, 1), "slider")
+
+	local cons, rope = constraint.Slider(ent1, ent2, 0, 0, vec1, vec2, 1)
+	if not verifyConstraint(self, cons) then return end
+
+	postCreate(self, "Slider", ent1, ent2, cons, rope)
 end
 
 --- Creates a slider between <ent1> and <ent2> at vector positions local to each ent, with <width> width.
 e2function void slider(entity ent1, vector v1, entity ent2, vector v2, width)
 	if not checkEnts(self, ent1, ent2) then return end
+	if not checkCount(self, "Slider") then return end
+	if not checkEdicts(self) then return end
 	local vec1, vec2 = Vector(v1[1], v1[2], v1[3]), Vector(v2[1], v2[2], v2[3])
-	addundo(self, constraint.Slider(ent1, ent2, 0, 0, vec1, vec2, width), "slider")
+
+	local cons, rope = constraint.Slider(ent1, ent2, 0, 0, vec1, vec2, width)
+	if not verifyConstraint(self, cons) then return end
+
+	postCreate(self, "Slider", ent1, ent2, cons, rope)
 end
+
+
+-- == NoCollide ==
 
 --- Nocollides <ent1> to <ent2>
 e2function void noCollide(entity ent1, entity ent2)
 	if not checkEnts(self, ent1, ent2) then return end
-	addundo(self, constraint.NoCollide(ent1, ent2, 0, 0), "nocollide")
+	if not checkCount(self, "NoCollide") then return end
+
+	local cons = constraint.NoCollide(ent1, ent2, 0, 0)
+	if not verifyConstraint(self, cons) then return end
+
+	postCreate(self, "NoCollide", ent1, ent2, cons)
 end
 
 --- Nocollides <ent> to entities/players, just like Right Click of No-Collide Stool
 e2function void noCollideAll(entity ent, state)
 	if not IsValid(ent) then return self:throw("Invalid entity!", nil) end
 	if not isOwner(self, ent) then return self:throw("You do not own this prop!", nil) end
-	if state ~= 0 then
-		ent:SetCollisionGroup( COLLISION_GROUP_WORLD )
-	else
-		ent:SetCollisionGroup( COLLISION_GROUP_NONE )
-	end
+
+	ent:SetCollisionGroup(state == 0 and COLLISION_GROUP_NONE or COLLISION_GROUP_WORLD)
 end
+
+
+-- == Welds ==
 
 --- Welds <ent1> to <ent2>
 e2function void weld(entity ent1, entity ent2)
 	if not checkEnts(self, ent1, ent2) then return end
-	addundo(self, constraint.Weld(ent1, ent2, 0, 0, 0, true), "weld")
+	if not checkCount(self, "Weld") then return end
+
+	local cons = constraint.Weld(ent1, ent2, 0, 0, 0, true)
+	if not verifyConstraint(self, cons) then return end
+
+	postCreate(self, "Weld", ent1, ent2, cons)
 end
 
 __e2setcost(5)
@@ -337,46 +613,46 @@ end
 
 --- Breaks all constraints between <this> and <ent2>
 e2function void entity:constraintBreak(entity ent2)
-	if not checkEnts(self, this, ent2) then return end
-	local consts = this.Constraints
-	local consts2 = ent2.Constraints
-	if !consts then
-		if !consts2 then return end
-		consts = consts2
-	end
-	for _,v in pairs( consts ) do
-		if IsValid(v) then
-			local CTab = v:GetTable()
-			if ( CTab.Ent1 == this and CTab.Ent2 == ent2 ) or  ( CTab.Ent1 == ent2 and CTab.Ent2 == this ) then
-				v:Remove()
-			end
-	 	end
+	if not checkEnts( self, this, ent2 ) then return end
+
+	local consts = this.Constraints or ent2.Constraints
+	if not consts then return end
+
+	for _, v in pairs( consts ) do
+		if v:IsValid() then
+			local case1 = v.Ent1 == this and v.Ent2 == ent2
+			local case2 = case1 or ( v.Ent1 == ent2 and v.Ent2 == this )
+
+			if case1 or case2 then v:Remove() end
+		end
 	end
 end
 
---- Breaks all constraints of type <type> on <this>
-e2function void entity:constraintBreak(string type)
-	if !IsValid(this) then return self:throw("Invalid entity!", nil) end
-	if !isOwner(self, this) then return self:throw("You do not own this prop!", nil) end
-	constraint.RemoveConstraints(this, caps(type))
+--- Breaks all constraints of type <consType> on <this>
+e2function void entity:constraintBreak(string consType)
+	if not IsValid(this) then return self:throw("Invalid entity!", nil) end
+	if not isOwner(self, this) then return self:throw("You do not own this prop!", nil) end
+	constraint.RemoveConstraints(this, caps(consType))
 end
 
---- Breaks a constraint of type <type> between <this> and <ent2>
-e2function void entity:constraintBreak(string type, entity ent2)
+--- Breaks a constraint of type <consType> between <this> and <ent2>
+e2function void entity:constraintBreak(string consType, entity ent2)
 	if not checkEnts(self, this, ent2) then return end
-	local consts = this.Constraints
-	local consts2 = ent2.Constraints
-	if not consts then
-		if not consts2 then return end
-		consts = consts2
-	end
-	for _,v in pairs( consts ) do
-		if IsValid(v) then
-			local CTab = v:GetTable()
-			if CTab.Type == caps(type) and ( CTab.Ent1 == this and CTab.Ent2 == ent2 ) or ( CTab.Ent1 == ent2 and CTab.Ent2 == this ) then
+
+	local consts = this.Constraints or ent2.Constraints
+	if not consts then return end
+
+	consType = caps( consType )
+	for _, v in ipairs( consts ) do
+		if v:IsValid() then
+			local correctType = v.Type == consType
+			local case1 = correctType and ( v.Ent1 == this and v.Ent2 == ent2 )
+			local case2 = correctType and ( case1 or ( v.Ent1 == ent2 and v.Ent2 == this ) )
+
+			if case1 or case2 then
 				v:Remove()
 				break
 			end
-	 	end
+		end
 	end
 end

--- a/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
@@ -340,7 +340,7 @@ e2function void winch(index, entity ent1, vector v1, entity ent2, vector v2, wid
 	local cons, rope = constraint.Elastic( ent1, ent2, 0, 0, vec1, vec2, constant, dampen, 0, "cable/cable2", width, true )
 	if not verifyConstraint( self, cons ) then return end
 
-	ropes[index] = cons
+	constraints[index] = cons
 	postCreate( self, "Hydraulic", ent1, ent2, cons, rope )
 end
 
@@ -349,19 +349,19 @@ e2function void hydraulic(index, entity ent1, vector v1, entity ent2, vector v2,
 	if not checkEnts( self, ent1, ent2 ) then return end
 	if not checkCount( self, "Hydraulic", ent1, ent2 ) then return end
 	if not checkEdicts( self ) then return end
-	local ropes = setupEntConstraints( ent1 )
+	local constraints = setupEntConstraints( ent1 )
 
 	local vec1, vec2 = Vector( v1[1], v1[2], v1[3] ), Vector( v2[1], v2[2], v2[3] )
 	if width < 0 or width > 50 then width = 1 end
 
-	local existing = ropes[index]
+	local existing = constraints[index]
 	if IsValid( existing ) then existing:Remove() end
 
 	local constant, dampen = CalcElasticConsts( ent1:GetPhysicsObject(), ent2:GetPhysicsObject(), ent1, ent2 )
 	local cons, rope = constraint.Elastic( ent1, ent2, 0, 0, vec1, vec2, constant, dampen, 0, "cable/cable2", width, false )
 	if not verifyConstraint( self, cons ) then return end
 
-	ropes[index] = cons
+	constraints[index] = cons
 	postCreate( self, "Hydraulic", ent1, ent2, cons, rope )
 end
 
@@ -370,18 +370,18 @@ e2function void hydraulic(index, entity ent1, vector v1, entity ent2, vector v2,
 	if not checkEnts( self, ent1, ent2 ) then return end
 	if not checkCount( self, "Hydraulic", ent1, ent2 ) then return end
 	if not checkEdicts( self ) then return end
-	local ropes = setupEntConstraints( ent1 )
+	local constraints = setupEntConstraints( ent1 )
 
 	local vec1, vec2 = Vector( v1[1], v1[2], v1[3] ), Vector( v2[1], v2[2], v2[3] )
 	if width < 0 or width > 50 then width = 1 end
 
-	local existing = ropes[index]
+	local existing = constraints[index]
 	if IsValid( existing ) then existing:Remove() end
 
 	local cons, rope = constraint.Elastic( ent1, ent2, 0, 0, vec1, vec2, constant, damping, 0, mat, width, tobool( stretch ) )
 	if not verifyConstraint( self, cons ) then return end
 
-	ropes[index] = cons
+	constraints[index] = cons
 	postCreate( self, "Hydraulic", ent1, ent2, cons, rope )
 end
 
@@ -390,18 +390,18 @@ e2function void hydraulic(index, entity ent1, vector v1, entity ent2, vector v2,
 	if not checkEnts( self, ent1, ent2 ) then return end
 	if not checkCount( self, "Hydraulic", ent1, ent2 ) then return end
 	if not checkEdicts( self ) then return end
-	local ropes = setupEntConstraints( ent1 )
+	local constraints = setupEntConstraints( ent1 )
 
 	local vec1, vec2 = Vector( v1[1], v1[2], v1[3] ), Vector( v2[1], v2[2], v2[3] )
 	if width < 0 or width > 50 then width = 1 end
 
-	local existing = ropes[index]
+	local existing = constraints[index]
 	if IsValid( existing ) then existing:Remove() end
 
 	local cons, rope = constraint.Elastic( ent1, ent2, 0, 0, vec1, vec2, constant, damping, rdamping, mat, width, tobool( stretch ) )
 	if not verifyConstraint( self, cons ) then return end
 
-	ropes[index] = cons
+	constraints[index] = cons
 	postCreate( self, "Hydraulic", ent1, ent2, cons, rope )
 end
 
@@ -413,18 +413,18 @@ e2function void rope(index, entity ent1, vector v1, entity ent2, vector v2)
 	if not checkEnts( self, ent1, ent2 ) then return end
 	if not checkCount( self, "Rope", ent1, ent2 ) then return end
 	if not checkEdicts( self ) then return end
-	local ropes = setupEntConstraints( ent1 )
+	local constraints = setupEntConstraints( ent1 )
 
 	local vec1, vec2 = Vector( v1[1], v1[2], v1[3] ), Vector( v2[1], v2[2], v2[3] )
 	local length = ( ent1:LocalToWorld( vec1 ) - ent2:LocalToWorld( vec2 ) ):Length()
 
-	local existing = ropes[index]
+	local existing = constraints[index]
 	if IsValid( existing ) then existing:Remove() end
 
 	local cons, rope = constraint.Rope( ent1, ent2, 0, 0, vec1, vec2, length, 0, 0, 1, "cable/rope", false )
 	if not verifyConstraint( self, cons ) then return end
 
-	ropes[index] = cons
+	constraints[index] = cons
 	postCreate( self, "Rope", ent1, ent2, cons, rope )
 end
 
@@ -433,18 +433,18 @@ e2function void rope(index, entity ent1, vector v1, entity ent2, vector v2, addl
 	if not checkEnts( self, ent1, ent2 ) then return end
 	if not checkCount( self, "Rope", ent1, ent2 ) then return end
 	if not checkEdicts( self ) then return end
-	local ropes = setupEntConstraints( ent1 )
+	local constraints = setupEntConstraints( ent1 )
 
 	local vec1, vec2 = Vector( v1[1], v1[2], v1[3] ), Vector( v2[1], v2[2], v2[3] )
 	local length = (ent1:LocalToWorld(vec1) - ent2:LocalToWorld(vec2)):Length()
 
-	local existing = ropes[index]
+	local existing = constraints[index]
 	if IsValid( existing ) then existing:Remove() end
 
 	local cons, rope = constraint.Rope( ent1, ent2, 0, 0, vec1, vec2, length, addlength, 0, width, mat, false )
 	if not verifyConstraint( self, cons ) then return end
 
-	ropes[index] = cons
+	constraints[index] = cons
 	postCreate( self, "Rope", ent1, ent2, cons, rope )
 end
 
@@ -453,18 +453,18 @@ e2function void rope(index, entity ent1, vector v1, entity ent2, vector v2, addl
 	if not checkEnts( self, ent1, ent2 ) then return end
 	if not checkCount( self, "Rope", ent1, ent2 ) then return end
 	if not checkEdicts( self ) then return end
-	local ropes = setupEntConstraints( ent1 )
+	local constraints = setupEntConstraints( ent1 )
 
 	local vec1, vec2 = Vector( v1[1], v1[2], v1[3] ), Vector( v2[1], v2[2], v2[3] )
 	local length = ( ent1:LocalToWorld( vec1 ) - ent2:LocalToWorld( vec2 ) ):Length()
 
-	local existing = ropes[index]
+	local existing = constraints[index]
 	if IsValid( existing ) then existing:Remove() end
 
 	local cons, rope = constraint.Rope( ent1, ent2, 0, 0, vec1, vec2, length, addlength, 0, width, mat, tobool( rigid ) )
 	if not verifyConstraint( self, cons ) then return end
 
-	ropes[index] = cons
+	constraints[index] = cons
 	postCreate( self, "Rope", ent1, ent2, cons, rope )
 end
 
@@ -476,9 +476,9 @@ e2function void entity:setLength(index, length)
 	if not isOwner(self, this) then return false end
 	if length < 0 then length = 0 end
 
-	local ropes = setupEntConstraints(ent1)
+	local constraints = setupEntConstraints(this)
 
-	local cons = ropes[index]
+	local cons = constraints[index]
 	if not IsValid(cons) then return end
 
 	if cons.Type == "Rope" then
@@ -494,13 +494,13 @@ e2function void entity:setConstant(index, constant)
 	if not isOwner(self, this) then return false end
 	if constant < 0 then constant = 0 end
 
-	local ropes = setupEntConstraints(ent1)
-	if not ropes then return end
+	local constraints = setupEntConstraints(this)
+	if not constraints then return end
 
-	local cons = ropes[index]
+	local cons = constraints[index]
 	if not IsValid(con) then return end
 
-	con:Fire("SetSpringConstant", constant, 0)
+	cons:Fire("SetSpringConstant", constant, 0)
 end
 
 --- Sets a hydraulic/winch stored at index <index> inside <this> (the first entity) to be <constant> constant and <dampen> damping.
@@ -510,14 +510,14 @@ e2function void entity:setConstant(index, constant, damping)
 	if constant < 0 then constant = 0 end
 	if damping < 0 then damping = 0 end
 
-	local ropes = setupEntConstraints(this)
-	if not this.data.Ropes then return end
+	local constraints = setupEntConstraints(this)
+	if not constraints then return end
 
-	local cons = ropes[index]
+	local cons = constraints[index]
 	if not IsValid(cons) then return end
 
-	con:Fire("SetSpringConstant", constant, 0)
-	con:Fire("SetSpringDamping", damping, 0)
+	cons:Fire("SetSpringConstant", constant, 0)
+	cons:Fire("SetSpringDamping", damping, 0)
 end
 
 --- Sets a hydraulic/winch stored at index <index> inside <this> to be <dampen> damping.
@@ -526,13 +526,13 @@ e2function void entity:setDamping(index, damping)
 	if not isOwner(self, this) then return false end
 	if damping < 0 then damping = 0 end
 
-	local ropes = setupEntConstraints(this)
-	if not ropes then return end
+	local constraints = setupEntConstraints(this)
+	if not constraints then return end
 
-	local cons = this.data.Ropes[index]
+	local cons = constraints[index]
 	if not IsValid(con) then return end
 
-	con:Fire("SetSpringDamping", damping, 0)
+	cons:Fire("SetSpringDamping", damping, 0)
 end
 
 __e2setcost(30)

--- a/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
@@ -22,7 +22,7 @@ local maxAdvBallsocket = CreateConVar( "wire_expression2_max_constraints_ballsoc
 local edictCutOff = CreateConVar( "wire_expression2_constraints_edict_cutoff", "0", cvFlags, "At what edict count will E2s be prevented from creating new rope-like constraints (0 turns the check off)", 0, 8192 )
 local shouldCleanup = CreateConVar( "Wire_expression2_constraints_cleanup", "0", cvFlags, "Whether or not Constraint Core should remove all constraints made by an E2 when it's deleted", 0, 1 )
 
-local playerCounts = {}
+local playerCounts = WireLib.RegisterPlayerTable()
 
 -- Returns the table being used to keep track of counts
 local function getCountHolder(self)

--- a/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
@@ -68,10 +68,6 @@ registerCallback("destruct", function(self)
 	clearCreatedConstraints(self)
 end)
 
-hook.Add("PlayerDisconnected", "Wire_Expression2_ConstraintsCleanup", function(ply)
-	playerCounts[ply] = nil
-end)
-
 __e2setcost(1)
 e2function void enableConstraintUndo(state)
 	self.data.constraintUndos = state ~= 0

--- a/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
@@ -613,7 +613,8 @@ end
 
 --- Breaks all constraints between <this> and <ent2>
 e2function void entity:constraintBreak(entity ent2)
-	if not checkEnts( self, this, ent2 ) then return end
+	if not IsValid(this) then return self:throw("Invalid entity!", nil) end
+	if not isOwner(self, this) then return self:throw("You do not own this prop!", nil) end
 
 	local consts = this.Constraints or ent2.Constraints
 	if not consts then return end
@@ -637,7 +638,8 @@ end
 
 --- Breaks a constraint of type <consType> between <this> and <ent2>
 e2function void entity:constraintBreak(string consType, entity ent2)
-	if not checkEnts(self, this, ent2) then return end
+	if not IsValid(this) then return self:throw("Invalid entity!", nil) end
+	if not isOwner(self, this) then return self:throw("You do not own this prop!", nil) end
 
 	local consts = this.Constraints or ent2.Constraints
 	if not consts then return end

--- a/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
@@ -252,9 +252,8 @@ __e2setcost(30)
 e2function void axis(entity ent1, vector v1, entity ent2, vector v2)
 	if not checkEnts(self, ent1, ent2) then return end
 	if not checkCount(self, "Axis", ent1, ent2) then return end
-	local vec1, vec2 = Vector(v1[1], v1[2], v1[3]), Vector(v2[1], v2[2], v2[3])
 
-	local cons = constraint.Axis(ent1, ent2, 0, 0, vec1, vec2, 0, 0, 0, 0)
+	local cons = constraint.Axis(ent1, ent2, 0, 0, v1, v2, 0, 0, 0, 0)
 	postCreate(self, "Axis", ent1, ent2, cons)
 end
 
@@ -262,9 +261,8 @@ end
 e2function void axis(entity ent1, vector v1, entity ent2, vector v2, friction)
 	if not checkEnts(self, ent1, ent2) then return end
 	if not checkCount(self, "Axis", ent1, ent2) then return end
-	local vec1, vec2 = Vector(v1[1], v1[2], v1[3]), Vector(v2[1], v2[2], v2[3])
 
-	local cons = constraint.Axis(ent1, ent2, 0, 0, vec1, vec2, 0, 0, friction, 0)
+	local cons = constraint.Axis(ent1, ent2, 0, 0, v1, v2, 0, 0, friction, 0)
 	postCreate(self, "Axis", ent1, ent2, cons)
 end
 
@@ -272,9 +270,8 @@ end
 e2function void axis(entity ent1, vector v1, entity ent2, vector v2, friction, vector localaxis)
 	if not checkEnts(self, ent1, ent2) then return end
 	if not checkCount(self, "Axis", ent1, ent2) then return end
-	local vec1, vec2, laxis = Vector(v1[1], v1[2], v1[3]), Vector(v2[1], v2[2], v2[3]), Vector(localaxis[1], localaxis[2], localaxis[3])
 
-	local cons = constraint.Axis(ent1, ent2, 0, 0, vec1, vec2, 0, 0, friction, 0, laxis)
+	local cons = constraint.Axis(ent1, ent2, 0, 0, v1, v2, 0, 0, friction, 0, localaxis)
 	if not verifyConstraint(self, cons) then return end
 
 	postCreate(self, "Axis", ent1, ent2, cons)
@@ -287,9 +284,8 @@ end
 e2function void ballsocket(entity ent1, vector v, entity ent2)
 	if not checkEnts(self, ent1, ent2) then return end
 	if not checkCount(self, "Ballsocket", ent1, ent2) then return end
-	local vec = Vector(v[1], v[2], v[3])
 
-	local cons = constraint.Ballsocket(ent1, ent2, 0, 0, vec, 0, 0, 0)
+	local cons = constraint.Ballsocket(ent1, ent2, 0, 0, v, 0, 0, 0)
 	if not verifyConstraint(self, cons) then return end
 
 	postCreate(self, "Ballsocket", ent1, ent2, cons)
@@ -299,9 +295,8 @@ end
 e2function void ballsocket(entity ent1, vector v, entity ent2, friction)
 	if not checkEnts(self, ent1, ent2) then return end
 	if not checkCount(self, "AdvBallsocket", ent1, ent2) then return end
-	local vec = Vector(v[1], v[2], v[3])
 
-	local cons = constraint.AdvBallsocket(ent1, ent2, 0, 0, vec, emptyVector, 0, 0, -180, -180, -180, 180, 180, 180, friction, friction, friction, 0, 0)
+	local cons = constraint.AdvBallsocket(ent1, ent2, 0, 0, v, emptyVector, 0, 0, -180, -180, -180, 180, 180, 180, friction, friction, friction, 0, 0)
 	if not verifyConstraint(self, cons) then return end
 
 	postCreate(self, "AdvBallsocket", ent1, ent2, cons)
@@ -311,9 +306,8 @@ end
 e2function void ballsocket(entity ent1, vector v, entity ent2, vector mins, vector maxs, vector frictions)
 	if not checkEnts(self, ent1, ent2) then return end
 	if not checkCount(self, "AdvBallsocket", ent1, ent2) then return end
-	local vec = Vector(v[1], v[2], v[3])
 
-	local cons = constraint.AdvBallsocket(ent1, ent2, 0, 0, vec, emptyVector, 0, 0, mins[1], mins[2], mins[3], maxs[1], maxs[2], maxs[3], frictions[1], frictions[2], frictions[3], 0, 0)
+	local cons = constraint.AdvBallsocket(ent1, ent2, 0, 0, v, emptyVector, 0, 0, mins[1], mins[2], mins[3], maxs[1], maxs[2], maxs[3], frictions[1], frictions[2], frictions[3], 0, 0)
 	if not verifyConstraint(self, cons) then return end
 
 	postCreate(self, "AdvBallsocket", ent1, ent2, cons)
@@ -323,9 +317,8 @@ end
 e2function void ballsocket(entity ent1, vector v, entity ent2, vector mins, vector maxs, vector frictions, rotateonly)
 	if not checkEnts(self, ent1, ent2) then return end
 	if not checkCount(self, "AdvBallsocket", ent1, ent2) then return end
-	local vec = Vector(v[1], v[2], v[3])
 
-	local cons = constraint.AdvBallsocket(ent1, ent2, 0, 0, vec, emptyVector, 0, 0, mins[1], mins[2], mins[3], maxs[1], maxs[2], maxs[3], frictions[1], frictions[2], frictions[3], rotateonly, 0)
+	local cons = constraint.AdvBallsocket(ent1, ent2, 0, 0, v, emptyVector, 0, 0, mins[1], mins[2], mins[3], maxs[1], maxs[2], maxs[3], frictions[1], frictions[2], frictions[3], rotateonly, 0)
 	if not verifyConstraint(self, cons) then return end
 
 	postCreate(self, "AdvBallsocket", ent1, ent2, cons)
@@ -335,9 +328,8 @@ end
 e2function void weldAng(entity ent1, vector v, entity ent2)
 	if not checkEnts(self, ent1, ent2) then return end
 	if not checkCount(self, "AdvBallsocket", ent1, ent2) then return end
-	local vec = Vector(v[1], v[2], v[3])
 
-	local cons = constraint.AdvBallsocket(ent1, ent2, 0, 0, vec, emptyVector, 0, 0, 0, -0, 0, 0, 0, 0, 0, 0, 0, 1, 0)
+	local cons = constraint.AdvBallsocket(ent1, ent2, 0, 0, v, emptyVector, 0, 0, 0, -0, 0, 0, 0, 0, 0, 0, 0, 1, 0)
 	if not verifyConstraint(self, cons) then return end
 
 	postCreate(self, "AdvBallsocket", ent1, ent2, cons)
@@ -371,14 +363,13 @@ e2function void winch(index, entity ent1, vector v1, entity ent2, vector v2, wid
 	if not checkEdicts( self ) then return end
 	local constraints = setupEntConstraints( ent1 )
 
-	local vec1, vec2 = Vector( v1[1], v1[2], v1[3] ), Vector( v2[1], v2[2], v2[3] )
 	if width < 0 or width > 50 then width = 1 end
 
 	local existing = constraints[index]
 	if IsValid( existing ) then existing:Remove() end
 
 	local constant, dampen = CalcElasticConsts( ent1:GetPhysicsObject(), ent2:GetPhysicsObject(), ent1, ent2 )
-	local cons, rope = constraint.Elastic( ent1, ent2, 0, 0, vec1, vec2, constant, dampen, 0, "cable/cable2", width, true )
+	local cons, rope = constraint.Elastic( ent1, ent2, 0, 0, v1, v2, constant, dampen, 0, "cable/cable2", width, true )
 	if not verifyConstraint( self, cons ) then return end
 
 	constraints[index] = cons
@@ -392,14 +383,13 @@ e2function void hydraulic(index, entity ent1, vector v1, entity ent2, vector v2,
 	if not checkEdicts( self ) then return end
 	local constraints = setupEntConstraints( ent1 )
 
-	local vec1, vec2 = Vector( v1[1], v1[2], v1[3] ), Vector( v2[1], v2[2], v2[3] )
 	if width < 0 or width > 50 then width = 1 end
 
 	local existing = constraints[index]
 	if IsValid( existing ) then existing:Remove() end
 
 	local constant, dampen = CalcElasticConsts( ent1:GetPhysicsObject(), ent2:GetPhysicsObject(), ent1, ent2 )
-	local cons, rope = constraint.Elastic( ent1, ent2, 0, 0, vec1, vec2, constant, dampen, 0, "cable/cable2", width, false )
+	local cons, rope = constraint.Elastic( ent1, ent2, 0, 0, v1, v2, constant, dampen, 0, "cable/cable2", width, false )
 	if not verifyConstraint( self, cons ) then return end
 
 	constraints[index] = cons
@@ -413,13 +403,12 @@ e2function void hydraulic(index, entity ent1, vector v1, entity ent2, vector v2,
 	if not checkEdicts( self ) then return end
 	local constraints = setupEntConstraints( ent1 )
 
-	local vec1, vec2 = Vector( v1[1], v1[2], v1[3] ), Vector( v2[1], v2[2], v2[3] )
 	if width < 0 or width > 50 then width = 1 end
 
 	local existing = constraints[index]
 	if IsValid( existing ) then existing:Remove() end
 
-	local cons, rope = constraint.Elastic( ent1, ent2, 0, 0, vec1, vec2, constant, damping, 0, mat, width, tobool( stretch ) )
+	local cons, rope = constraint.Elastic( ent1, ent2, 0, 0, v1, v2, constant, damping, 0, mat, width, tobool( stretch ) )
 	if not verifyConstraint( self, cons ) then return end
 
 	constraints[index] = cons
@@ -433,13 +422,12 @@ e2function void hydraulic(index, entity ent1, vector v1, entity ent2, vector v2,
 	if not checkEdicts( self ) then return end
 	local constraints = setupEntConstraints( ent1 )
 
-	local vec1, vec2 = Vector( v1[1], v1[2], v1[3] ), Vector( v2[1], v2[2], v2[3] )
 	if width < 0 or width > 50 then width = 1 end
 
 	local existing = constraints[index]
 	if IsValid( existing ) then existing:Remove() end
 
-	local cons, rope = constraint.Elastic( ent1, ent2, 0, 0, vec1, vec2, constant, damping, rdamping, mat, width, tobool( stretch ) )
+	local cons, rope = constraint.Elastic( ent1, ent2, 0, 0, v1, v2, constant, damping, rdamping, mat, width, tobool( stretch ) )
 	if not verifyConstraint( self, cons ) then return end
 
 	constraints[index] = cons
@@ -456,13 +444,12 @@ e2function void rope(index, entity ent1, vector v1, entity ent2, vector v2)
 	if not checkEdicts( self ) then return end
 	local constraints = setupEntConstraints( ent1 )
 
-	local vec1, vec2 = Vector( v1[1], v1[2], v1[3] ), Vector( v2[1], v2[2], v2[3] )
-	local length = ( ent1:LocalToWorld( vec1 ) - ent2:LocalToWorld( vec2 ) ):Length()
+	local length = ( ent1:LocalToWorld( v1 ) - ent2:LocalToWorld( v2 ) ):Length()
 
 	local existing = constraints[index]
 	if IsValid( existing ) then existing:Remove() end
 
-	local cons, rope = constraint.Rope( ent1, ent2, 0, 0, vec1, vec2, length, 0, 0, 1, "cable/rope", false )
+	local cons, rope = constraint.Rope( ent1, ent2, 0, 0, v1, v2, length, 0, 0, 1, "cable/rope", false )
 	if not verifyConstraint( self, cons ) then return end
 
 	constraints[index] = cons
@@ -476,13 +463,12 @@ e2function void rope(index, entity ent1, vector v1, entity ent2, vector v2, addl
 	if not checkEdicts( self ) then return end
 	local constraints = setupEntConstraints( ent1 )
 
-	local vec1, vec2 = Vector( v1[1], v1[2], v1[3] ), Vector( v2[1], v2[2], v2[3] )
-	local length = (ent1:LocalToWorld(vec1) - ent2:LocalToWorld(vec2)):Length()
+	local length = ( ent1:LocalToWorld(v1) - ent2:LocalToWorld(v2)):Length( )
 
 	local existing = constraints[index]
 	if IsValid( existing ) then existing:Remove() end
 
-	local cons, rope = constraint.Rope( ent1, ent2, 0, 0, vec1, vec2, length, addlength, 0, width, mat, false )
+	local cons, rope = constraint.Rope( ent1, ent2, 0, 0, v1, v2, length, addlength, 0, width, mat, false )
 	if not verifyConstraint( self, cons ) then return end
 
 	constraints[index] = cons
@@ -496,13 +482,12 @@ e2function void rope(index, entity ent1, vector v1, entity ent2, vector v2, addl
 	if not checkEdicts( self ) then return end
 	local constraints = setupEntConstraints( ent1 )
 
-	local vec1, vec2 = Vector( v1[1], v1[2], v1[3] ), Vector( v2[1], v2[2], v2[3] )
-	local length = ( ent1:LocalToWorld( vec1 ) - ent2:LocalToWorld( vec2 ) ):Length()
+	local length = ( ent1:LocalToWorld( v1 ) - ent2:LocalToWorld( v2 ) ):Length()
 
 	local existing = constraints[index]
 	if IsValid( existing ) then existing:Remove() end
 
-	local cons, rope = constraint.Rope( ent1, ent2, 0, 0, vec1, vec2, length, addlength, 0, width, mat, tobool( rigid ) )
+	local cons, rope = constraint.Rope( ent1, ent2, 0, 0, v1, v2, length, addlength, 0, width, mat, tobool( rigid ) )
 	if not verifyConstraint( self, cons ) then return end
 
 	constraints[index] = cons
@@ -583,26 +568,24 @@ __e2setcost(30)
 
 --- Creates a slider between <ent1> and <ent2> at vector positions local to each ent.
 e2function void slider(entity ent1, vector v1, entity ent2, vector v2)
-	if not checkEnts(self, ent1, ent2) then return end
-	if not checkCount(self, "Slider", ent1, ent2) then return end
-	if not checkEdicts(self) then return end
-	local vec1, vec2 = Vector(v1[1], v1[2], v1[3]), Vector(v2[1], v2[2], v2[3])
+	if not checkEnts( self, ent1, ent2 ) then return end
+	if not checkCount( self, "Slider", ent1, ent2 ) then return end
+	if not checkEdicts( self ) then return end
 
-	local cons, rope = constraint.Slider(ent1, ent2, 0, 0, vec1, vec2, 1)
-	if not verifyConstraint(self, cons) then return end
+	local cons, rope = constraint.Slider( ent1, ent2, 0, 0, v1, v2, 1 )
+	if not verifyConstraint( self, cons ) then return end
 
-	postCreate(self, "Slider", ent1, ent2, cons, rope)
+	postCreate( self, "Slider", ent1, ent2, cons, rope )
 end
 
 --- Creates a slider between <ent1> and <ent2> at vector positions local to each ent, with <width> width.
 e2function void slider(entity ent1, vector v1, entity ent2, vector v2, width)
-	if not checkEnts(self, ent1, ent2) then return end
-	if not checkCount(self, "Slider", ent1, ent2) then return end
-	if not checkEdicts(self) then return end
-	local vec1, vec2 = Vector(v1[1], v1[2], v1[3]), Vector(v2[1], v2[2], v2[3])
+	if not checkEnts( self, ent1, ent2 ) then return end
+	if not checkCount( self, "Slider", ent1, ent2 ) then return end
+	if not checkEdicts( self ) then return end
 
-	local cons, rope = constraint.Slider(ent1, ent2, 0, 0, vec1, vec2, width)
-	if not verifyConstraint(self, cons) then return end
+	local cons, rope = constraint.Slider( ent1, ent2, 0, 0, v1, v2, width )
+	if not verifyConstraint( self, cons ) then return end
 
 	postCreate(self, "Slider", ent1, ent2, cons, rope)
 end

--- a/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
@@ -210,7 +210,7 @@ __e2setcost(30)
 --- Creates an axis between <ent1> and <ent2> at vector positions local to each ent.
 e2function void axis(entity ent1, vector v1, entity ent2, vector v2)
 	if not checkEnts(self, ent1, ent2) then return end
-	if not checkCount(self, "Axis") then return end
+	if not checkCount(self, "Axis", ent1, ent2) then return end
 	local vec1, vec2 = Vector(v1[1], v1[2], v1[3]), Vector(v2[1], v2[2], v2[3])
 
 	local cons = constraint.Axis(ent1, ent2, 0, 0, vec1, vec2, 0, 0, 0, 0)
@@ -220,7 +220,7 @@ end
 --- Creates an axis between <ent1> and <ent2> at vector positions local to each ent, with <friction> friction.
 e2function void axis(entity ent1, vector v1, entity ent2, vector v2, friction)
 	if not checkEnts(self, ent1, ent2) then return end
-	if not checkCount(self, "Axis") then return end
+	if not checkCount(self, "Axis", ent1, ent2) then return end
 	local vec1, vec2 = Vector(v1[1], v1[2], v1[3]), Vector(v2[1], v2[2], v2[3])
 
 	local cons = constraint.Axis(ent1, ent2, 0, 0, vec1, vec2, 0, 0, friction, 0)
@@ -230,7 +230,7 @@ end
 --- Creates an axis between <ent1> and <ent2> at vector positions local to each ent, with <friction> friction and <localaxis> rotation axis.
 e2function void axis(entity ent1, vector v1, entity ent2, vector v2, friction, vector localaxis)
 	if not checkEnts(self, ent1, ent2) then return end
-	if not checkCount(self, "Axis") then return end
+	if not checkCount(self, "Axis", ent1, ent2) then return end
 	local vec1, vec2, laxis = Vector(v1[1], v1[2], v1[3]), Vector(v2[1], v2[2], v2[3]), Vector(localaxis[1], localaxis[2], localaxis[3])
 
 	local cons = constraint.Axis(ent1, ent2, 0, 0, vec1, vec2, 0, 0, friction, 0, laxis)
@@ -245,7 +245,7 @@ end
 --- Creates a ballsocket between <ent1> and <ent2> at <v>, which is local to <ent1>
 e2function void ballsocket(entity ent1, vector v, entity ent2)
 	if not checkEnts(self, ent1, ent2) then return end
-	if not checkCount(self, "Ballsocket") then return end
+	if not checkCount(self, "Ballsocket", ent1, ent2) then return end
 	local vec = Vector(v[1], v[2], v[3])
 
 	local cons = constraint.Ballsocket(ent1, ent2, 0, 0, vec, 0, 0, 0)
@@ -257,7 +257,7 @@ end
 --- Creates a ballsocket between <ent1> and <ent2> at <v>, which is local to <ent1>, with friction <friction>
 e2function void ballsocket(entity ent1, vector v, entity ent2, friction)
 	if not checkEnts(self, ent1, ent2) then return end
-	if not checkCount(self, "AdvBallsocket") then return end
+	if not checkCount(self, "AdvBallsocket", ent1, ent2) then return end
 	local vec = Vector(v[1], v[2], v[3])
 
 	local cons = constraint.AdvBallsocket(ent1, ent2, 0, 0, vec, emptyVector, 0, 0, -180, -180, -180, 180, 180, 180, friction, friction, friction, 0, 0)
@@ -269,7 +269,7 @@ end
 --- Creates an adv ballsocket between <ent1> and <ent2> at <v>, which is local to <ent1>, with many settings
 e2function void ballsocket(entity ent1, vector v, entity ent2, vector mins, vector maxs, vector frictions)
 	if not checkEnts(self, ent1, ent2) then return end
-	if not checkCount(self, "AdvBallsocket") then return end
+	if not checkCount(self, "AdvBallsocket", ent1, ent2) then return end
 	local vec = Vector(v[1], v[2], v[3])
 
 	local cons = constraint.AdvBallsocket(ent1, ent2, 0, 0, vec, emptyVector, 0, 0, mins[1], mins[2], mins[3], maxs[1], maxs[2], maxs[3], frictions[1], frictions[2], frictions[3], 0, 0)
@@ -281,7 +281,7 @@ end
 --- Creates an adv ballsocket between <ent1> and <ent2> at <v>, which is local to <ent1>, with many settings
 e2function void ballsocket(entity ent1, vector v, entity ent2, vector mins, vector maxs, vector frictions, rotateonly)
 	if not checkEnts(self, ent1, ent2) then return end
-	if not checkCount(self, "AdvBallsocket") then return end
+	if not checkCount(self, "AdvBallsocket", ent1, ent2) then return end
 	local vec = Vector(v[1], v[2], v[3])
 
 	local cons = constraint.AdvBallsocket(ent1, ent2, 0, 0, vec, emptyVector, 0, 0, mins[1], mins[2], mins[3], maxs[1], maxs[2], maxs[3], frictions[1], frictions[2], frictions[3], rotateonly, 0)
@@ -293,7 +293,7 @@ end
 --- Creates an angular weld (angles are fixed, position isn't) between <ent1> and <ent2> at <v>, which is local to <ent1>
 e2function void weldAng(entity ent1, vector v, entity ent2)
 	if not checkEnts(self, ent1, ent2) then return end
-	if not checkCount(self, "AdvBallsocket") then return end
+	if not checkCount(self, "AdvBallsocket", ent1, ent2) then return end
 	local vec = Vector(v[1], v[2], v[3])
 
 	local cons = constraint.AdvBallsocket(ent1, ent2, 0, 0, vec, emptyVector, 0, 0, 0, -0, 0, 0, 0, 0, 0, 0, 0, 1, 0)
@@ -326,7 +326,7 @@ end
 --- Makes a winch constraint (stored at index <index>) between <ent1> and <ent2>, at vectors local to their respective ents, with <width> width.
 e2function void winch(index, entity ent1, vector v1, entity ent2, vector v2, width)
 	if not checkEnts( self, ent1, ent2 ) then return end
-	if not checkCount( self, "Hydraulic" ) then return end
+	if not checkCount( self, "Hydraulic" , ent1, ent2 ) then return end
 	if not checkEdicts( self ) then return end
 	local constraints = setupEntConstraints( ent1 )
 
@@ -347,9 +347,9 @@ end
 --- Makes a hydraulic constraint (stored at index <index>) between <ent1> and <ent2>, at vectors local to their respective ents, with <width> width.
 e2function void hydraulic(index, entity ent1, vector v1, entity ent2, vector v2, width)
 	if not checkEnts( self, ent1, ent2 ) then return end
-	if not checkCount( self, "Hydraulic" ) then return end
+	if not checkCount( self, "Hydraulic", ent1, ent2 ) then return end
 	if not checkEdicts( self ) then return end
-	local ropes = setupRopes( ent1 )
+	local ropes = setupEntConstraints( ent1 )
 
 	local vec1, vec2 = Vector( v1[1], v1[2], v1[3] ), Vector( v2[1], v2[2], v2[3] )
 	if width < 0 or width > 50 then width = 1 end
@@ -368,9 +368,9 @@ end
 --- Makes a hydraulic constraint (stored at index <index>) between <ent1> and <ent2>, at vectors local to their respective ents, constant and damping, with <width> width, <mat> material, and <stretch> stretch only option.
 e2function void hydraulic(index, entity ent1, vector v1, entity ent2, vector v2, constant, damping, string mat, width, stretch)
 	if not checkEnts( self, ent1, ent2 ) then return end
-	if not checkCount( self, "Hydraulic" ) then return end
+	if not checkCount( self, "Hydraulic", ent1, ent2 ) then return end
 	if not checkEdicts( self ) then return end
-	local ropes = setupRopes( ent1 )
+	local ropes = setupEntConstraints( ent1 )
 
 	local vec1, vec2 = Vector( v1[1], v1[2], v1[3] ), Vector( v2[1], v2[2], v2[3] )
 	if width < 0 or width > 50 then width = 1 end
@@ -388,9 +388,9 @@ end
 --- Makes a hydraulic constraint (stored at index <index>) between <ent1> and <ent2>, at vectors local to their respective ents, constant, damping and relative damping, with <width> width, <mat> material, and <stretch> stretch only option.
 e2function void hydraulic(index, entity ent1, vector v1, entity ent2, vector v2, constant, damping, rdamping, string mat, width, stretch)
 	if not checkEnts( self, ent1, ent2 ) then return end
-	if not checkCount( self, "Hydraulic" ) then return end
+	if not checkCount( self, "Hydraulic", ent1, ent2 ) then return end
 	if not checkEdicts( self ) then return end
-	local ropes = setupRopes( ent1 )
+	local ropes = setupEntConstraints( ent1 )
 
 	local vec1, vec2 = Vector( v1[1], v1[2], v1[3] ), Vector( v2[1], v2[2], v2[3] )
 	if width < 0 or width > 50 then width = 1 end
@@ -411,9 +411,9 @@ end
 --- Creates a rope between <ent1> and <ent2> at vector positions local to each ent.
 e2function void rope(index, entity ent1, vector v1, entity ent2, vector v2)
 	if not checkEnts( self, ent1, ent2 ) then return end
-	if not checkCount( self, "Rope" ) then return end
+	if not checkCount( self, "Rope", ent1, ent2 ) then return end
 	if not checkEdicts( self ) then return end
-	local ropes = setupRopes( ent1 )
+	local ropes = setupEntConstraints( ent1 )
 
 	local vec1, vec2 = Vector( v1[1], v1[2], v1[3] ), Vector( v2[1], v2[2], v2[3] )
 	local length = ( ent1:LocalToWorld( vec1 ) - ent2:LocalToWorld( vec2 ) ):Length()
@@ -431,9 +431,9 @@ end
 --- Creates a rope between <ent1> and <ent2> at vector positions local to each ent, with <addlength> additional length, <width> width, and <mat> material.
 e2function void rope(index, entity ent1, vector v1, entity ent2, vector v2, addlength, width, string mat)
 	if not checkEnts( self, ent1, ent2 ) then return end
-	if not checkCount( self, "Rope" ) then return end
+	if not checkCount( self, "Rope", ent1, ent2 ) then return end
 	if not checkEdicts( self ) then return end
-	local ropes = setupRopes( ent1 )
+	local ropes = setupEntConstraints( ent1 )
 
 	local vec1, vec2 = Vector( v1[1], v1[2], v1[3] ), Vector( v2[1], v2[2], v2[3] )
 	local length = (ent1:LocalToWorld(vec1) - ent2:LocalToWorld(vec2)):Length()
@@ -451,9 +451,9 @@ end
 --- Creates a rope between <ent1> and <ent2> at vector positions local to each ent, with <addlength> additional length, <width> width, and <mat> material.
 e2function void rope(index, entity ent1, vector v1, entity ent2, vector v2, addlength, width, string mat, rigid )
 	if not checkEnts( self, ent1, ent2 ) then return end
-	if not checkCount( self, "Rope" ) then return end
+	if not checkCount( self, "Rope", ent1, ent2 ) then return end
 	if not checkEdicts( self ) then return end
-	local ropes = setupRopes( ent1 )
+	local ropes = setupEntConstraints( ent1 )
 
 	local vec1, vec2 = Vector( v1[1], v1[2], v1[3] ), Vector( v2[1], v2[2], v2[3] )
 	local length = ( ent1:LocalToWorld( vec1 ) - ent2:LocalToWorld( vec2 ) ):Length()
@@ -476,7 +476,7 @@ e2function void entity:setLength(index, length)
 	if not isOwner(self, this) then return false end
 	if length < 0 then length = 0 end
 
-	local ropes = setupRopes(ent1)
+	local ropes = setupEntConstraints(ent1)
 
 	local cons = ropes[index]
 	if not IsValid(cons) then return end
@@ -494,7 +494,7 @@ e2function void entity:setConstant(index, constant)
 	if not isOwner(self, this) then return false end
 	if constant < 0 then constant = 0 end
 
-	local ropes = setupRopes(ent1)
+	local ropes = setupEntConstraints(ent1)
 	if not ropes then return end
 
 	local cons = ropes[index]
@@ -510,7 +510,7 @@ e2function void entity:setConstant(index, constant, damping)
 	if constant < 0 then constant = 0 end
 	if damping < 0 then damping = 0 end
 
-	local ropes = setupRopes(this)
+	local ropes = setupEntConstraints(this)
 	if not this.data.Ropes then return end
 
 	local cons = ropes[index]
@@ -526,7 +526,7 @@ e2function void entity:setDamping(index, damping)
 	if not isOwner(self, this) then return false end
 	if damping < 0 then damping = 0 end
 
-	local ropes = setupRopes(this)
+	local ropes = setupEntConstraints(this)
 	if not ropes then return end
 
 	local cons = this.data.Ropes[index]
@@ -543,7 +543,7 @@ __e2setcost(30)
 --- Creates a slider between <ent1> and <ent2> at vector positions local to each ent.
 e2function void slider(entity ent1, vector v1, entity ent2, vector v2)
 	if not checkEnts(self, ent1, ent2) then return end
-	if not checkCount(self, "Slider") then return end
+	if not checkCount(self, "Slider", ent1, ent2) then return end
 	if not checkEdicts(self) then return end
 	local vec1, vec2 = Vector(v1[1], v1[2], v1[3]), Vector(v2[1], v2[2], v2[3])
 
@@ -556,7 +556,7 @@ end
 --- Creates a slider between <ent1> and <ent2> at vector positions local to each ent, with <width> width.
 e2function void slider(entity ent1, vector v1, entity ent2, vector v2, width)
 	if not checkEnts(self, ent1, ent2) then return end
-	if not checkCount(self, "Slider") then return end
+	if not checkCount(self, "Slider", ent1, ent2) then return end
 	if not checkEdicts(self) then return end
 	local vec1, vec2 = Vector(v1[1], v1[2], v1[3]), Vector(v2[1], v2[2], v2[3])
 
@@ -572,7 +572,7 @@ end
 --- Nocollides <ent1> to <ent2>
 e2function void noCollide(entity ent1, entity ent2)
 	if not checkEnts(self, ent1, ent2) then return end
-	if not checkCount(self, "NoCollide") then return end
+	if not checkCount(self, "NoCollide", ent1, ent2) then return end
 
 	local cons = constraint.NoCollide(ent1, ent2, 0, 0)
 	if not verifyConstraint(self, cons) then return end
@@ -594,7 +594,7 @@ end
 --- Welds <ent1> to <ent2>
 e2function void weld(entity ent1, entity ent2)
 	if not checkEnts(self, ent1, ent2) then return end
-	if not checkCount(self, "Weld") then return end
+	if not checkCount(self, "Weld", ent1, ent2) then return end
 
 	local cons = constraint.Weld(ent1, ent2, 0, 0, 0, true)
 	if not verifyConstraint(self, cons) then return end

--- a/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
@@ -13,7 +13,7 @@ local maxPerEntity = CreateConVar( "wire_expression2_max_consttraints_per_entity
 local maxBallsocket = CreateConVar( "wire_expression2_max_constraints_ballsocket", "0", cvFlags, 0 )
 local maxAdvBallsocket = CreateConVar( "wire_expression2_max_constraints_ballsocket_adv", "0", cvFlags, 0)
 
-local edictCutOff = CreateConVar( "wire_expression2_constraints_edict_cutoff", "7500", cvFlags, "At what edict count will E2s be prevented from creating new rope-like constraints", 0, 8192 )
+local edictCutOff = CreateConVar( "wire_expression2_constraints_edict_cutoff", "0", cvFlags, "At what edict count will E2s be prevented from creating new rope-like constraints (0 turns the check off)", 0, 8192 )
 local shouldCleanup = CreateConVar( "Wire_expression2_constraints_cleanup", "0", cvFlags, "Whether or not Constraint Core should remove all constraints made by an E2 when it's deleted", 0, 1 )
 
 
@@ -141,6 +141,8 @@ end
 
 local function checkEdicts(self)
 	local maxEdicts = edictCutOff:GetInt()
+	if maxEdicts == 0 then return true end
+
 	if ents.GetEdictCount() >= maxEdicts then
 		return self:throw( "Global edict limit reached!", false )
 	end


### PR DESCRIPTION
Constraint Core is a really cool extension, but there were a few opportunities for improvement in the source that I took advantage of.
What started as investigation into a constraint ownership issue turned into a larger code rework.

## Motivation
When I discovered the ownership issue, I wanted to implement a "good" solution that would make the file easier to modify later.

In doing so, I found a lot of little issues and potential errors in the code. I also discovered some pretty severe exploits, and decided I'd take on the task of modernizing and fully adopting Constraint Core into E2.

This is mostly a code change that fixes bugs, improves performance, and helps mitigate misuse.

**This PR is entirely backwards-compatible** - no API changes were made _(though, I would argue it could be dramatically improved if we did a full rework...)_

## Outline of Changes

### Functional changes
_* All convars are off-by-default, so they don't change any behavior until a server operator configures their value_
 - Added multiple convars to control limits for:
    - The total constraints any player can make with e2
    - The total constraints of _each type_ any player can make with a e2
    - The total constraints any player can make on any given entity
 - Added a convar to completely prevent new edict-producing constraints after the configured threshold (default `7500`) to prevent players from using Constraint Core to quickly exhaust the server's Edict limit
 - Added a convar to make the E2 clean up all created constraints on `destruct`
 - Added a validator that the makes sure the constraints were actually created, and breaks out of the function if something went wrong
 - Fixed a bug where Ropes, Elastic, etc. weren't being picked up by most Prop Protection addons _(refactored the undo/cleanup function to also include the created Rope-y entity)_
 - In `Entity:constraintBreak( Entity )` _(and similar)_, stopped checking ownership of the other Entity (i.e. so you can clear constraints between your prop and the world, for example - can't think of any reason that the target Entity has to be owned by you)

### Code changes
 - Made spacing consistent within each method:
    - If the method already had code with spaces inside parens, I changed the rest of the method to follow the same pattern
    - Top-level function definitions remain without spaces inside parens
    - New functions use space inside parens
 - Removed Garry operators (`//` -> `--`, `!` -> `not`) _(yes, I can see the irony of making this change in an e2 file, lol)_
 - Extracted ent setup functions (like setting up the "`Ropes`" table) into their own helper functions
 - General code simplification
 - Reduced indentation, mostly by negating and returning early
 - Created a new `postCreate` function that takes care of the counting, undo/cleanup, and constraint tracking
 - Made casing of constraint types consistent
 - Localized a few frequently used functions to save a handful of microseconds every execution
 - Segmented each section with comments
 - Improved consistency in some variable names

This is a lot of wordy buzzword B.S; **Basically I just tried to make the file a little less painful to work with and add some much-needed restrictions.**

## Testing
I'll run this branch on CFC for a few days and fix any issues that come up. During that time I'll tend to this PR and your lovely comments.

As a sanity check, I ran this E2 on both `master` and my branch:
```
@strict
Ent1 = entity(124)
Ent2 = entity(56)
Vec = vec(0)

axis(Ent1, Vec, Ent2, Vec)
axis(Ent1, Vec, Ent2, Vec, 1)
axis(Ent1, Vec, Ent2, Vec, 1, vec(1,1,1))

ballsocket(Ent1, Vec, Ent2)
ballsocket(Ent1, Vec, Ent2, 1)
ballsocket(Ent1, Vec, Ent2, vec(1), vec(2), vec(1))
ballsocket(Ent1, Vec, Ent2, vec(1), vec(2), vec(1), 1)

weldAng(Ent1, Vec, Ent2)

winch(1, Ent1, Vec, Ent2, Vec, 1)

hydraulic(2, Ent1, Vec, Ent2, Vec, 1)
hydraulic(3, Ent1, Vec, Ent2, Vec, 1, 1, "mat", 1, 1)
hydraulic(4, Ent1, Vec, Ent2, Vec, 1, 1, 1, "mat", 1, 1)

rope(5, Ent1, Vec, Ent2, Vec)
rope(6, Ent1, Vec, Ent2, Vec, 1, 1, "mat")
rope(7, Ent1, Vec, Ent2, Vec, 1, 1, "mat", 1)

Ent1:setLength(5, 2)

Ent1:setConstant(2, 1)
Ent1:setConstant(3, 1, 1)

Ent1:setDamping(4, 0)

slider(Ent1, Vec, Ent2, Vec)
slider(Ent1, Vec, Ent2, Vec, 1)

noCollide(Ent1, Ent2)
noCollideAll(Ent2, 0)

weld(Ent1, Ent2)

Ent1:constraintBreak("rope")
Ent1:constraintBreak("slider", Ent2)
Ent1:constraintBreak(world())
Ent1:constraintBreak()

interval(100)
``` 

I believe it uses every function. There were no errors, and running each chunk individually seems to work 👍 