### PR TITLE
EGP Fixes

### DIFF
--- a/lua/entities/gmod_wire_egp/lib/egplib/parenting.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/parenting.lua
@@ -76,6 +76,19 @@ local function getCenter( data )
 end
 EGP.ParentingFuncs.getCenter = getCenter
 
+-- Uses the output of GetGlobalPos instead.
+local function getCenterFromPos(data)
+	local centerx, centery = 0, 0
+	local vertices = data.vertices
+	local n = #vertices
+	for i, v in ipairs(vertices) do
+		centerx = centerx + v.x
+		centery = centery + v.y
+	end
+	return centerx / n, centery / n
+end
+EGP.ParentingFuncs.getCenterFromPos = getCenterFromPos
+
 -- (returns true if obj has vertices, false if not, followed by the new position data)
 function EGP:GetGlobalPos( Ent, index )
 	local bool, k, v = self:HasObject( Ent, index )

--- a/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
@@ -442,3 +442,18 @@ function EGP:EGPCursor( this, ply )
 
 	return ReturnFailure( this )
 end
+
+function EGP.WorldToLocal(egp, object, x, y)
+	local _, realpos = EGP:GetGlobalPos(egp, object.index)
+	x, y = x - realpos.x, y - realpos.y
+	
+	local theta = math.rad(realpos.angle + object.angle or 0)
+	if theta ~= 0 then
+		local cos_theta, sin_theta = math.cos(theta), math.sin(theta)
+		x, y =
+			x * cos_theta - y * sin_theta,
+			y * cos_theta + x * sin_theta
+	end
+	
+	return x, y
+end

--- a/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
@@ -447,7 +447,7 @@ function EGP.WorldToLocal(egp, object, x, y)
 	local _, realpos = EGP:GetGlobalPos(egp, object.index)
 	x, y = x - realpos.x, y - realpos.y
 	
-	local theta = math.rad(realpos.angle + object.angle or 0)
+	local theta = math.rad(realpos.angle)
 	if theta ~= 0 then
 		local cos_theta, sin_theta = math.cos(theta), math.sin(theta)
 		x, y =

--- a/lua/entities/gmod_wire_egp/lib/objects/box.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/box.lua
@@ -24,7 +24,7 @@ Obj.DataStreamInfo = function( self )
 	table.Merge( tbl, { angle = self.angle } )
 	return tbl
 end
-function Obj:Contains(x, y, egp)
+function Obj:Contains(egp, x, y)
 	x, y = EGP.WorldToLocal(egp, self, x, y)
 	
 	local w, h = self.w / 2, self.h / 2

--- a/lua/entities/gmod_wire_egp/lib/objects/box.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/box.lua
@@ -24,16 +24,21 @@ Obj.DataStreamInfo = function( self )
 	table.Merge( tbl, { angle = self.angle } )
 	return tbl
 end
-function Obj:Contains(point)
-	local theta = math.rad(point.angle + self.angle)
+function Obj:Contains(point, this)
+	local _, realpos = EGP:GetGlobalPos(this, self.index)
+	local x, y = point.x - realpos.x, point.y - realpos.y
+	
+	local theta = math.rad(realpos.angle + self.angle)
 	if theta ~= 0 then
 		local cos_theta, sin_theta = math.cos(theta), math.sin(theta)
-		point.x, point.y =
-			point.x * cos_theta - point.y * sin_theta,
-			point.y * cos_theta + point.x * sin_theta
+		x, y =
+			x * cos_theta - y * sin_theta,
+			y * cos_theta + x * sin_theta
 	end
 	
 	local w, h = self.w / 2, self.h / 2
-	return -w <= point.x and point.x <= w and
-	       -h <= point.y and point.y <= h
+	if this.TopLeft then x, y = x - w, y - h end
+	
+	return -w <= x and x <= w and
+	       -h <= y and y <= h
 end

--- a/lua/entities/gmod_wire_egp/lib/objects/box.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/box.lua
@@ -24,20 +24,11 @@ Obj.DataStreamInfo = function( self )
 	table.Merge( tbl, { angle = self.angle } )
 	return tbl
 end
-function Obj:Contains(point, this)
-	local _, realpos = EGP:GetGlobalPos(this, self.index)
-	local x, y = point.x - realpos.x, point.y - realpos.y
-	
-	local theta = math.rad(realpos.angle + self.angle)
-	if theta ~= 0 then
-		local cos_theta, sin_theta = math.cos(theta), math.sin(theta)
-		x, y =
-			x * cos_theta - y * sin_theta,
-			y * cos_theta + x * sin_theta
-	end
+function Obj:Contains(x, y, egp)
+	x, y = EGP.WorldToLocal(egp, self, x, y)
 	
 	local w, h = self.w / 2, self.h / 2
-	if this.TopLeft then x, y = x - w, y - h end
+	if egp.TopLeft then x, y = x - w, y - h end
 	
 	return -w <= x and x <= w and
 	       -h <= y and y <= h

--- a/lua/entities/gmod_wire_egp/lib/objects/circle.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/circle.lua
@@ -48,7 +48,8 @@ Obj.DataStreamInfo = function( self )
 	table.Merge( tbl, { angle = self.angle, fidelity = self.fidelity } )
 	return tbl
 end
-function Obj:Contains(point)
-	local x, y = point.x / self.w, point.y / self.h
+function Obj:Contains(point, this)
+	local _, realpos = EGP:GetGlobalPos(this, self.index)
+	local x, y = (point.x - realpos.x) / self.w, (point.y - realpos.y) / self.h
 	return x * x + y * y <= 1
 end

--- a/lua/entities/gmod_wire_egp/lib/objects/circle.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/circle.lua
@@ -48,8 +48,9 @@ Obj.DataStreamInfo = function( self )
 	table.Merge( tbl, { angle = self.angle, fidelity = self.fidelity } )
 	return tbl
 end
-function Obj:Contains(point, this)
-	local _, realpos = EGP:GetGlobalPos(this, self.index)
-	local x, y = (point.x - realpos.x) / self.w, (point.y - realpos.y) / self.h
+function Obj:Contains(x, y, egp)
+	-- Just do this directly since angle doesn't affect circles
+	local _, realpos = EGP:GetGlobalPos(egp, self.index)
+	x, y = (x - realpos.x) / self.w, (y - realpos.y) / self.h
 	return x * x + y * y <= 1
 end

--- a/lua/entities/gmod_wire_egp/lib/objects/circle.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/circle.lua
@@ -48,7 +48,7 @@ Obj.DataStreamInfo = function( self )
 	table.Merge( tbl, { angle = self.angle, fidelity = self.fidelity } )
 	return tbl
 end
-function Obj:Contains(x, y, egp)
+function Obj:Contains(egp, x, y)
 	-- Just do this directly since angle doesn't affect circles
 	local _, realpos = EGP:GetGlobalPos(egp, self.index)
 	x, y = (x - realpos.x) / self.w, (y - realpos.y) / self.h

--- a/lua/entities/gmod_wire_egp/lib/objects/poly.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/poly.lua
@@ -55,8 +55,10 @@ end
 Obj.DataStreamInfo = function( self )
 	return { vertices = self.vertices, material = self.material, r = self.r, g = self.g, b = self.b, a = self.a, filtering = self.filtering, parent = self.parent }
 end
-function Obj:Contains(point)
+
+function Obj:Contains(point, this)
 	if #self.vertices < 3 then return false end
+	local _, realpos = EGP:GetGlobalPos(this, self.index)
 
 	-- To check whether a point is in the polygon, we check whether it's to the
 	-- 'inside' side of each edge. (If the polygon is counterclockwise then the
@@ -69,8 +71,8 @@ function Obj:Contains(point)
 		inside = function(a, b, c) return counterclockwise(b, a, c) end
 	end
 
-	for i = 1, #self.vertices - 1 do
-		if not inside(self.vertices[i], self.vertices[i + 1], point) then return false end
+	for i = 1, #realpos.vertices - 1 do
+		if not inside(realpos.vertices[i], realpos.vertices[i + 1], point) then return false end
 	end
-	return inside(self.vertices[#self.vertices], self.vertices[1], point)
+	return inside(realpos.vertices[#self.vertices], realpos.vertices[1], point)
 end

--- a/lua/entities/gmod_wire_egp/lib/objects/poly.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/poly.lua
@@ -56,9 +56,11 @@ Obj.DataStreamInfo = function( self )
 	return { vertices = self.vertices, material = self.material, r = self.r, g = self.g, b = self.b, a = self.a, filtering = self.filtering, parent = self.parent }
 end
 
-function Obj:Contains(point, this)
+function Obj:Contains(x, y, egp)
 	if #self.vertices < 3 then return false end
-	local _, realpos = EGP:GetGlobalPos(this, self.index)
+	-- Convert into {x,y} format that poly uses.
+	local point = { x = x, y = y }
+	local _, realpos = EGP:GetGlobalPos(egp, self.index)
 	local vertices = realpos.vertices
 
 	-- To check whether a point is in the polygon, we check whether it's to the

--- a/lua/entities/gmod_wire_egp/lib/objects/poly.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/poly.lua
@@ -59,20 +59,21 @@ end
 function Obj:Contains(point, this)
 	if #self.vertices < 3 then return false end
 	local _, realpos = EGP:GetGlobalPos(this, self.index)
+	local vertices = realpos.vertices
 
 	-- To check whether a point is in the polygon, we check whether it's to the
 	-- 'inside' side of each edge. (If the polygon is counterclockwise then the
 	-- inside is the left side; otherwise it's the right side.) This only works
 	-- for convex polygons, but so does `surface.drawPoly`.
 	local inside
-	if counterclockwise(self.vertices[1], self.vertices[2], self.vertices[3]) then
+	if counterclockwise(vertices[1], vertices[2], vertices[3]) then
 		inside = counterclockwise
 	else
 		inside = function(a, b, c) return counterclockwise(b, a, c) end
 	end
 
-	for i = 1, #realpos.vertices - 1 do
-		if not inside(realpos.vertices[i], realpos.vertices[i + 1], point) then return false end
+	for i = 1, #vertices - 1 do
+		if not inside(vertices[i], vertices[i + 1], point) then return false end
 	end
-	return inside(realpos.vertices[#self.vertices], realpos.vertices[1], point)
+	return inside(vertices[#vertices], vertices[1], point)
 end

--- a/lua/entities/gmod_wire_egp/lib/objects/poly.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/poly.lua
@@ -56,7 +56,7 @@ Obj.DataStreamInfo = function( self )
 	return { vertices = self.vertices, material = self.material, r = self.r, g = self.g, b = self.b, a = self.a, filtering = self.filtering, parent = self.parent }
 end
 
-function Obj:Contains(x, y, egp)
+function Obj:Contains(egp, x, y)
 	if #self.vertices < 3 then return false end
 	-- Convert into {x,y} format that poly uses.
 	local point = { x = x, y = y }

--- a/lua/entities/gmod_wire_egp/lib/objects/roundedbox.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/roundedbox.lua
@@ -52,20 +52,11 @@ Obj.DataStreamInfo = function( self )
 	table.Merge( tbl, { angle = self.angle, radius = self.radius, fidelity = self.fidelity } )
 	return tbl
 end
-function Obj:Contains(point, this)
-	local _, realpos = EGP:GetGlobalPos(this, self.index)
-	local x, y = point.x - realpos.x, point.y - realpos.y
-	
-	local theta = math.rad(realpos.angle + self.angle)
-	if theta ~= 0 then
-		local cos_theta, sin_theta = math.cos(theta), math.sin(theta)
-		x, y =
-			x * cos_theta - y * sin_theta,
-			y * cos_theta + x * sin_theta
-	end
+function Obj:Contains(x, y, egp)
+	x, y = EGP.WorldToLocal(egp, self, x, y)
 	
 	local w, h = self.w / 2, self.h / 2
-	if this.TopLeft then x, y = x - w, y - h end
+	if egp.TopLeft then x, y = x - w, y - h end
 	
 	local r = math.min(math.min(w, h), self.radius)
 	x, y = math.abs(x), math.abs(y)

--- a/lua/entities/gmod_wire_egp/lib/objects/roundedbox.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/roundedbox.lua
@@ -52,7 +52,7 @@ Obj.DataStreamInfo = function( self )
 	table.Merge( tbl, { angle = self.angle, radius = self.radius, fidelity = self.fidelity } )
 	return tbl
 end
-function Obj:Contains(x, y, egp)
+function Obj:Contains(egp, x, y)
 	x, y = EGP.WorldToLocal(egp, self, x, y)
 	
 	local w, h = self.w / 2, self.h / 2

--- a/lua/entities/gmod_wire_egp/lib/objects/roundedbox.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/roundedbox.lua
@@ -52,18 +52,23 @@ Obj.DataStreamInfo = function( self )
 	table.Merge( tbl, { angle = self.angle, radius = self.radius, fidelity = self.fidelity } )
 	return tbl
 end
-function Obj:Contains(point)
-	local theta = math.rad(point.angle + self.angle)
+function Obj:Contains(point, this)
+	local _, realpos = EGP:GetGlobalPos(this, self.index)
+	local x, y = point.x - realpos.x, point.y - realpos.y
+	
+	local theta = math.rad(realpos.angle + self.angle)
 	if theta ~= 0 then
 		local cos_theta, sin_theta = math.cos(theta), math.sin(theta)
-		point.x, point.y =
-			point.x * cos_theta - point.y * sin_theta,
-			point.y * cos_theta + point.x * sin_theta
+		x, y =
+			x * cos_theta - y * sin_theta,
+			y * cos_theta + x * sin_theta
 	end
 	
 	local w, h = self.w / 2, self.h / 2
+	if this.TopLeft then x, y = x - w, y - h end
+	
 	local r = math.min(math.min(w, h), self.radius)
-	local x, y = math.abs(point.x), math.abs(point.y)
+	x, y = math.abs(x), math.abs(y)
 	if x > w or y > h then return false end
 	x, y = x - w + r, y - h + r
 	if x < 0 or y < 0 then return true end

--- a/lua/entities/gmod_wire_egp/lib/objects/wedge.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/wedge.lua
@@ -54,17 +54,19 @@ Obj.DataStreamInfo = function( self )
 	table.Merge( tbl, { angle = self.angle, size = self.size, fidelity = self.fidelity } )
 	return tbl
 end
-function Obj:Contains(point)
-	local theta = math.rad(point.angle + self.angle)
+function Obj:Contains(point, this)
+	local _, realpos = EGP:GetGlobalPos(this, self.index)
+	local x, y = (point.x - realpos.x) / self.w, (point.y - realpos.y) / self.h
+	
+	local theta = math.rad(realpos.angle + self.angle)
 	if theta ~= 0 then
 		local cos_theta, sin_theta = math.cos(theta), math.sin(theta)
-		point.x, point.y =
-			point.x * cos_theta - point.y * sin_theta,
-			point.y * cos_theta + point.x * sin_theta
+		x, y =
+			x * cos_theta - y * sin_theta,
+			y * cos_theta + x * sin_theta
 	end
 	
-	local x, y = point.x / self.w, point.y / self.h
 	if x * x + y * y > 1 then return false end
-	local theta = math.deg(math.atan2(y, x))
+	theta = math.deg(math.atan2(y, x))
 	return theta <= -self.size or 0 <= theta
 end

--- a/lua/entities/gmod_wire_egp/lib/objects/wedge.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/wedge.lua
@@ -54,17 +54,9 @@ Obj.DataStreamInfo = function( self )
 	table.Merge( tbl, { angle = self.angle, size = self.size, fidelity = self.fidelity } )
 	return tbl
 end
-function Obj:Contains(point, this)
-	local _, realpos = EGP:GetGlobalPos(this, self.index)
-	local x, y = (point.x - realpos.x) / self.w, (point.y - realpos.y) / self.h
-	
-	local theta = math.rad(realpos.angle + self.angle)
-	if theta ~= 0 then
-		local cos_theta, sin_theta = math.cos(theta), math.sin(theta)
-		x, y =
-			x * cos_theta - y * sin_theta,
-			y * cos_theta + x * sin_theta
-	end
+function Obj:Contains(x, y, egp)
+	x, y = EGP.WorldToLocal(egp, self, x, y)
+	x, y = x / self.w, y / self.h
 	
 	if x * x + y * y > 1 then return false end
 	theta = math.deg(math.atan2(y, x))

--- a/lua/entities/gmod_wire_egp/lib/objects/wedge.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/wedge.lua
@@ -54,7 +54,7 @@ Obj.DataStreamInfo = function( self )
 	table.Merge( tbl, { angle = self.angle, size = self.size, fidelity = self.fidelity } )
 	return tbl
 end
-function Obj:Contains(x, y, egp)
+function Obj:Contains(egp, x, y)
 	x, y = EGP.WorldToLocal(egp, self, x, y)
 	x, y = x / self.w, y / self.h
 	

--- a/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
@@ -1042,21 +1042,8 @@ __e2setcost(20)
 
 --- Returns 1 if the object with specified index contains the specified point.
 e2function number wirelink:egpObjectContainsPoint(number index, vector2 point)
-	local bool, _, object = EGP:HasObject(this, index)
-	if bool then 
-		local hasVertices, pos = EGP:GetGlobalPos(this, index)
-		if this.TopLeft and object.CanTopLeft and object.w and object.h then
-			pos.x = pos.x + object.w / 2
-			pos.y = pos.y + object.h / 2
-		elseif hasVertices then
-			-- Localize the point to the object. Yeah.
-			local x, y = getCenterFromPos(pos)
-			local fakex, fakey = getCenter(makeArray(object), true)
-			return object:Contains({ x = point[1] - x + fakex, y = point[2] - y + fakey, angle = 0 }) and 1 or 0
-		end
-		return object:Contains({ x = point[1] - pos.x, y = point[2] - pos.y, angle = pos.angle }) and 1 or 0
-	end
-	return 0
+	local _, _, object = EGP:HasObject(this, index)
+	return object and object:Contains({ x = point[1], y = point[2] }, this) and 1 or 0
 end
 
 __e2setcost(10)

--- a/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
@@ -609,7 +609,8 @@ e2function void wirelink:egpPos( number index, vector2 pos )
 	if (!EGP:IsAllowed( self, this )) then return end
 	local bool, k, v = EGP:HasObject( this, index )
 	if (bool) then
-		if (EGP:EditObject( v, { x = pos[1], y = pos[2] } )) then EGP:DoAction( this, self, "SendObject", v ) Update(self,this) end
+		local x, y = pos[1], pos[2]
+		if (EGP:EditObject( v, { x = x, y = y, _x = x, _y = y } )) then EGP:DoAction( this, self, "SendObject", v ) Update(self,this) end
 	end
 end
 
@@ -621,7 +622,7 @@ e2function void wirelink:egpAngle( number index, number angle )
 	if (!EGP:IsAllowed( self, this )) then return end
 	local bool, k, v = EGP:HasObject( this, index )
 	if (bool) then
-		if (EGP:EditObject( v, { angle = angle } )) then EGP:DoAction( this, self, "SendObject", v ) Update(self,this) end
+		if (EGP:EditObject( v, { angle = angle, _angle = angle } )) then EGP:DoAction( this, self, "SendObject", v ) Update(self,this) end
 	end
 end
 
@@ -642,8 +643,8 @@ e2function void wirelink:egpAngle( number index, vector2 worldpos, vector2 axisp
 
 			angle = -ang.yaw
 
-			local t = { x = x, y = y }
-			if (v.angle) then t.angle = angle end
+			local t = { x = x, _x = x, y = y, _y = y }
+			if (v.angle) then t.angle = angle, t._angle = angle end
 
 			if (EGP:EditObject( v, t )) then EGP:DoAction( this, self, "SendObject", v ) Update(self,this) end
 		end

--- a/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
@@ -1043,7 +1043,7 @@ __e2setcost(20)
 --- Returns 1 if the object with specified index contains the specified point.
 e2function number wirelink:egpObjectContainsPoint(number index, vector2 point)
 	local _, _, object = EGP:HasObject(this, index)
-	return object and object:Contains(point[1], point[2], this) and 1 or 0
+	return object and object:Contains(this, point[1], point[2]) and 1 or 0
 end
 
 __e2setcost(10)

--- a/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
@@ -829,9 +829,7 @@ e2function vector wirelink:egpGlobalPos( number index )
 end
 
 e2function array wirelink:egpGlobalVertices( number index )
-	ErrorNoHalt = override
 	local hasvertices, data = EGP:GetGlobalPos( this, index )
-	ErrorNoHalt = olderror
 	if (hasvertices) then
 		if (data.vertices) then
 			local ret = {}

--- a/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
@@ -1052,9 +1052,9 @@ e2function number wirelink:egpObjectContainsPoint(number index, vector2 point)
 			-- Localize the point to the object. Yeah.
 			local x, y = getCenterFromPos(pos)
 			local fakex, fakey = getCenter(makeArray(object), true)
-			return object:Contains({ x = x - point[1] + fakex, y = y - point[2] + fakey, angle = 0 }) and 1 or 0
+			return object:Contains({ x = point[1] - x + fakex, y = point[2] - y + fakey, angle = 0 }) and 1 or 0
 		end
-		return object:Contains({ x = pos.x - point[1], y = pos.y - point[2], angle = pos.angle }) and 1 or 0
+		return object:Contains({ x = point[1] - pos.x, y = point[2] - pos.y, angle = pos.angle }) and 1 or 0
 	end
 	return 0
 end

--- a/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
@@ -1043,7 +1043,7 @@ __e2setcost(20)
 --- Returns 1 if the object with specified index contains the specified point.
 e2function number wirelink:egpObjectContainsPoint(number index, vector2 point)
 	local _, _, object = EGP:HasObject(this, index)
-	return object and object:Contains({ x = point[1], y = point[2] }, this) and 1 or 0
+	return object and object:Contains(point[1], point[2], this) and 1 or 0
 end
 
 __e2setcost(10)

--- a/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
@@ -644,7 +644,7 @@ e2function void wirelink:egpAngle( number index, vector2 worldpos, vector2 axisp
 			angle = -ang.yaw
 
 			local t = { x = x, _x = x, y = y, _y = y }
-			if (v.angle) then t.angle = angle, t._angle = angle end
+			if (v.angle) then t.angle, t._angle = angle, angle end
 
 			if (EGP:EditObject( v, t )) then EGP:DoAction( this, self, "SendObject", v ) Update(self,this) end
 		end


### PR DESCRIPTION
1. Fixes egpObjectContainsPoint for polys.
2. Allows egpGlobalPos to get center position of polys.

Note that the poly *Contains* function only properly works on convex polys.

Also, in case you're concerned, the values in https://github.com/wiremod/wire/pull/2593/commits/a144a820a0c504abbcd266aae429793ae0e8b13c are nil. This makes ErrorNoHalt nil.