### PR TITLE
Fix the holoemitter tool errors

### DIFF
--- a/lua/wire/stools/holoemitter.lua
+++ b/lua/wire/stools/holoemitter.lua
@@ -56,7 +56,7 @@ function TOOL:Reload()
 	end
 end
 
-function TOOL:BuildCPanel( panel )
+function TOOL.BuildCPanel( panel )
 	WireToolHelpers.MakePresetControl(panel, "wire_holoemitter")
 	WireDermaExts.ModelSelect(panel, "wire_holoemitter_model", list.Get( "Wire_Misc_Tools_Models" ), 1)
 

--- a/lua/wire/stools/holoemitter.lua
+++ b/lua/wire/stools/holoemitter.lua
@@ -5,12 +5,13 @@ if CLIENT then
 	language.Add( "tool.wire_holoemitter.name", "Holographic Emitter Tool (Wire)" )
 	language.Add( "tool.wire_holoemitter.desc", "The emitter required for holographic projections" )
 	language.Add( "Tool.wire_holoemitter.fadetime", "Max fade time" )
-	language.Add( "Tool.wire_holoemitter.fadetime.description", "Client side max fade time. Set to 0 to never fade (WARNING: May cause FPS issues if set to 0 or too high).")
+	language.Add( "Tool.wire_holoemitter.fadetime.description", "Client side max fade time. Set to 0 to never fade (WARNING: May cause FPS issues if set to 0 or too high)." )
 	language.Add( "Tool.wire_holoemitter.keeplatestdot", "Keep latest dot indefinitely (prevent fading)." )
 	TOOL.Information = {
 		{ name = "left_0", stage = 0, text = "Create emitter" },
 		{ name = "right_0", stage = 0, text = "Link emitter to any entity (makes it draw local to that entity instead)" },
 		{ name = "right_1", stage = 1, text = "Link to entity (click the same holoemitter again to unlink it)" },
+		{ name = "reload", stage = 1, text = "Cancel linking" },
 	}
 end
 WireToolSetup.BaseLang()
@@ -47,17 +48,15 @@ function TOOL:RightClick( trace )
 	return true
 end
 
-function TOOL.Reload(trace)
-	self.Linked = nil
-	self:SetStage(0)
-
-	if IsValid(trace.Entity) and trace.Entity:GetClass() == "gmod_wire_holoemitter" then
-		ent:LinkToGrid( nil )
-		return true
+function TOOL:Reload(trace)
+	if (self:GetStage() == 1) then
+		self:SetStage(0)
+		self.Linked = nil
+		return false
 	end
 end
 
-function TOOL.BuildCPanel( panel )
+function TOOL:BuildCPanel( panel )
 	WireToolHelpers.MakePresetControl(panel, "wire_holoemitter")
 	WireDermaExts.ModelSelect(panel, "wire_holoemitter_model", list.Get( "Wire_Misc_Tools_Models" ), 1)
 

--- a/lua/wire/stools/holoemitter.lua
+++ b/lua/wire/stools/holoemitter.lua
@@ -48,8 +48,8 @@ function TOOL:RightClick( trace )
 	return true
 end
 
-function TOOL:Reload(trace)
-	if (self:GetStage() == 1) then
+function TOOL:Reload()
+	if self:GetStage() == 1 then
 		self:SetStage(0)
 		self.Linked = nil
 		return false


### PR DESCRIPTION
The Reload method wasn't set properly so it'd cause shared errors whenever it was being used, the code itself in the method was also outdated and not valid anymore so i've improved it too.