### PR TITLE
Add `Ignore [ARRAY]` input to targetfinder to ignore specific entities

### DIFF
--- a/lua/entities/gmod_wire_target_finder.lua
+++ b/lua/entities/gmod_wire_target_finder.lua
@@ -10,7 +10,7 @@ function ENT:Initialize()
 	self:SetMoveType( MOVETYPE_VPHYSICS )
 	self:SetSolid( SOLID_VPHYSICS )
 
-	self.Inputs = Wire_CreateInputs(self, { "Hold" })
+	self.Inputs = Wire_CreateInputs(self, { "Hold", "Ignore [ARRAY]" })
 	self.Outputs = WireLib.CreateSpecialOutputs( self, { "Out" }, { "ENTITY" } )
 end
 
@@ -117,12 +117,19 @@ function ENT:Setup(maxrange, players, npcs, npcname, beacons, hoverballs, thrust
 		table.insert(AdjInputs, inputhold)
 	end
 	table.insert(AdjInputs, "Hold")
+	table.insert(AdjInputs, "Ignore [ARRAY]")
+
 	Wire_AdjustInputs(self, AdjInputs)
 
 	self:ShowOutput(false)
 end
 
 function ENT:TriggerInput(iname, value)
+	if iname == "Ignore" then
+		self.Ignored = value
+		return
+	end
+
 	if value > 0 and self.Selector.Next[iname] then
 		self:SelectorNext(self.Selector.Next[iname])
 		--[[elseif self.Selector.Prev[iname] then
@@ -265,9 +272,13 @@ function ENT:Think()
 		local bogeys, dists, ndists = {}, {}, 0
 		for _, contact in ipairs(ents.FindInSphere(mypos, self.MaxRange or 10)) do
 			local class = contact:GetClass()
-			if (not self.NoTargetOwnersStuff or (class == "player") or (WireLib.GetOwner(contact) ~= self:GetPlayer())) and
+			if
+				-- Ignore array of entities if provided
+				(not self.Ignored or not table.HasValue(self.Ignored, contact) ) and
+				-- Ignore owned stuff if checked
+				((not self.NoTargetOwnersStuff or (class == "player") or (WireLib.GetOwner(contact) ~= self:GetPlayer())) and
 				-- NPCs
-				(self.TargetNPC and (contact:IsNPC()) and (isOneOf(class, self.NPCName))) or
+				((self.TargetNPC and (contact:IsNPC()) and (isOneOf(class, self.NPCName))) or
 				--Players
 				(self.TargetPlayer and (class == "player") and CheckPlayers(self, contact) or
 				--Locators
@@ -283,7 +294,7 @@ function ENT:Think()
 				-- Vehicles
 				(self.TargetVehicles and contact:IsVehicle()) or
 				-- Entity classnames
-				(self.EntFil ~= "" and isOneOf(class, self.EntFil)))
+				(self.EntFil ~= "" and isOneOf(class, self.EntFil)))))
 			then
 				local dist = (contact:GetPos() - mypos):Length()
 				if (dist >= self.MinRange) then


### PR DESCRIPTION
Adds an `Ignore` input of type `array` that takes in a list of entities to specifically ignore in the target finder. Can use this for example with the `Friends List` component's `Friends` output array.

Fixes #2379