### PR TITLE
Fix mistake in EGP MoveTopLeft

### DIFF
--- a/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
@@ -113,7 +113,8 @@ function EGP:MoveTopLeft(ent, obj)
 				t.y = t.y - parent.h / 2
 			end
 		end
-		if t and t.angle then t.angle = -t.angle end
+		if not t then t = { angle = obj.angle } end
+		if t.angle then t.angle = -t.angle end
 	end
 
 	if t then

--- a/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
@@ -108,7 +108,7 @@ function EGP:MoveTopLeft(ent, obj)
 					t[v[2]] = obj[v[2]] - h
 				end
 			else
-				if not t then t = { x = 0, y = 0 } end
+				if not t then t = { x = obj.x, y = obj.y, angle = obj.angle } end
 				t.x = t.x - parent.w / 2
 				t.y = t.y - parent.h / 2
 			end


### PR DESCRIPTION
Fixes position and angle of parented objects that cannot topleft.