### PR TITLE
Add vehicle exit and entry events for E2

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -765,6 +765,14 @@ e2function vector entity:aabbWorldSize()
 end
 /******************************************************************************/
 
+hook.Add("PlayerLeaveVehicle","Exp2RunOnLeaveVehicle",function(ply, vehicle)
+	E2Lib.triggerEvent("playerLeftVehicle", { ply, vehicle } )
+end)
+
+hook.Add("PlayerEnteredVehicle","Exp2RunOnEnteredVehicle", function(ply, vehicle)
+	E2Lib.triggerEvent("playerEnteredVehicle", { ply, vehicle })
+end)
+
 __e2setcost(5)
 
 e2function entity entity:driver()
@@ -784,6 +792,9 @@ e2function string toString(entity ent)
 end
 
 e2function string entity:toString() = e2function string toString(entity ent)
+
+E2Lib.registerEvent("playerLeftVehicle", { "e", "e" })
+E2Lib.registerEvent("playerEnteredVehicle", { "e", "e" })
 
 /******************************************************************************/
 


### PR DESCRIPTION
As it states on the tin, I've always thought that E2 was missing the ability to detect when players have entered or left a vehicle and with the recent addition of events, it seems like the time is fitting!

Added support for both

```
event playerEnteredVehicle(P:entity, V:entity) {
    print(P, V)
}

event playerLeftVehicle(P:entity, V:entity) {
    print(P, V)
}
```
