### PR TITLE
Fix globalvars table after EmergencyRamClear

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/globalvars.lua
+++ b/lua/entities/gmod_wire_expression2/core/globalvars.lua
@@ -9,6 +9,8 @@ gvars.safe = {} -- Safe from hacking using gTableSafe
 
 hook.Add("Wire_EmergencyRamClear","gvars_EmergencyRamClear",function()
 	gvars = {}
+	gvars.shared = {}
+	gvars.safe = {}
 end)
 
 ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Seems like this was forgotten when the hook was introduced