### PR TITLE
Add event argument names for better autocompletion

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -1338,12 +1338,12 @@ function Compiler:InstrEVENT(args)
 	for k, arg in ipairs(event.args) do
 		if not hargs[k] then
 			-- TODO: Maybe this should be a warning so that events can have extra params added without breaking old code?
-			self:Error("Event '" .. name .. "' missing argument #" .. k .. " of type " .. tps_pretty(arg["type"]), args)
+			self:Error("Event '" .. name .. "' missing argument #" .. k .. " of type " .. tps_pretty(arg.type), args)
 		end
 
 		local param_id = wire_expression_types[hargs[k][2]][1]
 
-		if arg["type"] ~= param_id then
+		if arg.type ~= param_id then
 			self:Error("Mismatched event argument: " .. tps_pretty(arg) .. " vs " .. tps_pretty(param_id), args)
 		end
 	end
@@ -1359,7 +1359,7 @@ function Compiler:InstrEVENT(args)
 	self:PushScope()
 		for k, arg in ipairs(event.args) do
 			if not hargs[k][4] --[[ ensure it isn't a discard parameter ]] then
-				self:SetLocalVariableType(hargs[k][1], arg["type"], args, true)
+				self:SetLocalVariableType(hargs[k][1], arg.type, args, true)
 			end
 		end
 

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -1335,14 +1335,15 @@ function Compiler:InstrEVENT(args)
 		self:Error("Event '" .. name .. "' does not take arguments (" .. table.concat(extra_arg_types, ", ") .. ")", args)
 	end
 
-	for k, typeid in ipairs(event.args) do
+	for k, arg in ipairs(event.args) do
 		if not hargs[k] then
 			-- TODO: Maybe this should be a warning so that events can have extra params added without breaking old code?
-			self:Error("Event '" .. name .. "' missing argument #" .. k .. " of type " .. tps_pretty(typeid), args)
+			self:Error("Event '" .. name .. "' missing argument #" .. k .. " of type " .. tps_pretty(arg["type"]), args)
 		end
 
 		local param_id = wire_expression_types[hargs[k][2]][1]
-		if typeid ~= param_id then
+
+		if arg["type"] ~= param_id then
 			self:Error("Mismatched event argument: " .. tps_pretty(arg) .. " vs " .. tps_pretty(param_id), args)
 		end
 	end
@@ -1356,9 +1357,9 @@ function Compiler:InstrEVENT(args)
 	local OldScopes = self:SaveScopes()
 	self:InitScope()
 	self:PushScope()
-		for k, typeid in ipairs(event.args) do
+		for k, arg in ipairs(event.args) do
 			if not hargs[k][4] --[[ ensure it isn't a discard parameter ]] then
-				self:SetLocalVariableType(hargs[k][1], typeid, args, true)
+				self:SetLocalVariableType(hargs[k][1], arg["type"], args, true)
 			end
 		end
 

--- a/lua/entities/gmod_wire_expression2/core/chat.lua
+++ b/lua/entities/gmod_wire_expression2/core/chat.lua
@@ -166,7 +166,7 @@ end
 
 -- Ply: entity, Msg: string, Team: number
 E2Lib.registerEvent("chat", {
-	{ "Player",		"e" },
-	{ "Message",	"s" },
-	{ "Team",		"n" }
+	{ "Player", "e" },
+	{ "Message", "s" },
+	{ "Team", "n" }
 })

--- a/lua/entities/gmod_wire_expression2/core/chat.lua
+++ b/lua/entities/gmod_wire_expression2/core/chat.lua
@@ -165,4 +165,4 @@ e2function number entity:lastSaidTeam()
 end
 
 -- Ply: entity, Msg: string, Team: number
-E2Lib.registerEvent("chat", { "e", "s", "n" })
+E2Lib.registerEvent("chat", { "Player:e", "Message:n", "Team:n" })

--- a/lua/entities/gmod_wire_expression2/core/chat.lua
+++ b/lua/entities/gmod_wire_expression2/core/chat.lua
@@ -165,4 +165,8 @@ e2function number entity:lastSaidTeam()
 end
 
 -- Ply: entity, Msg: string, Team: number
-E2Lib.registerEvent("chat", { "Player:e", "Message:n", "Team:n" })
+E2Lib.registerEvent("chat", {
+	{ "Player",		"e" },
+	{ "Message",	"s" },
+	{ "Team",		"n" }
+})

--- a/lua/entities/gmod_wire_expression2/core/core.lua
+++ b/lua/entities/gmod_wire_expression2/core/core.lua
@@ -269,7 +269,7 @@ e2function string inputClkName()
 end
 
 E2Lib.registerEvent("input", {
-	{ "Key", "s" }
+	{ "InputName", "s" }
 })
 
 -- This MUST be the first destruct hook!

--- a/lua/entities/gmod_wire_expression2/core/core.lua
+++ b/lua/entities/gmod_wire_expression2/core/core.lua
@@ -268,7 +268,9 @@ e2function string inputClkName()
 	return self.triggerinput or ""
 end
 
-E2Lib.registerEvent("input", {"Key:s"})
+E2Lib.registerEvent("input", {
+	{ "Key", "s" }
+})
 
 -- This MUST be the first destruct hook!
 registerCallback("destruct", function(self)
@@ -294,7 +296,9 @@ e2function number last()
 end
 
 -- number (whether it is being reset or just removed)
-E2Lib.registerEvent("removed", { "Reason:n" })
+E2Lib.registerEvent("removed", {
+	{ "Reason", "n" }
+})
 
 -- dupefinished()
 -- Made by Divran

--- a/lua/entities/gmod_wire_expression2/core/core.lua
+++ b/lua/entities/gmod_wire_expression2/core/core.lua
@@ -297,7 +297,7 @@ end
 
 -- number (whether it is being reset or just removed)
 E2Lib.registerEvent("removed", {
-	{ "Reason", "n" }
+	{ "Resetting", "n" }
 })
 
 -- dupefinished()

--- a/lua/entities/gmod_wire_expression2/core/core.lua
+++ b/lua/entities/gmod_wire_expression2/core/core.lua
@@ -268,7 +268,7 @@ e2function string inputClkName()
 	return self.triggerinput or ""
 end
 
-E2Lib.registerEvent("input", {"s"})
+E2Lib.registerEvent("input", {"Key:s"})
 
 -- This MUST be the first destruct hook!
 registerCallback("destruct", function(self)
@@ -294,7 +294,7 @@ e2function number last()
 end
 
 -- number (whether it is being reset or just removed)
-E2Lib.registerEvent("removed", { "n" })
+E2Lib.registerEvent("removed", { "Reason:n" })
 
 -- dupefinished()
 -- Made by Divran

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -2,6 +2,7 @@ AddCSLuaFile()
 
 E2Lib = {
 	Env = {
+		---@type { name: string, args: { [1]: string, [2]: string }[], constructor: fun(t: table)?, destructor: fun(t: table)?, listening: table<userdata, boolean> }
 		Events = {}
 	}
 }

--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -793,8 +793,14 @@ end
 
 e2function string entity:toString() = e2function string toString(entity ent)
 
-E2Lib.registerEvent("playerLeftVehicle", { "Player:e", "Vehicle:e" })
-E2Lib.registerEvent("playerEnteredVehicle", { "Player:e", "Vehicle:e" })
+E2Lib.registerEvent("playerLeftVehicle", {
+	{ "Player", "e" },
+	{ "Vehicle", "e" },
+})
+E2Lib.registerEvent("playerEnteredVehicle", {
+	{ "Player", "e" },
+	{ "Vehicle", "e" },
+})
 
 /******************************************************************************/
 

--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -793,8 +793,8 @@ end
 
 e2function string entity:toString() = e2function string toString(entity ent)
 
-E2Lib.registerEvent("playerLeftVehicle", { "e", "e" })
-E2Lib.registerEvent("playerEnteredVehicle", { "e", "e" })
+E2Lib.registerEvent("playerLeftVehicle", { "Player:e", "Vehicle:e" })
+E2Lib.registerEvent("playerEnteredVehicle", { "Player:e", "Vehicle:e" })
 
 /******************************************************************************/
 

--- a/lua/entities/gmod_wire_expression2/core/files.lua
+++ b/lua/entities/gmod_wire_expression2/core/files.lua
@@ -477,10 +477,10 @@ net.Receive("wire_expression2_file_list", function(netlen, ply)
 end )
 
 E2Lib.registerEvent("fileErrored", {
-	{ "Filename",	"s" },
-	{ "Status",		"n" }
+	{ "FilePath", "s" },
+	{ "Status", "n" }
 })
 E2Lib.registerEvent("fileLoaded", {
-	{ "Filename",	"s" },
-	{ "Data",		"s" }
+	{ "FilePath", "s" },
+	{ "Data", "s" }
 })

--- a/lua/entities/gmod_wire_expression2/core/files.lua
+++ b/lua/entities/gmod_wire_expression2/core/files.lua
@@ -476,5 +476,11 @@ net.Receive("wire_expression2_file_list", function(netlen, ply)
 	run_on.list.dir = ""
 end )
 
-E2Lib.registerEvent("fileErrored", {"s", "n"})
-E2Lib.registerEvent("fileLoaded", {"Filename:s", "Data:s"})
+E2Lib.registerEvent("fileErrored", {
+	{ "Filename",	"s" },
+	{ "Status",		"n" }
+})
+E2Lib.registerEvent("fileLoaded", {
+	{ "Filename",	"s" },
+	{ "Data",		"s" }
+})

--- a/lua/entities/gmod_wire_expression2/core/files.lua
+++ b/lua/entities/gmod_wire_expression2/core/files.lua
@@ -477,4 +477,4 @@ net.Receive("wire_expression2_file_list", function(netlen, ply)
 end )
 
 E2Lib.registerEvent("fileErrored", {"s", "n"})
-E2Lib.registerEvent("fileLoaded", {"s", "s"})
+E2Lib.registerEvent("fileLoaded", {"Filename:s", "Data:s"})

--- a/lua/entities/gmod_wire_expression2/core/http.lua
+++ b/lua/entities/gmod_wire_expression2/core/http.lua
@@ -134,13 +134,13 @@ end )
 
 -- error: string, url: string
 E2Lib.registerEvent("httpErrored", {
-	{ "Error",		"s" },
-	{ "Url",		"s" }
+	{ "Error", "s" },
+	{ "Url", "s" }
 })
 
 -- body: string, size: number, url: string
 E2Lib.registerEvent("httpLoaded", {
-	{ "Body",		"s" },
-	{ "Size",		"s" },
-	{ "Url",		"s" }
+	{ "Body", "s" },
+	{ "Size", "n" },
+	{ "Url", "s" }
 })

--- a/lua/entities/gmod_wire_expression2/core/http.lua
+++ b/lua/entities/gmod_wire_expression2/core/http.lua
@@ -133,7 +133,14 @@ registerCallback( "destruct", function( self )
 end )
 
 -- error: string, url: string
-E2Lib.registerEvent("httpErrored", { "Error:s", "Url:s" })
+E2Lib.registerEvent("httpErrored", {
+	{ "Error",		"s" },
+	{ "Url",		"s" }
+})
 
 -- body: string, size: number, url: string
-E2Lib.registerEvent("httpLoaded", { "Body:s", "Size:n", "Url:s" })
+E2Lib.registerEvent("httpLoaded", {
+	{ "Body",		"s" },
+	{ "Size",		"s" },
+	{ "Url",		"s" }
+})

--- a/lua/entities/gmod_wire_expression2/core/http.lua
+++ b/lua/entities/gmod_wire_expression2/core/http.lua
@@ -133,7 +133,7 @@ registerCallback( "destruct", function( self )
 end )
 
 -- error: string, url: string
-E2Lib.registerEvent("httpErrored", { "s", "s" })
+E2Lib.registerEvent("httpErrored", { "Error:s", "Url:s" })
 
 -- body: string, size: number, url: string
-E2Lib.registerEvent("httpLoaded", { "s", "n", "s" })
+E2Lib.registerEvent("httpLoaded", { "Body:s", "Size:n", "Url:s" })

--- a/lua/entities/gmod_wire_expression2/core/init.lua
+++ b/lua/entities/gmod_wire_expression2/core/init.lua
@@ -184,9 +184,37 @@ function E2Lib.registerEvent(name, args, constructor, destructor)
 	name = name:sub(1, 1):lower() .. name:sub(2)
 	-- assert(not E2Lib.Env.Events[name], "Possible addon conflict: Trying to override existing E2 event '" .. name .. "'")
 
+	local extended_args = {}
+	
+	if args != nil then
+		for k, v in pairs(args) do
+
+			local exploded = string.Explode(":", v)
+
+			local a_type = ""
+			local a_placeholder = ""
+
+			if #exploded <= 1 then
+				a_type = exploded[1]
+				a_placeholder = a_type:upper()
+			else
+				a_type = exploded[2]
+				a_placeholder = exploded[1]
+
+				-- Ensure that event arg's placeholder start with uppercase letter
+				a_placeholder = a_placeholder:sub(1,1):upper() .. a_placeholder:sub(2)
+			end
+
+			extended_args[k] = {
+				["type"] = a_type,
+				["placeholder"] = a_placeholder
+			}
+		end
+	end
+
 	E2Lib.Env.Events[name] = {
 		name = name,
-		args = args or {},
+		args = extended_args,
 
 		constructor = constructor,
 		destructor = destructor,

--- a/lua/entities/gmod_wire_expression2/core/init.lua
+++ b/lua/entities/gmod_wire_expression2/core/init.lua
@@ -187,10 +187,25 @@ function E2Lib.registerEvent(name, args, constructor, destructor)
 	
 	if args ~= nil then
 		for k, v in pairs(args) do
-			extended_args[k] = {
-				["placeholder"] = v[1]:match("(%u%w*)"),
-				["type"]		= v[2]:match("(%w+)")
-			}
+
+			if type(v) == "string" then -- backwards compatibility for old method without name
+				extended_args[k] = {
+					placeholder = v:upper() .. k,
+					type = v
+				}
+			else
+				extended_args[k] = {
+					placeholder = assert(v[1], "Expected name for event argument #" .. k),
+					type = assert(v[2], "Expected type for event argument #" .. k)
+				}
+			end
+			
+			--[[
+				extended_args[k] = {
+					["placeholder"] = v[1]:match("(%u%w*)"),
+					["type"]		= v[2]:match("(%w+)")
+				}
+			]]
 		end
 	end
 

--- a/lua/entities/gmod_wire_expression2/core/init.lua
+++ b/lua/entities/gmod_wire_expression2/core/init.lua
@@ -181,33 +181,15 @@ end
 ---@param destructor fun(self: table)? # Destructor to run when E2 stops listening to this event. Passes E2 context
 function E2Lib.registerEvent(name, args, constructor, destructor)
 	-- Ensure event starts with lowercase letter
-	name = name:sub(1, 1):lower() .. name:sub(2)
 	-- assert(not E2Lib.Env.Events[name], "Possible addon conflict: Trying to override existing E2 event '" .. name .. "'")
 
 	local extended_args = {}
 	
-	if args != nil then
+	if args ~= nil then
 		for k, v in pairs(args) do
-
-			local exploded = string.Explode(":", v)
-
-			local a_type = ""
-			local a_placeholder = ""
-
-			if #exploded <= 1 then
-				a_type = exploded[1]
-				a_placeholder = a_type:upper()
-			else
-				a_type = exploded[2]
-				a_placeholder = exploded[1]
-
-				-- Ensure that event arg's placeholder start with uppercase letter
-				a_placeholder = a_placeholder:sub(1,1):upper() .. a_placeholder:sub(2)
-			end
-
 			extended_args[k] = {
-				["type"] = a_type,
-				["placeholder"] = a_placeholder
+				["placeholder"] = v[1]:match("(%u%w*)"),
+				["type"]		= v[2]:match("(%w+)")
 			}
 		end
 	end

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -417,7 +417,7 @@ e2function string keyClkPressedBind()
 end
 
 -- Player, Key, UporDown, KeyBind
-E2Lib.registerEvent("keyPressed", {"e", "s", "n", "s"})
+E2Lib.registerEvent("keyPressed", {"Player:e", "Key:s", "Direction:n", "KeyBind:s"})
 
 -- Use Support --
 
@@ -442,7 +442,7 @@ e2function entity useClk()
 	return self.data.runByUse or NULL
 end
 
-E2Lib.registerEvent("chipUsed", { "e" }, function(self)
+E2Lib.registerEvent("chipUsed", { "Player:e" }, function(self)
 	self.entity:SetUseType(SIMPLE_USE)
 	self.entity.Use = function(selfent, activator)
 		self.entity:ExecuteEvent("chipUsed", { activator })
@@ -737,8 +737,8 @@ e2function entity lastDisconnectedPlayer()
 	return lastLeft
 end
 
-E2Lib.registerEvent("playerConnected", { "e" })
-E2Lib.registerEvent("playerDisconnected", { "e" })
+E2Lib.registerEvent("playerConnected", { "Player:e" })
+E2Lib.registerEvent("playerDisconnected", { "Player:e" })
 
 ----- Death+Respawns by Vurv -----
 
@@ -889,8 +889,8 @@ e2function entity lastSpawnedPlayer()
 	return RespawnList.last.ply
 end
 
-E2Lib.registerEvent("playerSpawn", { "e" })
-E2Lib.registerEvent("playerDeath", { "e", "e", "e" })
+E2Lib.registerEvent("playerSpawn", { "Player:e" })
+E2Lib.registerEvent("playerDeath", { "Victim:e", "Inflictor:e", "Attacker:e" })
 
 
 --******************************************--

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -418,10 +418,10 @@ end
 
 -- Player, Key, UporDown, KeyBind
 E2Lib.registerEvent("keyPressed", {
-	{ "Player",		"e" },
-	{ "Key",		"s" },
-	{ "Direction",	"n" },
-	{ "KeyBind",	"s" }
+	{ "Player", "e" },
+	{ "Key", "s" },
+	{ "Down", "n" },
+	{ "KeyBind", "s" }
 })
 
 -- Use Support --
@@ -743,10 +743,10 @@ e2function entity lastDisconnectedPlayer()
 end
 
 E2Lib.registerEvent("playerConnected", {
-	{ "Player",		"e" }
+	{ "Player", "e" }
 })
 E2Lib.registerEvent("playerDisconnected", {
-	{ "Player",		"e" }
+	{ "Player", "e" }
 })
 
 ----- Death+Respawns by Vurv -----
@@ -899,13 +899,13 @@ e2function entity lastSpawnedPlayer()
 end
 
 E2Lib.registerEvent("playerSpawn", {
-	{ "Player",		"e" }
+	{ "Player", "e" }
 })
 
 E2Lib.registerEvent("playerDeath", {
-	{ "Victim",		"e" },
-	{ "Inflictor",	"e" },
-	{ "Attacker",	"e" }
+	{ "Victim", "e" },
+	{ "Inflictor", "e" },
+	{ "Attacker", "e" }
 })
 
 

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -417,7 +417,12 @@ e2function string keyClkPressedBind()
 end
 
 -- Player, Key, UporDown, KeyBind
-E2Lib.registerEvent("keyPressed", {"Player:e", "Key:s", "Direction:n", "KeyBind:s"})
+E2Lib.registerEvent("keyPressed", {
+	{ "Player",		"e" },
+	{ "Key",		"s" },
+	{ "Direction",	"n" },
+	{ "KeyBind",	"s" }
+})
 
 -- Use Support --
 
@@ -442,7 +447,7 @@ e2function entity useClk()
 	return self.data.runByUse or NULL
 end
 
-E2Lib.registerEvent("chipUsed", { "Player:e" }, function(self)
+E2Lib.registerEvent("chipUsed", { { "Player", "e" } }, function(self)
 	self.entity:SetUseType(SIMPLE_USE)
 	self.entity.Use = function(selfent, activator)
 		self.entity:ExecuteEvent("chipUsed", { activator })
@@ -737,8 +742,12 @@ e2function entity lastDisconnectedPlayer()
 	return lastLeft
 end
 
-E2Lib.registerEvent("playerConnected", { "Player:e" })
-E2Lib.registerEvent("playerDisconnected", { "Player:e" })
+E2Lib.registerEvent("playerConnected", {
+	{ "Player",		"e" }
+})
+E2Lib.registerEvent("playerDisconnected", {
+	{ "Player",		"e" }
+})
 
 ----- Death+Respawns by Vurv -----
 
@@ -889,8 +898,15 @@ e2function entity lastSpawnedPlayer()
 	return RespawnList.last.ply
 end
 
-E2Lib.registerEvent("playerSpawn", { "Player:e" })
-E2Lib.registerEvent("playerDeath", { "Victim:e", "Inflictor:e", "Attacker:e" })
+E2Lib.registerEvent("playerSpawn", {
+	{ "Player",		"e" }
+})
+
+E2Lib.registerEvent("playerDeath", {
+	{ "Victim",		"e" },
+	{ "Inflictor",	"e" },
+	{ "Attacker",	"e" }
+})
 
 
 --******************************************--

--- a/lua/wire/client/text_editor/texteditor.lua
+++ b/lua/wire/client/text_editor/texteditor.lua
@@ -2166,7 +2166,11 @@ tbl[2] = function( self )
 	if self.ac_event or self.ac_directive_line then return end
 
 	local word = self:AC_GetCurrentWord()
-	if word and word ~= "" and word:sub(1,1) == "_" then
+
+	local line, char = self.Caret[1], self.Caret[2]
+	local after = self.Rows[line]:sub(char, char + 1) -- Slicing with two chars because you can for some reason trigger autocomplete with the caret before the first character.
+
+	if word and word ~= "" and word:sub(1,1) == "_" and not after:find(":", 1, true) then -- Don't show constant if it's _: (discard was used)
 		return FindConstants( self, word )
 	end
 end
@@ -2527,14 +2531,12 @@ local function FindEvents(self, word)
 			-- Cache display signature
 			if not data.display then
 
-				local concated_args = {}
-
+				local arg_types = {}
 				for k, v in ipairs(data.args) do
-					concated_args[k] = v.type
+					arg_types[k] = v.type
 				end
 
-				--data.display = name .. "(" .. table.concat(data.args["type"], ",") .. ")"
-				data.display = name .. "(" .. table.concat(concated_args, ", ").. ")"
+				data.display = name .. "(" .. table.concat(arg_types, ", ").. ")"
 			end
 
 			local function repl(self, editor)

--- a/lua/wire/client/text_editor/texteditor.lua
+++ b/lua/wire/client/text_editor/texteditor.lua
@@ -2506,14 +2506,6 @@ function EDITOR:AC_Check( notimer )
 	self:AC_SetVisible( false )
 end
 
-local function concat_args(args_table, where, cend)
-	local res = ""
-	for k, v in ipairs(args_table) do
-		res = res .. v[where] .. cend
-	end
-	return res:sub(1, -#cend - 1) -- remove the last "cend" (ie. ", ")
-end
-
 local function FindEvents(self, word)
 	local suggestions, count = {}, 0
 	for name, data in pairs(E2Lib.Env.Events) do
@@ -2524,18 +2516,25 @@ local function FindEvents(self, word)
 			if not data.replacement then
 				local buf = {}
 				for k, event_arg in ipairs(data.args) do
-					local ty = event_arg["type"]
+					local ty = event_arg.type
 					local tyname = wire_expression_types2[ty][1]:lower()
 					if tyname == "normal" then tyname = "number" end
-					buf[k] = event_arg["placeholder"] .. ":" .. tyname
+					buf[k] = ( event_arg.placeholder or ty:upper() ) .. ":" .. tyname
 				end
 				data.replacement = name .. "(" .. table.concat(buf, ", ") .. ") {"
 			end
 
 			-- Cache display signature
 			if not data.display then
+
+				local concated_args = {}
+
+				for k, v in ipairs(data.args) do
+					concated_args[k] = v.type
+				end
+
 				--data.display = name .. "(" .. table.concat(data.args["type"], ",") .. ")"
-				data.display = name .. "(" .. concat_args(data.args, "type", ",") .. ")"
+				data.display = name .. "(" .. table.concat(concated_args, ", ").. ")"
 			end
 
 			local function repl(self, editor)

--- a/lua/wire/client/text_editor/texteditor.lua
+++ b/lua/wire/client/text_editor/texteditor.lua
@@ -2506,6 +2506,14 @@ function EDITOR:AC_Check( notimer )
 	self:AC_SetVisible( false )
 end
 
+local function concat_args(args_table, where, cend)
+	local res = ""
+	for k, v in ipairs(args_table) do
+		res = res .. v[where] .. cend
+	end
+	return res:sub(1, -#cend - 1) -- remove the last "cend" (ie. ", ")
+end
+
 local function FindEvents(self, word)
 	local suggestions, count = {}, 0
 	for name, data in pairs(E2Lib.Env.Events) do
@@ -2515,17 +2523,19 @@ local function FindEvents(self, word)
 			-- Cache replacement string
 			if not data.replacement then
 				local buf = {}
-				for k, ty in ipairs(data.args) do
+				for k, event_arg in ipairs(data.args) do
+					local ty = event_arg["type"]
 					local tyname = wire_expression_types2[ty][1]:lower()
 					if tyname == "normal" then tyname = "number" end
-					buf[k] = ty:upper() .. ":" .. tyname
+					buf[k] = event_arg["placeholder"] .. ":" .. tyname
 				end
-				data.replacement = name .. "(" .. table.concat(buf, ", ") .. ")"
+				data.replacement = name .. "(" .. table.concat(buf, ", ") .. ") {"
 			end
 
 			-- Cache display signature
 			if not data.display then
-				data.display = name .. "(" .. table.concat(data.args, ",") .. ")"
+				--data.display = name .. "(" .. table.concat(data.args["type"], ",") .. ")"
+				data.display = name .. "(" .. concat_args(data.args, "type", ",") .. ")"
 			end
 
 			local function repl(self, editor)


### PR DESCRIPTION
So I tested the new events system of @Vurv78 , it's very cool but I found a little problem.

For example, if we write playerDeath using autocomplete, this is what it looks like:
![confusing](https://user-images.githubusercontent.com/78973002/222004597-01f04a39-c597-4e54-95a7-a2beafd0bbd5.png)
The automatically added arguments all have the same name, which creates an error, and can be confusing.

So I made it possible to add placeholder names automatically in the registerEvent function:
```lua
E2Lib.registerEvent("chat", { "Player:e", "Message:n", "Team:n" })
```
And now it looks like this in the E2 editor:
![e2_fix](https://user-images.githubusercontent.com/78973002/222005873-3a97740d-52c0-46fa-bc07-155c28457f70.gif)