### PR TITLE
Add stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,29 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '43 19 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-issue-stale: -1
+        days-before-issue-close: -1
+        stale-pr-message: "This pull request has been marked as stale as there haven't been any changes in the past month. It will be closed in 15 days."
+        stale-pr-label: "Stale"
+        days-before-pr-stale: 30
+        days-before-pr-close: 45


### PR DESCRIPTION
Add workflow to mark old PRs as ` Stale ` after 30d. They will be closed in 45d.

There's been an increase in completely dead PRs recently, with #2307, #2337, #2356, #2367, #2431, #2435, #2439 and #2451.
I will close these manually for now but this workflow should be used for the future to nudge people to work on their PRs or to close it if they can't/won't.

Not sure if this will require action on your part @Anticept, but making a pr if anyone has issues w/ this

*:p github not making this branch on my fork*