### PR TITLE
Add `WireLib.CanTool` which defaults to CPPI

### DIFF
--- a/lua/entities/gmod_wire_clutch.lua
+++ b/lua/entities/gmod_wire_clutch.lua
@@ -271,9 +271,10 @@ function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
 		Ent2 = GetEntByID(v.Ent2, game.GetWorld())
 
 		if IsValid(Ent1) and
-		   Ent1 ~= Ent2 and
-		   hook.Run( "CanTool", ply, WireLib.dummytrace(Ent1), "ballsocket_adv" ) and
-		   hook.Run( "CanTool", ply, WireLib.dummytrace(Ent2), "ballsocket_adv" ) then
+			Ent1 ~= Ent2 and
+			WireLib.CanTool(ply, Ent1, "ballsocket_adv") and
+			WireLib.CanTool(ply, Ent2, "ballsocket_adv")
+		then
 			self:AddClutch( Ent1, Ent2 )
 		end
 	end

--- a/lua/entities/gmod_wire_colorer.lua
+++ b/lua/entities/gmod_wire_colorer.lua
@@ -121,7 +121,7 @@ function ENT:TriggerInput(iname, value)
 			filter = { self }
 		}
 		if not IsValid(trace.Entity) then return end
-		if not hook.Run( "CanTool", self:GetPlayer(), trace, "colour" ) then return end
+		if not WireLib.CanTool(self:GetPlayer(), trace.Entity, "colour") then return end
 
 		if trace.Entity:IsPlayer() then
 			trace.Entity:SetColor(Color(self.InColor.r, self.InColor.g, self.InColor.b, 255))

--- a/lua/entities/gmod_wire_exit_point.lua
+++ b/lua/entities/gmod_wire_exit_point.lua
@@ -68,7 +68,7 @@ end
 
 function ENT:CheckPP(ent)
 	-- Check Prop Protection. Most block/allow all of CanTool, but lets check hoverdrive controller specifically, since if they can attach one to your vehicle, they can simulate this anyways
-	return IsValid(ent) and gamemode.Call("CanTool", self:GetPlayer(), WireLib.dummytrace(ent), "wire_hoverdrivecontroller")
+	return IsValid(ent) and WireLib.CanTool(self:GetPlayer(), ent, "wire_hoverdrivecontroller")
 end
 
 function ENT:Think()

--- a/lua/entities/gmod_wire_freezer.lua
+++ b/lua/entities/gmod_wire_freezer.lua
@@ -45,7 +45,7 @@ function ENT:TriggerInput(name, value)
 		for _, ent in pairs(self.Marks) do
 			if ent:IsValid() then
 				local phys = ent:GetPhysicsObject()
-				if phys:IsValid() and gamemode.Call("CanTool", ply, WireLib.dummytrace(ent), "nocollide") then
+				if phys:IsValid() and WireLib.CanTool(ply, ent, "nocollide") then
 					if self.CollisionState == 0 then
 						ent:SetCollisionGroup( COLLISION_GROUP_NONE )
 						phys:EnableCollisions(true)

--- a/lua/entities/gmod_wire_grabber.lua
+++ b/lua/entities/gmod_wire_grabber.lua
@@ -81,7 +81,7 @@ function ENT:CanGrab(trace)
 	-- If there's no physics object then we can't constraint it!
 	if not util.IsValidPhysicsObject(trace.Entity, trace.PhysicsBone) then return false end
 
-	if not gamemode.Call( "CanTool", self:GetPlayer(), trace, "weld" ) then return false end
+	if not WireLib.CanTool(self:GetPlayer(), trace.Entity, "weld") then return false end
 
 	return true
 end

--- a/lua/entities/gmod_wire_nailer.lua
+++ b/lua/entities/gmod_wire_nailer.lua
@@ -32,7 +32,7 @@ function ENT:CanNail(trace)
 	-- If there's no physics object then we can't constraint it!
 	if not util.IsValidPhysicsObject(trace.Entity, trace.PhysicsBone) then return false end
 	-- The nailer tool no longer exists, but we ask for permission under its name anyway
-	if hook.Run( "CanTool", self:GetPlayer(), trace, "nailer" ) == false then return false end
+	if not WireLib.CanTool(self:GetPlayer(), trace.Entity, "nailer" ) then return false end
 	return true
 end
 

--- a/lua/entities/gmod_wire_pod.lua
+++ b/lua/entities/gmod_wire_pod.lua
@@ -222,7 +222,7 @@ function ENT:LinkEnt( pod )
 
 	-- if pod is still not a vehicle even after all of the above, then error out
 	if not IsValid(pod) or not pod:IsVehicle() then return false, "Must link to a vehicle" end
-	if hook.Run( "CanTool", self:GetPlayer(), WireLib.dummytrace(pod), "wire_pod" ) == false then return false, "You do not have permission to access this vehicle" end
+	if not WireLib.CanTool(self:GetPlayer(), pod, "wire_pod" ) then return false, "You do not have permission to access this vehicle" end
 
 	self:SetPod( pod )
 	WireLib.SendMarks(self, {pod})

--- a/lua/entities/gmod_wire_target_finder.lua
+++ b/lua/entities/gmod_wire_target_finder.lua
@@ -394,7 +394,7 @@ end
 
 function ENT:TargetPainter( tt, targeted )
 	local ply = self:GetPlayer()
-	if tt and IsValid(tt) and tt:EntIndex() ~= 0 and ply:IsValid() and hook.Run( "CanTool", ply, WireLib.dummytrace(tt), "colour" ) then
+	if tt and IsValid(tt) and tt:EntIndex() ~= 0 and ply:IsValid() and WireLib.CanTool(ply, tt, "colour") then
 		if (targeted) then
 			self.OldColor = tt:GetColor()
 			tt:SetColor(Color(255, 0, 0, 255))

--- a/lua/entities/gmod_wire_vehicle.lua
+++ b/lua/entities/gmod_wire_vehicle.lua
@@ -18,7 +18,7 @@ function ENT:LinkEnt( pod )
 	pod = WireLib.GetClosestRealVehicle(pod,self:GetPos(),self:GetPlayer())
 
 	if not IsValid(pod) or not pod:IsVehicle() then return false, "Must link to a vehicle" end
-	if hook.Run( "CanTool", self:GetPlayer(), WireLib.dummytrace(pod), "wire_vehicle" ) == false then return false, "You do not have permission to access this vehicle" end
+	if not WireLib.CanTool(self:GetPlayer(), pod, "wire_vehicle") then return false, "You do not have permission to access this vehicle" end
 
 	self.Vehicle = pod
 	WireLib.SendMarks(self, {pod})

--- a/lua/weapons/gmod_tool/stools/wire_adv.lua
+++ b/lua/weapons/gmod_tool/stools/wire_adv.lua
@@ -146,8 +146,8 @@ if SERVER then
 			local outputentity = wiring[5]
 
 			if IsValid( inputentity ) and IsValid( outputentity ) and
-				hook.Run( "CanTool", ply, WireLib.dummytrace( inputentity ), "wire_adv" ) and
-				hook.Run( "CanTool", ply, WireLib.dummytrace( outputentity ), "wire_adv" ) then
+				WireLib.CanTool(ply, inputentity, "wire_adv" ) and
+				WireLib.CanTool(ply, outputentity, "wire_adv" ) then
 
 				local inputname = wiring[1]
 				local inputpos = wiring[2]
@@ -182,7 +182,7 @@ if SERVER then
 		local ent = net.ReadEntity()
 		local tbl = net.ReadTable()
 
-		if hook.Run( "CanTool", ply, WireLib.dummytrace( ent ), "wire_adv" ) then
+		if WireLib.CanTool(ply, ent, "wire_adv" ) then
 			for i=1,#tbl do
 				WireLib.Link_Clear( ent, tbl[i] )
 			end

--- a/lua/weapons/gmod_tool/stools/wire_debugger.lua
+++ b/lua/weapons/gmod_tool/stools/wire_debugger.lua
@@ -59,7 +59,7 @@ properties.Add("wire_debugger_start", {
 	Filter = function(self,ent,ply)
 		if not IsValid(ent) then return false end
 		if not IsWire(ent) then return false end
-		if not hook.Run("CanTool", ply, WireLib.dummytrace(ent), "wire_debugger") then return false end
+		if not WireLib.CanTool(ply, ent, "wire_debugger") then return false end
 		if Components[ply] then
 			for _, cmp in ipairs(Components[ply]) do
 				if (cmp == ent) then return false end

--- a/lua/weapons/remotecontroller.lua
+++ b/lua/weapons/remotecontroller.lua
@@ -61,7 +61,7 @@ function SWEP:On()
 	local ply = self:GetOwner()
 
 	if IsValid(self.Linked) and self.Linked.HasPly and self.Linked:HasPly() then
-		if hook.Run("CanTool", ply, WireLib.dummytrace(self.Linked), "remotecontroller") then
+		if WireLib.CanTool(ply, self.Linked, "remotecontroller") then
 			if self.Linked.RC then
 				self.Linked:RCEject(self.Linked:GetPly())
 			else

--- a/lua/wire/gates/entity.lua
+++ b/lua/wire/gates/entity.lua
@@ -740,7 +740,7 @@ GateActions["entity_setmass"] = {
 	output = function(gate, Ent, Val )
 		if not Ent:IsValid() then return end
 		if not Ent:GetPhysicsObject():IsValid() then return end
-		if not gamemode.Call("CanTool", WireLib.GetOwner(gate), WireLib.dummytrace(Ent), "weight") then return end
+		if not WireLib.CanTool(WireLib.GetOwner(gate), Ent, "weight") then return end
 		if not Val then Val = Ent:GetPhysicsObject():GetMass() end
 		Val = math.Clamp(Val, 0.001, 50000)
 		Ent:GetPhysicsObject():SetMass(Val)
@@ -780,7 +780,7 @@ GateActions["entity_setcol"] = {
 	inputtypes = { "ENTITY" , "VECTOR" },
 	output = function(gate, Ent, Col )
 		if not Ent:IsValid() then return end
-		if not gamemode.Call("CanTool", WireLib.GetOwner(gate), WireLib.dummytrace(Ent), "color") then return end
+		if not WireLib.CanTool(WireLib.GetOwner(gate), Ent, "color") then return end
 		if not isvector(Col) then Col = Vector(255,255,255) end
 		Ent:SetColor(Color(Col.x,Col.y,Col.z,255))
 	end,

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1185,6 +1185,38 @@ function WireLib.IsValidMaterial(material)
 	return material
 end
 
+if CPPI and FindMetaTable("Entity").CPPICanTool then
+	---@param player Player
+	---@param entity Entity
+	---@param toolname string
+	function WireLib.CanTool(player, entity, toolname)
+		return entity:CPPICanTool(player, toolname)
+	end
+else
+	local zero = Vector(0, 0, 0)
+	local norm = Vector(1, 0, 0)
+
+	local tr = { ---@type TraceResult
+		Hit = true, HitNonWorld = true, HitNoDraw = false, HitSky = false, AllSolid = true,
+		HitNormal = zero, Normal = norm,
+
+		Fraction = 1, FractionLeftSolid = 0,
+		HitBox = 0, HitGroup = 0, HitTexture = "**studio**",
+		MatType = 0, PhysicsBone = 0, SurfaceProps = 0, DispFlags = 0, Contents = 0,
+
+		Entity = NULL, HitPos = zero, StartPos = zero,
+	}
+
+	---@param player Player
+	---@param entity Entity
+	---@param toolname string
+	function WireLib.CanTool(player, entity, toolname)
+		local pos = entity:GetPos()
+		tr.Entity, tr.HitPos, tr.StartPos = entity, pos, pos
+		return hook.Run("CanTool", player, tr, toolname)
+	end
+end
+
 function WireLib.SetColor(ent, color)
 	color.r = math_clamp(color.r, 0, 255)
 	color.g = math_clamp(color.g, 0, 255)

--- a/lua/wire/stools/expression2.lua
+++ b/lua/wire/stools/expression2.lua
@@ -167,7 +167,7 @@ if SERVER then
 			if chip.player == player then -- Just download if the toolgun user owns this chip
 				self:Download(player, chip)
 				player:SetAnimation(PLAYER_ATTACK1)
-			elseif hook.Run("CanTool", player, WireLib.dummytrace(chip), "wire_expression2") then -- The player has prop protection perms on the chip
+			elseif WireLib.CanTool(player, chip, "wire_expression2") then -- The player has prop protection perms on the chip
 				self:Download(player, chip)
 				player:SetAnimation(PLAYER_ATTACK1)
 
@@ -391,7 +391,7 @@ if SERVER then
 			return
 		end
 
-		if not hook.Run( "CanTool", ply, WireLib.dummytrace( toent ), "wire_expression2" ) then
+		if not WireLib.CanTool(ply, toent, "wire_expression2") then
 			WireLib.AddNotify(ply, "You are not allowed to upload to the target Expression chip. Upload aborted.", NOTIFY_ERROR, 7, NOTIFYSOUND_DRIP3)
 			return
 		end
@@ -466,7 +466,7 @@ if SERVER then
 		if not IsValid(E2) or E2:GetClass() ~= "gmod_wire_expression2" then return end
 		if canhas(player) then return end
 		if E2.error then return end
-		if hook.Run( "CanTool", player, WireLib.dummytrace( E2 ), "wire_expression2", "halt execution" ) then
+		if WireLib.CanTool(player, E2, "wire_expression2") then
 			E2:Destruct()
 			E2:Error("Execution halted (Triggered by: " .. player:Nick() .. ")", "Execution halted")
 			if E2.player ~= player then
@@ -488,7 +488,7 @@ if SERVER then
 		-- Same check as tool code
 		if E2.player == player then
 			WireLib.Expression2Download(player, E2)
-		elseif hook.Run("CanTool", player, WireLib.dummytrace(E2), "wire_expression2") then
+		elseif WireLib.CanTool(player, E2, "wire_expression2") then
 			WireLib.Expression2Download(player, E2)
 
 			local playerType = "player"
@@ -514,7 +514,7 @@ if SERVER then
 		E2 = Entity(E2)
 		if not IsValid(E2) or E2:GetClass() ~= "gmod_wire_expression2" then return end
 		if canhas(player) then return end
-		if hook.Run( "CanTool", player, WireLib.dummytrace( E2 ), "wire_expression2", "reset" ) then
+		if WireLib.CanTool(player, E2, "wire_expression2") then
 			if E2.context.data.last or E2.first then return end
 
 			E2:Reset()

--- a/lua/wire/stools/hydraulic.lua
+++ b/lua/wire/stools/hydraulic.lua
@@ -178,7 +178,7 @@ function TOOL:RightClick( trace )
 	end
 	local trace2 = util.TraceLine( tr )
 
-	if not hook.Run( "CanTool", self:GetOwner(), trace2, "wire_hydraulic" ) then return false end
+	if not WireLib.CanTool(self:GetOwner(), trace2.Entity, "wire_hydraulic") then return false end
 
 	return self:LeftClick(trace) and self:LeftClick(trace2)
 end

--- a/lua/wire/wireshared.lua
+++ b/lua/wire/wireshared.lua
@@ -131,26 +131,6 @@ end
 
 -- end extra table functions
 
-function WireLib.dummytrace(ent)
-	local pos = ent:GetPos()
-	return {
-		FractionLeftSolid = 0,
-		HitNonWorld       = true,
-		Fraction          = 0,
-		Entity            = ent,
-		HitPos            = pos,
-		HitNormal         = Vector(0,0,0),
-		HitBox            = 0,
-		Normal            = Vector(1,0,0),
-		Hit               = true,
-		HitGroup          = 0,
-		MatType           = 0,
-		StartPos          = pos,
-		PhysicsBone       = 0,
-		WorldToLocal      = Vector(0,0,0),
-	}
-end
-
 local table = table
 local pairs_sortvalues = pairs_sortvalues
 local ipairs_map = ipairs_map


### PR DESCRIPTION
* Added CanTool function which uses CPPICanTool if CPPI is available, and falls back to a *much faster* implementation of a CanTool hook call.

* Removed all manual calls to CanTool, replaced with WireLib.CanTool
* Removed WireLib.dummytrace

## Potential issues
* Currently the functions assume the player and entity are valid. Should this be the case?
* The `CanTool` fallback reuses a stored table and only mutates the Entity/StartPos/HitPos fields in order to be optimized. This depends on addons being sane and not for some reason mutating the traceresult. Is this fine?

Fixes #1896
