### PR TITLE
Fix too long font EGP E2 errors

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
@@ -245,6 +245,7 @@ end
 ----------------------------
 e2function void wirelink:egpFont( number index, string font )
 	if (!EGP:IsAllowed( self, this )) then return end
+    if #font > 30 then return end
 	local bool, k, v = EGP:HasObject( this, index )
 	if (bool) then
 		if (EGP:EditObject( v, { font = font } )) then EGP:DoAction( this, self, "SendObject", v ) Update(self,this) end
@@ -253,6 +254,7 @@ end
 
 e2function void wirelink:egpFont( number index, string font, number size )
 	if (!EGP:IsAllowed( self, this )) then return end
+    if #font > 30 then return end
 	local bool, k, v = EGP:HasObject( this, index )
 	if (bool) then
 		if (EGP:EditObject( v, { font = font, size = size } )) then EGP:DoAction( this, self, "SendObject", v ) Update(self,this) end

--- a/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
@@ -245,7 +245,7 @@ end
 ----------------------------
 e2function void wirelink:egpFont( number index, string font )
 	if (!EGP:IsAllowed( self, this )) then return end
-	if #font > 30 then return end
+	if #font > 30 then return self:throw("Font string is too long!", nil) end
 	local bool, k, v = EGP:HasObject( this, index )
 	if (bool) then
 		if (EGP:EditObject( v, { font = font } )) then EGP:DoAction( this, self, "SendObject", v ) Update(self,this) end
@@ -254,7 +254,7 @@ end
 
 e2function void wirelink:egpFont( number index, string font, number size )
 	if (!EGP:IsAllowed( self, this )) then return end
-	if #font > 30 then return end
+	if #font > 30 then return self:throw("Font string is too long!", nil) end
 	local bool, k, v = EGP:HasObject( this, index )
 	if (bool) then
 		if (EGP:EditObject( v, { font = font, size = size } )) then EGP:DoAction( this, self, "SendObject", v ) Update(self,this) end

--- a/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
@@ -245,7 +245,7 @@ end
 ----------------------------
 e2function void wirelink:egpFont( number index, string font )
 	if (!EGP:IsAllowed( self, this )) then return end
-    if #font > 30 then return end
+	if #font > 30 then return end
 	local bool, k, v = EGP:HasObject( this, index )
 	if (bool) then
 		if (EGP:EditObject( v, { font = font } )) then EGP:DoAction( this, self, "SendObject", v ) Update(self,this) end
@@ -254,7 +254,7 @@ end
 
 e2function void wirelink:egpFont( number index, string font, number size )
 	if (!EGP:IsAllowed( self, this )) then return end
-    if #font > 30 then return end
+	if #font > 30 then return end
 	local bool, k, v = EGP:HasObject( this, index )
 	if (bool) then
 		if (EGP:EditObject( v, { font = font, size = size } )) then EGP:DoAction( this, self, "SendObject", v ) Update(self,this) end


### PR DESCRIPTION
surface.CreateFont can't take fonts longer than 30 characters, if it does it will error.
This allows players to spam clientside errors.

Another option would be erroring the chip rather than returning, either works.

Example:
![image](https://user-images.githubusercontent.com/69946827/231468559-b049e966-aa64-46f5-a9dc-2893a5e69c3a.png)

```lua
@name 
@inputs EGP:wirelink
@persist Str:string

interval(100)

Str += "b"

EGP:egpText(1,"x",vec2(1,1))
EGP:egpFont(1,Str)
```