### PR TITLE
Account for nil value in EGP Spawning

### DIFF
--- a/lua/wire/stools/egp.lua
+++ b/lua/wire/stools/egp.lua
@@ -106,8 +106,11 @@ if (SERVER) then
 			ent:SetTranslucent(self:GetClientNumber("translucent")~=0)
 		elseif (Type == 2) then -- HUD
 			ent = SpawnHUD( ply, trace.HitPos + trace.HitNormal * 0.25, trace.HitNormal:Angle() + Angle(90,0,0) )
+			if not IsValid(ent) then return end
 		elseif (Type == 3) then -- Emitter
 			ent = SpawnEmitter( ply, trace.HitPos + trace.HitNormal * 0.25, trace.HitNormal:Angle() + Angle(90,0,0) )
+			if not IsValid(ent) then return end
+
 			ent:SetUseRT(self:GetClientNumber("emitter_usert")~=0)
 		end
 


### PR DESCRIPTION
Seems that the EGP tool didn't account for a possible nil value if convars disallowed the spawning of either egp hud or egp emitter.

The errors that they produced:
```
EGP HUD:
[wire] addons/wire/lua/wire/stools/egp.lua:126: attempt to index local 'ent' (a nil value)
  1. LeftClick - addons/wire/lua/wire/stools/egp.lua:126
   2. unknown - gamemodes/sandbox/entities/weapons/gmod_tool/shared.lua:220
```

``` 
EGP Emitter:
[wire] addons/wire/lua/wire/stools/egp.lua:111: attempt to index local 'ent' (a nil value)
  1. LeftClick - addons/wire/lua/wire/stools/egp.lua:111
   2. unknown - gamemodes/sandbox/entities/weapons/gmod_tool/shared.lua:220
```