### PR TITLE
`wire_rt_screen` improvements

### DIFF
--- a/lua/entities/gmod_wire_rt_screen.lua
+++ b/lua/entities/gmod_wire_rt_screen.lua
@@ -178,15 +178,14 @@ if CLIENT then
         end
 
         if name == "" then
-            MsgN("ImprovedRTCameras: got empty name (typically happens at entity creation).")
+            MsgN("WireRTScreen: got empty name (typically happens at entity creation).")
             return nil
         end
 
         local path = "improvedrt_screen/monitor_"..name..".vmt"
 
         if not file.Exists("materials/"..path, "GAME") then
-            MsgN("ImprovedRTCameras: material "..path.." does not exist on client for some reason!")
-            MsgN("Screen would not be rendered")
+            MsgN("WireRTScreen: material "..path.." does not exist on client for some reason! Screen will not be rendered")
             return nil
         end
 

--- a/lua/entities/gmod_wire_rt_screen.lua
+++ b/lua/entities/gmod_wire_rt_screen.lua
@@ -116,7 +116,10 @@ if SERVER then
 
         local Inputs = table.Copy(InputsTable)
 
-        for _, tbl in pairs(GetMaterialParameters(self:GetScreenMaterial())) do
+		local matParams = GetMaterialParameters(self:GetScreenMaterial())
+		if not matParams then return end
+
+        for _, tbl in pairs(matParams) do
             table.insert(Inputs, tbl.WireName.." ["..tbl.WireType.."]")
         end
 
@@ -239,13 +242,15 @@ if CLIENT then
         local tex2 = material:GetString("!targettex2")
         if tex2 ~= nil then material:SetTexture(tex2, rt) end
 
-        for mtl_param, tbl in pairs(self.MaterialParamsDesc) do
-            --print(self.MaterialParams[tbl.WireName])
+		if self.MaterialParamsDesc then
+			for mtl_param, tbl in pairs(self.MaterialParamsDesc) do
+				--print(self.MaterialParams[tbl.WireName])
 
-            local value = self.MaterialParams[tbl.WireName] or tbl.Default
+				local value = self.MaterialParams[tbl.WireName] or tbl.Default
 
-            material[tbl.MaterialFn](material, mtl_param, value)
-        end
+				material[tbl.MaterialFn](material, mtl_param, value)
+			end
+		end
 
         local xraw = 256 / monitor.RatioX
         local yraw = 256


### PR DESCRIPTION
This PR fixes an error that occures when a player enters invalid materials as rt screen material such as `wire_rt_screen_screenmaterial test1347134`. This PR also improves the console messages to properly display the right addon, before it'd show "ImprovedRTCameras" which is now replaced with "WireRTScreen"

The entire file is a mismash of tabs and spaces indentation, i didn't touch those as it'll mess up the PR diff view, feel free to fix those before merging if needed.