### PR TITLE
Stop the editors autocomplete from running endlessly

### DIFF
--- a/lua/wire/client/text_editor/texteditor.lua
+++ b/lua/wire/client/text_editor/texteditor.lua
@@ -2416,7 +2416,7 @@ tbl.RunOnCheck = function( self )
 		local word = self:AC_GetCurrentWord()
 		if word and word:match("^%u") then
 			-- Writing a variable. Wait for user to stop writing to avoid calling the tokenizer a ton of times.
-			timer.Create("E2_AC_SaveVariable", 1, 0.6, function()
+			timer.Create("E2_AC_SaveVariable", 0.6, 1, function()
 				if self and self.AC_SaveVariables then
 					self:AC_SaveVariables()
 				end


### PR DESCRIPTION
Seems like someone accidentally switched around the two arguments and made the timer run forever 