### PR TITLE
Additional Turret Options

### DIFF
--- a/lua/entities/gmod_wire_turret.lua
+++ b/lua/entities/gmod_wire_turret.lua
@@ -150,11 +150,11 @@ function ENT:SetDamage( damage )
 end
 
 function ENT:SetBlastDamage( blastdamage )
-	self.blastdamage = math.Clamp( blastdamage, 0, GetConVar("wire_turret_blastdamage_max") )
+	self.blastdamage = math.Clamp( blastdamage, 0, GetConVar("wire_turret_blastdamage_max"):GetInt() )
 end
 
 function ENT:SetBlastRadius( blastradius )
-	self.blastradius = math.Clamp( blastradius, 0, GetConVar("wire_turret_blastradius_max") )
+	self.blastradius = math.Clamp( blastradius, 0, GetConVar("wire_turret_blastradius_max"):GetInt() )
 end
 
 function ENT:SetForce( force )

--- a/lua/entities/gmod_wire_turret.lua
+++ b/lua/entities/gmod_wire_turret.lua
@@ -202,4 +202,18 @@ function ENT:Setup(delay, damage, force, sound, numbullets, spread, blastdamage,
 	self:SetNumBullets(numbullets)
 end
 
+-- Legacy Support
+function ENT:Setup(delay, damage, force, sound, numbullets, spread, tracer, tracernum)
+	self:SetForce(force)
+	self:SetDelay(delay)
+	self:SetSound(sound)
+	self:SetDamage(damage)
+	self:SetSpread(spread)
+	self:SetTracer(tracer)
+	self:SetTraceNum(tracernum)
+	self:SetNumBullets(numbullets)
+end
+
 duplicator.RegisterEntityClass( "gmod_wire_turret", WireLib.MakeWireEnt, "Data", "delay", "damage", "force", "sound", "numbullets", "spread", "blastdamage", "blastradius", "tracer", "tracernum" )
+-- Legacy Support
+duplicator.RegisterEntityClass( "gmod_wire_turret", WireLib.MakeWireEnt, "Data", "delay", "damage", "force", "sound", "numbullets", "spread", "tracer", "tracernum" )

--- a/lua/entities/gmod_wire_turret.lua
+++ b/lua/entities/gmod_wire_turret.lua
@@ -202,18 +202,6 @@ function ENT:Setup(delay, damage, force, sound, numbullets, spread, blastdamage,
 	self:SetNumBullets(numbullets)
 end
 
--- Legacy Support
-function ENT:Setup(delay, damage, force, sound, numbullets, spread, tracer, tracernum)
-	self:SetForce(force)
-	self:SetDelay(delay)
-	self:SetSound(sound)
-	self:SetDamage(damage)
-	self:SetSpread(spread)
-	self:SetTracer(tracer)
-	self:SetTraceNum(tracernum)
-	self:SetNumBullets(numbullets)
-end
-
 duplicator.RegisterEntityClass( "gmod_wire_turret", WireLib.MakeWireEnt, "Data", "delay", "damage", "force", "sound", "numbullets", "spread", "blastdamage", "blastradius", "tracer", "tracernum" )
 -- Legacy Support
 duplicator.RegisterEntityClass( "gmod_wire_turret", WireLib.MakeWireEnt, "Data", "delay", "damage", "force", "sound", "numbullets", "spread", "tracer", "tracernum" )

--- a/lua/entities/gmod_wire_turret.lua
+++ b/lua/entities/gmod_wire_turret.lua
@@ -150,11 +150,11 @@ function ENT:SetDamage( damage )
 end
 
 function ENT:SetBlastDamage( blastdamage )
-	self.blastdamage = math.Clamp( blastdamage, 0, 100 )
+	self.blastdamage = math.Clamp( blastdamage, 0, GetConVar("wire_turret_blastdamage_max") )
 end
 
 function ENT:SetBlastRadius( blastradius )
-	self.blastradius = math.Clamp( blastradius, 0, 500 )
+	self.blastradius = math.Clamp( blastradius, 0, GetConVar("wire_turret_blastradius_max") )
 end
 
 function ENT:SetForce( force )

--- a/lua/wire/stools/turret.lua
+++ b/lua/wire/stools/turret.lua
@@ -7,13 +7,15 @@ Sound( "NPC_FloorTurret.Shoot" )
 
 -- Add Default Language translation (saves adding it to the txt files)
 if CLIENT then
-	language.Add( "tool.wire_turret.name", "Turret" )
+	language.Add( "tool.wire_turret.name", "Extended Turret" )
 	language.Add( "tool.wire_turret.desc", "Throws bullets at things" )
 
 	language.Add( "Tool_wire_turret_spread", "Bullet Spread" )
 	language.Add( "Tool_wire_turret_numbullets", "Bullets per Shot" )
 	language.Add( "Tool_wire_turret_force", "Bullet Force" )
 	language.Add( "Tool_wire_turret_sound", "Shoot Sound" )
+	language.Add( "Tool_wire_turret_blastdamage", "Blast Damage" )
+	language.Add( "Tool_wire_turret_blastradius", "Blast Radius" )
 	language.Add( "Tool_wire_turret_tracernum", "Tracer Every x Bullets:" )
 	TOOL.Information = { { name = "left", text = "Create/Update " .. TOOL.Name } }
 end
@@ -25,6 +27,8 @@ TOOL.ClientConVar = {
 	force 		= 1,
 	sound 		= 0,
 	damage 		= 10,
+	blastdamage = 0,
+	blastradius = 0,
 	spread 		= 0,
 	numbullets	= 1,
 	automatic	= 1,
@@ -39,7 +43,7 @@ TOOL.GetGhostMin = function() return -2 end
 if SERVER then
 	function TOOL:GetConVars()
 		return self:GetClientNumber("delay"), self:GetClientNumber("damage"), self:GetClientNumber("force"), self:GetClientInfo("sound"),
-			self:GetClientNumber("numbullets"), self:GetClientNumber("spread"), self:GetClientInfo("tracer"), self:GetClientNumber("tracernum")
+			self:GetClientNumber("numbullets"), self:GetClientNumber("spread"), self:GetClientNumber("blastdamage"), self:GetClientNumber("blastradius"), self:GetClientInfo("tracer"), self:GetClientNumber("tracernum")
 	end
 end
 

--- a/lua/wire/stools/turret.lua
+++ b/lua/wire/stools/turret.lua
@@ -61,6 +61,11 @@ function TOOL:GetModel()
 	return ValidTurretModels[model] and model or "models/weapons/w_smg1.mdl"
 end
 
+-- Add convar values for the controversial blast functions
+-- To all wire devs/contributors, why do we hardlock values instead of making them convars?
+CreateConVar( "wire_turret_blastdamage_max", "100", {FCVAR_ARCHIVE, FCVAR_REPLICATED, FCVAR_NOTIFY}, "Sets the max damage that Turrets can have in regards to Blast Damage, This hardlocks the menu slider and actual damage" .. "0 to Disable", 0, 99999)
+CreateConVar( "wire_turret_blastradius_max", "500", {FCVAR_ARCHIVE, FCVAR_REPLICATED, FCVAR_NOTIFY}, "Sets the max radius that Turrets can have in regards to Blast Radius, This hardlocks the menu slider and actual damage" .. "0 to Disable", 0, 99999)
+
 function TOOL.BuildCPanel( CPanel )
 	WireToolHelpers.MakePresetControl(CPanel, "wire_turret")
 
@@ -95,6 +100,8 @@ function TOOL.BuildCPanel( CPanel )
 	end
 	CPanel:NumSlider("#Damage", "wire_turret_damage", 0, 100, 0)
 	CPanel:NumSlider("#Tool_wire_turret_spread", "wire_turret_spread", 0, 1.0, 2)
+	CPanel:NumSlider("#Tool_wire_turret_blastdamage", "wire_turret_spread", 0, GetConVar("wire_turret_blastdamage_max"), 0)
+	CPanel:NumSlider("#Tool_wire_turret_blastdradius", "wire_turret_spread", 0, GetConVar("wire_turret_blastradius_max"), 0)
 	CPanel:NumSlider("#Tool_wire_turret_force", "wire_turret_force", 0, 500, 1)
 
 	-- The delay between shots.

--- a/lua/wire/stools/turret.lua
+++ b/lua/wire/stools/turret.lua
@@ -100,8 +100,8 @@ function TOOL.BuildCPanel( CPanel )
 	end
 	CPanel:NumSlider("#Damage", "wire_turret_damage", 0, 100, 0)
 	CPanel:NumSlider("#Tool_wire_turret_spread", "wire_turret_spread", 0, 1.0, 2)
-	CPanel:NumSlider("#Tool_wire_turret_blastdamage", "wire_turret_spread", 0, GetConVar("wire_turret_blastdamage_max"), 0)
-	CPanel:NumSlider("#Tool_wire_turret_blastdradius", "wire_turret_spread", 0, GetConVar("wire_turret_blastradius_max"), 0)
+	CPanel:NumSlider("#Tool_wire_turret_blastdamage", "wire_turret_spread", 0, GetConVar("wire_turret_blastdamage_max"):GetInt(), 0)
+	CPanel:NumSlider("#Tool_wire_turret_blastdradius", "wire_turret_spread", 0, GetConVar("wire_turret_blastradius_max"):GetInt(), 0)
 	CPanel:NumSlider("#Tool_wire_turret_force", "wire_turret_force", 0, 500, 1)
 
 	-- The delay between shots.


### PR DESCRIPTION
had this on my drive for awhile and figure I'd throw this out if any dev/contributor is interested in this.

tl;dr adds blast radius and blast damage to turrets so people don't have to cheese wire explosives/prop explosives for their bullet based contraptions

Adds Convars for these values since 1) hardlocking/clamping like the damage was done is gross and 2) it's a pretty uh, *colorful function*

Not immediately suggesting to merge this as I haven't figured out how to maintain old turrets as this would modify it's inputs, and even duplicating it would mean having to redo turrets just based on whether servers had this. I GUESS that would be the best option if their is no alternative

obligatory not a good coder probably has some unncessary/dogshit code in it but lmao i tried