### PR TITLE
Add "on component" to lights.

### DIFF
--- a/lua/entities/gmod_wire_light.lua
+++ b/lua/entities/gmod_wire_light.lua
@@ -245,8 +245,8 @@ function ENT:TriggerInput(iname, value)
 	self:UpdateLight()
 end
 
-function ENT:Setup(directional, radiant, glow, brightness, size, r, g, b, spritesize, on)
-	self.on = on or false
+function ENT:Setup(directional, radiant, glow, brightness, size, r, g, b, spritesize, startOn)
+	self.startOn = startOn == nil or startOn
 	self.directional = directional or false
 	self.radiant = radiant or false
 	self.glow = glow or false
@@ -263,8 +263,7 @@ function ENT:Setup(directional, radiant, glow, brightness, size, r, g, b, sprite
 		self.spritesize = math.Clamp( self.spritesize, 0, 256 )
 	end
 
-	if not self.on then self:SetOn(true) end
-	
+	self:SetOn(self.startOn)
 	self:Directional( self.directional )
 	self:Radiant( self.radiant )
 	self:SetGlow( self.glow )
@@ -272,14 +271,10 @@ function ENT:Setup(directional, radiant, glow, brightness, size, r, g, b, sprite
 	self:SetSize( self.size )
 	self:SetSpriteSize( self.spritesize )
 
-	local inputs = {"Red", "Green", "Blue", "RGB [VECTOR]", "SpriteSize"}
+	local inputs = {"On", "Red", "Green", "Blue", "RGB [VECTOR]", "SpriteSize"}
 	if self.glow then
 		table.insert(inputs, 5, "GlowBrightness")
 		table.insert(inputs, 6, "GlowSize")
-	end
-	
-	if self.on then
-		table.insert(inputs, 1, "On")
 	end
 	
 	WireLib.AdjustInputs(self, inputs)
@@ -287,4 +282,4 @@ function ENT:Setup(directional, radiant, glow, brightness, size, r, g, b, sprite
 	self:UpdateLight()
 end
 
-duplicator.RegisterEntityClass("gmod_wire_light", WireLib.MakeWireEnt, "Data", "directional", "radiant", "glow", "brightness", "size", "R", "G", "B", "spritesize")
+duplicator.RegisterEntityClass("gmod_wire_light", WireLib.MakeWireEnt, "Data", "directional", "radiant", "glow", "brightness", "size", "R", "G", "B", "spritesize", "startOn")

--- a/lua/entities/gmod_wire_light.lua
+++ b/lua/entities/gmod_wire_light.lua
@@ -232,7 +232,7 @@ function ENT:TriggerInput(iname, value)
 	self:UpdateLight()
 end
 
-function ENT:Setup(on, directional, radiant, glow, brightness, size, r, g, b, spritesize)
+function ENT:Setup(directional, radiant, glow, brightness, size, r, g, b, spritesize, on)
 	self.on = on or false
 	self.directional = directional or false
 	self.radiant = radiant or false
@@ -274,4 +274,4 @@ function ENT:Setup(on, directional, radiant, glow, brightness, size, r, g, b, sp
 	self:UpdateLight()
 end
 
-duplicator.RegisterEntityClass("gmod_wire_light", WireLib.MakeWireEnt, "Data", "on", "directional", "radiant", "glow", "brightness", "size", "R", "G", "B", "spritesize")
+duplicator.RegisterEntityClass("gmod_wire_light", WireLib.MakeWireEnt, "Data", "directional", "radiant", "glow", "brightness", "size", "R", "G", "B", "spritesize", "on")

--- a/lua/entities/gmod_wire_light.lua
+++ b/lua/entities/gmod_wire_light.lua
@@ -246,7 +246,6 @@ function ENT:TriggerInput(iname, value)
 end
 
 function ENT:Setup(directional, radiant, glow, brightness, size, r, g, b, spritesize, startOn)
-	self.startOn = startOn == nil or startOn
 	self.directional = directional or false
 	self.radiant = radiant or false
 	self.glow = glow or false
@@ -263,7 +262,7 @@ function ENT:Setup(directional, radiant, glow, brightness, size, r, g, b, sprite
 		self.spritesize = math.Clamp( self.spritesize, 0, 256 )
 	end
 
-	self:SetOn(self.startOn)
+	self:SetOn(startOn == nil or startOn)
 	self:Directional( self.directional )
 	self:Radiant( self.radiant )
 	self:SetGlow( self.glow )

--- a/lua/entities/gmod_wire_light.lua
+++ b/lua/entities/gmod_wire_light.lua
@@ -283,4 +283,4 @@ function ENT:Setup(directional, radiant, glow, brightness, size, r, g, b, sprite
 	self:UpdateLight()
 end
 
-duplicator.RegisterEntityClass("gmod_wire_light", WireLib.MakeWireEnt, "Data", "directional", "radiant", "glow", "brightness", "size", "R", "G", "B", "spritesize", "on")
+duplicator.RegisterEntityClass("gmod_wire_light", WireLib.MakeWireEnt, "Data", "directional", "radiant", "glow", "brightness", "size", "R", "G", "B", "spritesize")

--- a/lua/entities/gmod_wire_light.lua
+++ b/lua/entities/gmod_wire_light.lua
@@ -245,7 +245,8 @@ function ENT:TriggerInput(iname, value)
 	self:UpdateLight()
 end
 
-function ENT:Setup(directional, radiant, glow, brightness, size, r, g, b, spritesize)
+function ENT:Setup(directional, radiant, glow, brightness, size, r, g, b, spritesize, on)
+	self.on = on or false
 	self.directional = directional or false
 	self.radiant = radiant or false
 	self.glow = glow or false
@@ -262,7 +263,7 @@ function ENT:Setup(directional, radiant, glow, brightness, size, r, g, b, sprite
 		self.spritesize = math.Clamp( self.spritesize, 0, 256 )
 	end
 
-	self:SetOn(true)
+	if not self.on then self:SetOn(true) end
 	
 	self:Directional( self.directional )
 	self:Radiant( self.radiant )
@@ -271,12 +272,15 @@ function ENT:Setup(directional, radiant, glow, brightness, size, r, g, b, sprite
 	self:SetSize( self.size )
 	self:SetSpriteSize( self.spritesize )
 
-	local inputs = {"On", "Red", "Green", "Blue", "RGB [VECTOR]", "SpriteSize"}
+	local inputs = {"Red", "Green", "Blue", "RGB [VECTOR]", "SpriteSize"}
 	if self.glow then
 		table.insert(inputs, 5, "GlowBrightness")
 		table.insert(inputs, 6, "GlowSize")
 	end
 	
+	if self.on then
+		table.insert(inputs, 1, "On")
+	end
 	
 	WireLib.AdjustInputs(self, inputs)
 

--- a/lua/entities/gmod_wire_light.lua
+++ b/lua/entities/gmod_wire_light.lua
@@ -245,8 +245,7 @@ function ENT:TriggerInput(iname, value)
 	self:UpdateLight()
 end
 
-function ENT:Setup(directional, radiant, glow, brightness, size, r, g, b, spritesize, on)
-	self.on = on or false
+function ENT:Setup(directional, radiant, glow, brightness, size, r, g, b, spritesize)
 	self.directional = directional or false
 	self.radiant = radiant or false
 	self.glow = glow or false
@@ -263,7 +262,7 @@ function ENT:Setup(directional, radiant, glow, brightness, size, r, g, b, sprite
 		self.spritesize = math.Clamp( self.spritesize, 0, 256 )
 	end
 
-	if not self.on then self:SetOn(true) end
+	self:SetOn(true)
 	
 	self:Directional( self.directional )
 	self:Radiant( self.radiant )
@@ -272,15 +271,12 @@ function ENT:Setup(directional, radiant, glow, brightness, size, r, g, b, sprite
 	self:SetSize( self.size )
 	self:SetSpriteSize( self.spritesize )
 
-	local inputs = {"Red", "Green", "Blue", "RGB [VECTOR]", "SpriteSize"}
+	local inputs = {"On", "Red", "Green", "Blue", "RGB [VECTOR]", "SpriteSize"}
 	if self.glow then
 		table.insert(inputs, 5, "GlowBrightness")
 		table.insert(inputs, 6, "GlowSize")
 	end
 	
-	if self.on then
-		table.insert(inputs, 1, "On")
-	end
 	
 	WireLib.AdjustInputs(self, inputs)
 

--- a/lua/wire/stools/light.lua
+++ b/lua/wire/stools/light.lua
@@ -13,6 +13,7 @@ if CLIENT then
 	language.Add( "WireLightTool_glow", "Glow Component" )
 	language.Add( "WireLightTool_const", "Constraint:" )
 	language.Add( "WireLightTool_color", "Initial Color:" )
+	language.Add("WireLightTool_on", "On component")
 	TOOL.Information = { { name = "left", text = "Create/Update " .. TOOL.Name } }
 
 	WireToolSetup.setToolMenuIcon( "icon16/lightbulb.png" )
@@ -31,7 +32,8 @@ if SERVER then
 			self:GetClientNumber("r"),
 			self:GetClientNumber("g"),
 			self:GetClientNumber("b"),
-			self:GetClientNumber("spritesize")
+			self:GetClientNumber("spritesize"),
+			self:GetClientNumber("on") ~= 0
 	end
 
 	function TOOL:LeftClick_PostMake( ent, ply, trace )
@@ -103,6 +105,7 @@ TOOL.ClientConVar = {
 	g            = 0,
 	b            = 0,
 	spritesize   = 128,
+	on			 = 0
 }
 
 function TOOL.BuildCPanel(panel)
@@ -113,6 +116,7 @@ function TOOL.BuildCPanel(panel)
 	panel:CheckBox("#WireLightTool_directional", "wire_light_directional")
 	panel:CheckBox("#WireLightTool_radiant", "wire_light_radiant")
 	panel:CheckBox("#WireLightTool_glow", "wire_light_glow")
+	panel:CheckBox("#WireLightTool_on", "wire_light_on")
 	panel:NumSlider("#WireLightTool_bright", "wire_light_brightness", 0, 10, 0)
 	panel:NumSlider("#WireLightTool_size", "wire_light_size", 0, 1024, 0)
 	panel:NumSlider("#WireLightTool_spritesize", "wire_light_spritesize", 0, 256, 0)

--- a/lua/wire/stools/light.lua
+++ b/lua/wire/stools/light.lua
@@ -24,7 +24,6 @@ WireToolSetup.SetupMax(8)
 if SERVER then
 	function TOOL:GetConVars()
 		return
-			self:GetClientNumber("on") ~= 0,
 			self:GetClientNumber("directional") ~= 0,
 			self:GetClientNumber("radiant") ~= 0,
 			self:GetClientNumber("glow") ~= 0,
@@ -33,7 +32,8 @@ if SERVER then
 			self:GetClientNumber("r"),
 			self:GetClientNumber("g"),
 			self:GetClientNumber("b"),
-			self:GetClientNumber("spritesize")
+			self:GetClientNumber("spritesize"),
+			self:GetClientNumber("on") ~= 0
 	end
 
 	function TOOL:LeftClick_PostMake( ent, ply, trace )

--- a/lua/wire/stools/light.lua
+++ b/lua/wire/stools/light.lua
@@ -13,7 +13,6 @@ if CLIENT then
 	language.Add( "WireLightTool_glow", "Glow Component" )
 	language.Add( "WireLightTool_const", "Constraint:" )
 	language.Add( "WireLightTool_color", "Initial Color:" )
-	language.Add("WireLightTool_on", "On component")
 	TOOL.Information = { { name = "left", text = "Create/Update " .. TOOL.Name } }
 
 	WireToolSetup.setToolMenuIcon( "icon16/lightbulb.png" )
@@ -32,8 +31,7 @@ if SERVER then
 			self:GetClientNumber("r"),
 			self:GetClientNumber("g"),
 			self:GetClientNumber("b"),
-			self:GetClientNumber("spritesize"),
-			self:GetClientNumber("on") ~= 0
+			self:GetClientNumber("spritesize")
 	end
 
 	function TOOL:LeftClick_PostMake( ent, ply, trace )
@@ -105,7 +103,6 @@ TOOL.ClientConVar = {
 	g            = 0,
 	b            = 0,
 	spritesize   = 128,
-	on			 = 0
 }
 
 function TOOL.BuildCPanel(panel)
@@ -116,7 +113,6 @@ function TOOL.BuildCPanel(panel)
 	panel:CheckBox("#WireLightTool_directional", "wire_light_directional")
 	panel:CheckBox("#WireLightTool_radiant", "wire_light_radiant")
 	panel:CheckBox("#WireLightTool_glow", "wire_light_glow")
-	panel:CheckBox("#WireLightTool_on", "wire_light_on")
 	panel:NumSlider("#WireLightTool_bright", "wire_light_brightness", 0, 10, 0)
 	panel:NumSlider("#WireLightTool_size", "wire_light_size", 0, 1024, 0)
 	panel:NumSlider("#WireLightTool_spritesize", "wire_light_spritesize", 0, 256, 0)

--- a/lua/wire/stools/light.lua
+++ b/lua/wire/stools/light.lua
@@ -13,7 +13,7 @@ if CLIENT then
 	language.Add( "WireLightTool_glow", "Glow Component" )
 	language.Add( "WireLightTool_const", "Constraint:" )
 	language.Add( "WireLightTool_color", "Initial Color:" )
-	language.Add("WireLightTool_on", "On component")
+	language.Add("WireLightTool_starton", "Start on")
 	TOOL.Information = { { name = "left", text = "Create/Update " .. TOOL.Name } }
 
 	WireToolSetup.setToolMenuIcon( "icon16/lightbulb.png" )
@@ -33,7 +33,7 @@ if SERVER then
 			self:GetClientNumber("g"),
 			self:GetClientNumber("b"),
 			self:GetClientNumber("spritesize"),
-			self:GetClientNumber("on") ~= 0
+			self:GetClientNumber("starton") ~= 0
 	end
 
 	function TOOL:LeftClick_PostMake( ent, ply, trace )
@@ -105,7 +105,7 @@ TOOL.ClientConVar = {
 	g            = 0,
 	b            = 0,
 	spritesize   = 128,
-	on			 = 0
+	starton		= 0
 }
 
 function TOOL.BuildCPanel(panel)
@@ -116,7 +116,7 @@ function TOOL.BuildCPanel(panel)
 	panel:CheckBox("#WireLightTool_directional", "wire_light_directional")
 	panel:CheckBox("#WireLightTool_radiant", "wire_light_radiant")
 	panel:CheckBox("#WireLightTool_glow", "wire_light_glow")
-	panel:CheckBox("#WireLightTool_on", "wire_light_on")
+	panel:CheckBox("#WireLightTool_starton", "wire_light_starton")
 	panel:NumSlider("#WireLightTool_bright", "wire_light_brightness", 0, 10, 0)
 	panel:NumSlider("#WireLightTool_size", "wire_light_size", 0, 1024, 0)
 	panel:NumSlider("#WireLightTool_spritesize", "wire_light_spritesize", 0, 256, 0)

--- a/lua/wire/stools/light.lua
+++ b/lua/wire/stools/light.lua
@@ -13,6 +13,7 @@ if CLIENT then
 	language.Add( "WireLightTool_glow", "Glow Component" )
 	language.Add( "WireLightTool_const", "Constraint:" )
 	language.Add( "WireLightTool_color", "Initial Color:" )
+	language.Add("WireLightTool_on", "On component")
 	TOOL.Information = { { name = "left", text = "Create/Update " .. TOOL.Name } }
 
 	WireToolSetup.setToolMenuIcon( "icon16/lightbulb.png" )
@@ -23,6 +24,7 @@ WireToolSetup.SetupMax(8)
 if SERVER then
 	function TOOL:GetConVars()
 		return
+			self:GetClientNumber("on") ~= 0,
 			self:GetClientNumber("directional") ~= 0,
 			self:GetClientNumber("radiant") ~= 0,
 			self:GetClientNumber("glow") ~= 0,
@@ -102,7 +104,8 @@ TOOL.ClientConVar = {
 	r            = 0,
 	g            = 0,
 	b            = 0,
-	spritesize   = 128
+	spritesize   = 128,
+	on			 = 0
 }
 
 function TOOL.BuildCPanel(panel)
@@ -113,6 +116,7 @@ function TOOL.BuildCPanel(panel)
 	panel:CheckBox("#WireLightTool_directional", "wire_light_directional")
 	panel:CheckBox("#WireLightTool_radiant", "wire_light_radiant")
 	panel:CheckBox("#WireLightTool_glow", "wire_light_glow")
+	panel:CheckBox("#WireLightTool_on", "wire_light_on")
 	panel:NumSlider("#WireLightTool_bright", "wire_light_brightness", 0, 10, 0)
 	panel:NumSlider("#WireLightTool_size", "wire_light_size", 0, 1024, 0)
 	panel:NumSlider("#WireLightTool_spritesize", "wire_light_spritesize", 0, 256, 0)


### PR DESCRIPTION
#### Description:
Adds a new component to lights that, when enabled, allows them to be turned on and off.
Additionally, all glow lights now do not create dlights when glow size is less than 1.

#### Purpose:
Allows users to control lights without having to set the light's other values (which is something that Gmod lights can do but Wire can't because...?).
Removes dlight bloat from invisible dlights.
The design was made to preserve backwards-compatibility with lights that were created without this feature in mind.

Fixes #2573