### PR TITLE
Fix noCollide

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
@@ -656,7 +656,7 @@ end
 --- Nocollides <ent1> to <ent2>
 [deprecated]
 e2function void noCollide(entity ent1, entity ent2)
-	noCollideCreate(ent1, ent2)
+	noCollideCreate(self, ent1, ent2)
 end
 
 e2function void entity:noCollideAll(state)


### PR DESCRIPTION
It's easy; if we break the deprecated functions, users will *have* to upgrade!