### PR TITLE
Fix gmod_wire_spu NULL error

### DIFF
--- a/lua/entities/gmod_wire_spu/init.lua
+++ b/lua/entities/gmod_wire_spu/init.lua
@@ -111,6 +111,7 @@ function ENT:ResendCache(player)
   timer.Simple(0.4+math.random()*1.2,
     function()
       if not self:IsValid() then return end
+      if not IsValid(ply) then return end
 
       self.Cache:Flush()
       for address,value in pairs(self.Memory) do

--- a/lua/entities/gmod_wire_spu/init.lua
+++ b/lua/entities/gmod_wire_spu/init.lua
@@ -111,7 +111,7 @@ function ENT:ResendCache(player)
   timer.Simple(0.4+math.random()*1.2,
     function()
       if not self:IsValid() then return end
-      if not IsValid(ply) then return end
+      if not IsValid(player) then return end
 
       self.Cache:Flush()
       for address,value in pairs(self.Memory) do


### PR DESCRIPTION
Adds a simple IsValid check to make sure that the player entity still exists when the timer runs