### PR TITLE
Harden E2 tables against abuse

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -43,9 +43,17 @@ function E2Lib.setSubMaterial(ent, index, material)
 	duplicator.StoreEntityModifier(ent, "submaterial", { ["SubMaterialOverride_"..index] = material })
 end
 
+local weak_values = { __type = "kv" }
+
 -- Returns a default e2 table.
 function E2Lib.newE2Table()
-	return {n={},ntypes={},s={},stypes={},size=0}
+	return setmetatable({
+		n = setmetatable({}, weak_values),
+		ntypes = setmetatable({}, weak_values),
+		s = setmetatable({}, weak_values),
+		stypes = setmetatable({}, weak_values),
+		size = 0
+	}, { __type = "v" })
 end
 
 -- Returns a cloned table of the variable given if it is a table.

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -43,7 +43,7 @@ function E2Lib.setSubMaterial(ent, index, material)
 	duplicator.StoreEntityModifier(ent, "submaterial", { ["SubMaterialOverride_"..index] = material })
 end
 
-local weak_values = { __mode = "kv" }
+local weak_kv, weak_values = { __mode = "kv" }, { __mode = "v" }
 
 -- Returns a default e2 table.
 function E2Lib.newE2Table()
@@ -53,7 +53,7 @@ function E2Lib.newE2Table()
 		s = setmetatable({}, weak_values),
 		stypes = setmetatable({}, weak_values),
 		size = 0
-	}, { __mode = "v" })
+	}, weak_values)
 end
 
 -- Returns a cloned table of the variable given if it is a table.

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -43,7 +43,7 @@ function E2Lib.setSubMaterial(ent, index, material)
 	duplicator.StoreEntityModifier(ent, "submaterial", { ["SubMaterialOverride_"..index] = material })
 end
 
-local weak_values = { __type = "kv" }
+local weak_values = { __mode = "kv" }
 
 -- Returns a default e2 table.
 function E2Lib.newE2Table()
@@ -53,7 +53,7 @@ function E2Lib.newE2Table()
 		s = setmetatable({}, weak_values),
 		stypes = setmetatable({}, weak_values),
 		size = 0
-	}, { __type = "v" })
+	}, { __mode = "v" })
 end
 
 -- Returns a cloned table of the variable given if it is a table.

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -43,17 +43,9 @@ function E2Lib.setSubMaterial(ent, index, material)
 	duplicator.StoreEntityModifier(ent, "submaterial", { ["SubMaterialOverride_"..index] = material })
 end
 
-local weak_kv, weak_values = { __mode = "kv" }, { __mode = "v" }
-
--- Returns a default e2 table.
+-- Returns a default e2 table instance.
 function E2Lib.newE2Table()
-	return setmetatable({
-		n = setmetatable({}, weak_values),
-		ntypes = setmetatable({}, weak_values),
-		s = setmetatable({}, weak_values),
-		stypes = setmetatable({}, weak_values),
-		size = 0
-	}, weak_values)
+	return { n = {}, ntypes = {}, s = {}, stypes = {}, size = 0 }
 end
 
 -- Returns a cloned table of the variable given if it is a table.

--- a/lua/entities/gmod_wire_expression2/core/globalvars.lua
+++ b/lua/entities/gmod_wire_expression2/core/globalvars.lua
@@ -111,9 +111,11 @@ end
 
 local string_sub = string.sub
 e2function table gtable:toTable()
-	local ret = {n={},ntypes={},s={},stypes={},size=0,istable=true,depth=0}
+	local ret = {n={},ntypes={},s={},stypes={},size=0}
 
 	for k,v in pairs( this ) do
+		if self.prf > e2_tickquota then error("perf", 0) end
+
 		local typeid, index = string_sub( k, 1,1 ), string_sub( k, 2 )
 		if typeid == "x" then
 			typeid = string_sub( k, 1,3 )
@@ -123,9 +125,9 @@ e2function table gtable:toTable()
 		ret.s[index] = v
 		ret.stypes[index] = typeid
 		ret.size = ret.size + 1
-	end
 
-	self.prf = self.prf + ret.size / 3
+		self.prf = self.prf + 3
+	end
 
 	return ret
 end
@@ -159,9 +161,7 @@ registerCallback("postinit",function()
 				if (val) then -- If the var exists
 					return val -- return it
 				end
-				local default = v[2]
-				if istable(default) then default = table.Copy(default) end
-				return default
+				return E2Lib.fixDefault(v[2])
 			end
 			local function setf( self, args )
 				local op1, op2, op3 = args[2], args[3], args[4]
@@ -186,9 +186,7 @@ registerCallback("postinit",function()
 					rv1[v[1]..rv2] = nil
 					return val
 				end
-				local default = v[2]
-				if istable(default) then default = table.Copy(default) end
-				return default
+				return E2Lib.fixDefault(v[2])
 			end)
 
 			-- gRemoveAll*() - Remove all variables of a type in the player's non-shared table
@@ -340,15 +338,11 @@ registerCallback("postinit",function()
 			if (self.data.gvars.shared == 1) then
 				local ret = GetVar(self.data.gvars.group,gvars.shared,rv1,v[1])
 				if (ret) then return ret end
-				local default = v[2][2]
-				if istable(default) then default = table.Copy(default) end
-				return default
+				return E2Lib.fixDefault(v[2][2])
 			else
 				local ret = GetVar(self.data.gvars.group,gvars[self.uid],rv1,v[1])
 				if (ret) then return ret end
-				local default = v[2][2]
-				if istable(default) then default = table.Copy(default) end
-				return default
+				return E2Lib.fixDefault(v[2][2])
 			end
 		end)
 
@@ -372,15 +366,11 @@ registerCallback("postinit",function()
 			if (self.data.gvars.shared == 1) then
 				local ret = GetVar(self.data.gvars.group,gvars.shared,rv1,v[1])
 				if (ret) then return ret end
-				local default = v[2][2]
-				if istable(default) then default = table.Copy(default) end
-				return default
+				return E2Lib.fixDefault(v[2][2])
 			else
 				local ret = GetVar(self.data.gvars.group,gvars[self.uid],rv1,v[1])
 				if (ret) then return ret end
-				local default = v[2][2]
-				if istable(default) then default = table.Copy(default) end
-				return default
+				return E2Lib.fixDefault(v[2][2])
 			end
 		end)
 
@@ -405,9 +395,7 @@ registerCallback("postinit",function()
 					end
 				end
 			end
-			local default = v[2][2]
-			if istable(default) then default = table.Copy(default) end
-			return default
+			return E2Lib.fixDefault(v[2][2])
 		end)
 
 		-- gDelete*(N) (same as gDelete*(N:toString()))
@@ -431,9 +419,7 @@ registerCallback("postinit",function()
 					end
 				end
 			end
-			local default = v[2][2]
-			if istable(default) then default = table.Copy(default) end
-			return default
+			return E2Lib.fixDefault(v[2][2])
 		end)
 
 		__e2setcost(5)

--- a/lua/entities/gmod_wire_expression2/core/globalvars.lua
+++ b/lua/entities/gmod_wire_expression2/core/globalvars.lua
@@ -111,7 +111,7 @@ end
 
 local string_sub = string.sub
 e2function table gtable:toTable()
-	local ret = {n={},ntypes={},s={},stypes={},size=0}
+	local ret = E2Lib.newE2Table()
 
 	for k,v in pairs( this ) do
 		if self.prf > e2_tickquota then error("perf", 0) end

--- a/lua/entities/gmod_wire_expression2/core/globalvars.lua
+++ b/lua/entities/gmod_wire_expression2/core/globalvars.lua
@@ -315,9 +315,6 @@ registerCallback("postinit",function()
 	end
 
 	for k,v in pairs( types ) do
-
-		__e2setcost(8)
-
 		-- gSet*(S,*)
 		registerFunction("gSet"..k,"s"..v[1],"",function(self,args)
 			local op1, op2 = args[2], args[3]
@@ -329,7 +326,7 @@ registerCallback("postinit",function()
 				if (!gvars[self.uid][self.data.gvars.group]) then gvars[self.uid][self.data.gvars.group] = {} end
 				gvars[self.uid][self.data.gvars.group][v[1]..rv1] = rv2
 			end
-		end)
+		end, 8, nil, { deprecated = true })
 
 		-- gGet*(S)
 		registerFunction("gGet"..k,"s",v[1],function(self,args)
@@ -344,7 +341,7 @@ registerCallback("postinit",function()
 				if (ret) then return ret end
 				return E2Lib.fixDefault(v[2][2])
 			end
-		end)
+		end, 8, nil, { deprecated = true })
 
 		-- gSet*(N,*) (same as gSet*(N:toString(),*)
 		registerFunction("gSet"..k,"n"..v[1],"",function(self,args)
@@ -357,7 +354,7 @@ registerCallback("postinit",function()
 				if (!gvars[self.uid][self.data.gvars.group]) then gvars[self.uid][self.data.gvars.group] = {} end
 				gvars[self.uid][self.data.gvars.group][v[1]..tostring(rv1)] = rv2
 			end
-		end)
+		end, 8, nil, { deprecated = true })
 
 		-- gGet*(N) (same as gGet*(N:toString()))
 		registerFunction("gGet"..k,"n",v[1],function(self,args)
@@ -372,7 +369,7 @@ registerCallback("postinit",function()
 				if (ret) then return ret end
 				return E2Lib.fixDefault(v[2][2])
 			end
-		end)
+		end, 8, nil, { deprecated = true })
 
 		-- gDelete*(S)
 		registerFunction("gDelete"..k,"s",v[1],function(self,args)
@@ -396,7 +393,7 @@ registerCallback("postinit",function()
 				end
 			end
 			return E2Lib.fixDefault(v[2][2])
-		end)
+		end, 8, nil, { deprecated = true })
 
 		-- gDelete*(N) (same as gDelete*(N:toString()))
 		registerFunction("gDelete"..k,"n",v[1],function(self,args)
@@ -420,9 +417,7 @@ registerCallback("postinit",function()
 				end
 			end
 			return E2Lib.fixDefault(v[2][2])
-		end)
-
-		__e2setcost(5)
+		end, 8, nil, { deprecated = true })
 
 		-- gDeleteAll*()
 		registerFunction("gDeleteAll"..k,"","",function(self,args)
@@ -432,7 +427,7 @@ registerCallback("postinit",function()
 					v = nil
 				end
 			end
-		end)
+		end, 5, nil, { deprecated = true })
 	end
 
 end)

--- a/lua/entities/gmod_wire_expression2/core/table.lua
+++ b/lua/entities/gmod_wire_expression2/core/table.lua
@@ -347,7 +347,7 @@ end
 
 -- Clones a table while adding prf for the size of the clone.
 local function prf_clone(self, tbl, lookup)
-	local copy = {}
+	local copy, before = {}, collectgarbage("count")
 
 	lookup = lookup or {}
 	lookup[tbl] = copy
@@ -372,6 +372,11 @@ local function prf_clone(self, tbl, lookup)
 			prf = prf + opcost -- simple assign operation
 			copy[k] = v
 		end
+	end
+
+	local mem = (collectgarbage("count") - before)
+	if mem > 0 then
+		self.prf = self.prf + mem * 20
 	end
 
 	self.prf = self.prf + prf
@@ -591,6 +596,7 @@ end
 __e2setcost(10)
 
 e2function table table:clone()
+	self.prf = self.prf + this.size * 2
 	return prf_clone(self, this)
 end
 

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -433,7 +433,8 @@ function ENT:ResetContext()
 		-- reduces all the opcounters based on the time passed since 
 		-- the last time the chip was reset or errored
 		-- waiting up to 30s before resetting results in a 0.1 multiplier 
-		resetPrfMult = math.max(0.1,(30 - (CurTime() - self.lastResetOrError)) / 30)
+		local passed = CurTime() - self.lastResetOrError
+		resetPrfMult = math.max(0.1, (30 - passed) / 30)
 	end
 	self.lastResetOrError = CurTime()
 
@@ -601,8 +602,18 @@ function ENT:Reset()
 	-- prevent E2 from executing anything
 	self.context.resetting = true
 
+	if self.context.timebench > e2_timequota then -- Abusing reset() at end of excution.
+		-- E2Lib.abuse(self.player)
+		self:Error("Expression 2 (" .. self.name .. "): tick quota exceeded", "tick quota exceeded")
+		return
+	end
+
 	-- reset the chip in the next tick
-	timer.Simple(0, function() if IsValid(self) then self:Setup(self.original, self.inc_files) end end)
+	timer.Simple(0, function()
+		if IsValid(self) then
+			self:Setup(self.original, self.inc_files)
+		end
+	end)
 end
 
 function ENT:TriggerInput(key, value)

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -602,12 +602,6 @@ function ENT:Reset()
 	-- prevent E2 from executing anything
 	self.context.resetting = true
 
-	if self.context.timebench > e2_timequota then -- Abusing reset() at end of excution.
-		-- E2Lib.abuse(self.player)
-		self:Error("Expression 2 (" .. self.name .. "): tick quota exceeded", "tick quota exceeded")
-		return
-	end
-
 	-- reset the chip in the next tick
 	timer.Simple(0, function()
 		if IsValid(self) then


### PR DESCRIPTION
* Make tables have weak keys/values (Hopefully fixing some memleak issues where non-used tables were kept?)
* Add memory usage to perf inside of table clone operations (using `collectgarbage`)
* Add base 2 opcost per item in `t:clone()`
* Add quota check inside of `gtable:toTable()`
* Use `E2Lib.fixDefault` in gtable
* Prevent abusing `reset()` to avoid tick quota

## Todo:
- [ ] Invoke the wrath of `E2Lib.abuse` on people abusing the `reset()` exploit ?
- [ ] Ensure no problems are caused by e2 tables having weak keyvalues (and weak values on the base table)