### PR TITLE
Add playerUse event

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -908,6 +908,26 @@ E2Lib.registerEvent("playerDeath", {
 	{ "Attacker", "e" }
 })
 
+local Using = WireLib.RegisterPlayerTable()
+
+hook.Add("PlayerBindDown", "Exp2PlayerButtonDownUse", function(ply, binding, button)
+	if binding == "use" then
+		Using[ply] = nil
+	end
+end)
+
+hook.Add("PlayerUse", "Exp2PlayerUse", function(ply, ent)
+	if not Using[ply] then
+		Using[ply] = true
+		E2Lib.triggerEvent("playerUse", { ply, ent })
+	end
+end)
+
+E2Lib.registerEvent("playerUse", {
+	{ "Player", "e" },
+	{ "Entity", "e" }
+})
+
 
 --******************************************--
 


### PR DESCRIPTION
Fixes #2159 

Adds event that binds to https://wiki.facepunch.com/gmod/GM:PlayerUse, however only calls this event once per use, unlike the gmod hook. Basically `chipUsed` but for every entity.

```golo
event playerUse(Player:entity, Entity:entity) {
    print(Player, "Just used", Entity)
}
```