### PR TITLE
Fix #2552 and restore E2 saving

### DIFF
--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -4,14 +4,6 @@ include('shared.lua')
 
 DEFINE_BASECLASS("base_wire_entity")
 
--- This makes E2s not save using garry's workshop save
--- Until someone can find the cause of the crashes, leave this in here
-local old = gmsave.ShouldSaveEntity
-function gmsave.ShouldSaveEntity( ent, ... )
-	if ent:GetClass() == "gmod_wire_expression2" then return false end
-	return old( ent, ... )
-end
-
 e2_softquota = nil
 e2_hardquota = nil
 e2_tickquota = nil

--- a/lua/entities/gmod_wire_spu/init.lua
+++ b/lua/entities/gmod_wire_spu/init.lua
@@ -42,6 +42,7 @@ function ENT:Initialize()
     self.SoundSources[i]:SetParent(self)
     self.SoundSources[i]:SetModel("models/cheeze/wires/nano_math.mdl")
     self.SoundSources[i]:SetPos(self:GetPos())
+	self.SoundSources[i].DoNotDuplicate = true
     self.SoundSources[i]:Spawn()
     self.SoundSources[i]:PhysicsDestroy()
   end

--- a/lua/entities/gmod_wire_trigger_entity.lua
+++ b/lua/entities/gmod_wire_trigger_entity.lua
@@ -3,6 +3,7 @@ AddCSLuaFile()
 ENT.Base = "base_anim"
 ENT.Name = "Wire Trigger Entity"
 ENT.Author = "mitterdoo"
+ENT.DoNotDuplicate = true
 
 function ENT:Initialize()
 


### PR DESCRIPTION
Fixes #2552. I haven't checked if there are any other occurrences of this so if you know any other wire entities that use a hidden helper prop, let me know. This fix should also apply to duplications, as per its design, which doesn't seem to have any issues either.

Restores the ability to save E2 using `gmsave`. If you *really* don't want this I'll revert it, but I haven't encountered a single issue from it. It just works. For the record, `gmsave` uses the same functions as the duplicator, which means that any issues with duplication would propagate to saving, and vice versa.

Sorry, also, for the PR spam.