### PR TITLE
Fix tonemapping with select screens

### DIFF
--- a/lua/entities/gmod_wire_characterlcd/cl_init.lua
+++ b/lua/entities/gmod_wire_characterlcd/cl_init.lua
@@ -415,8 +415,12 @@ function ENT:DrawSpecialCharacter(c,x,y,w,h,r,g,b)
 	end
 end
 
+local VECTOR_1_1_1 = Vector(1, 1, 1)
 function ENT:Draw()
 	self:DrawModel()
+	
+	local tone = render.GetToneMappingScaleLinear()
+	render.SetToneMappingScaleLinear(VECTOR_1_1_1)
 
 	local szx = 18
 	local szy = 24
@@ -540,6 +544,7 @@ function ENT:Draw()
 		end
 	end
 
+	render.SetToneMappingScaleLinear(tone)
 	Wire_Render(self)
 end
 

--- a/lua/entities/gmod_wire_consolescreen/cl_init.lua
+++ b/lua/entities/gmod_wire_consolescreen/cl_init.lua
@@ -531,9 +531,12 @@ function ENT:DrawSpecialCharacter(c,x,y,w,h,r,g,b)
 	end
 end
 
+local VECTOR_1_1_1 = Vector(1, 1, 1)
 function ENT:Draw()
 	self:DrawModel()
-
+	
+	local tone = render.GetToneMappingScaleLinear()
+	render.SetToneMappingScaleLinear(VECTOR_1_1_1)
 	local curtime = CurTime()
 	local DeltaTime = curtime - self.PrevTime
 	self.PrevTime = curtime
@@ -684,6 +687,7 @@ function ENT:Draw()
 	end
 
 	self.GPU:Render(self.Memory1[2024],self.Memory1[2023])
+	render.SetToneMappingScaleLinear(tone)
 	Wire_Render(self)
 end
 

--- a/lua/entities/gmod_wire_digitalscreen/cl_init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/cl_init.lua
@@ -276,8 +276,12 @@ function ENT:RedrawRow(y)
 	end
 end
 
+local VECTOR_1_1_1 = Vector(1, 1, 1)
 function ENT:Draw()
 	self:DrawModel()
+	
+	local tone = render.GetToneMappingScaleLinear()
+	render.SetToneMappingScaleLinear(VECTOR_1_1_1)
 
 	if self.NeedRefresh then
 		self.NeedRefresh = false
@@ -313,8 +317,9 @@ function ENT:Draw()
 			end
 		end)
 	end
-
+	
 	self.GPU:Render(0,0,1024,1024,nil,-(1024-self.ScreenWidth)/1024,-(1024-self.ScreenHeight)/1024)
+	render.SetToneMappingScaleLinear(tone)
 	Wire_Render(self)
 end
 

--- a/lua/entities/gmod_wire_egp/cl_init.lua
+++ b/lua/entities/gmod_wire_egp/cl_init.lua
@@ -70,9 +70,13 @@ end
 
 function ENT:DrawEntityOutline() end
 
+local VECTOR_1_1_1 = Vector(1, 1, 1)
 function ENT:Draw()
 	self:DrawModel()
 	Wire_Render(self)
+	
+	local tone = render.GetToneMappingScaleLinear()
+	render.SetToneMappingScaleLinear(VECTOR_1_1_1)
 	if self.UpdateConstantly or self.NeedsUpdate then
 		self:_EGP_Update()
 	end
@@ -84,6 +88,7 @@ function ENT:Draw()
 	end
 
 	self.GPU:Render(0,0,1024,1024,nil,-0.5,-0.5)
+	render.SetToneMappingScaleLinear(tone)
 end
 
 function ENT:OnRemove()

--- a/lua/entities/gmod_wire_gpu/cl_init.lua
+++ b/lua/entities/gmod_wire_gpu/cl_init.lua
@@ -315,7 +315,7 @@ function ENT:RenderMisc(pos, ang, resolution, aspect, monitor)
 end
 
 
-
+local VECTOR_1_1_1 = Vector(1, 1, 1)
 --------------------------------------------------------------------------------
 -- Entity drawing function
 function ENT:Draw()
@@ -326,6 +326,9 @@ function ENT:Draw()
 
   -- Draw GPU itself
   self:DrawModel()
+  
+	local tone = render.GetToneMappingScaleLinear()
+	render.SetToneMappingScaleLinear(VECTOR_1_1_1)
 
   -- Draw image from another GPU
   local videoSource = MonitorLookup[self:EntIndex()]
@@ -410,7 +413,8 @@ function ENT:Draw()
       self.VertexCamSettings = nil
     end
   end
-
+  
+	render.SetToneMappingScaleLinear(tone)
   Wire_Render(self)
 end
 

--- a/lua/entities/gmod_wire_gpu/cl_init.lua
+++ b/lua/entities/gmod_wire_gpu/cl_init.lua
@@ -319,103 +319,100 @@ local VECTOR_1_1_1 = Vector(1, 1, 1)
 --------------------------------------------------------------------------------
 -- Entity drawing function
 function ENT:Draw()
-  -- Calculate time-related variables
-  self.CurrentTime = CurTime()
-  self.DeltaTime = math.min(1/30,self.CurrentTime - (self.PreviousTime or 0))
-  self.PreviousTime = self.CurrentTime
+	-- Calculate time-related variables
+	self.CurrentTime = CurTime()
+	self.DeltaTime = math.min(1/30,self.CurrentTime - (self.PreviousTime or 0))
+	self.PreviousTime = self.CurrentTime
 
-  -- Draw GPU itself
-  self:DrawModel()
+	-- Draw GPU itself
+	self:DrawModel()
   
 	local tone = render.GetToneMappingScaleLinear()
 	render.SetToneMappingScaleLinear(VECTOR_1_1_1)
 
-  -- Draw image from another GPU
-  local videoSource = MonitorLookup[self:EntIndex()]
-  if videoSource then
-    videoGPU = ents.GetByIndex(videoSource)
-    if videoGPU and videoGPU:IsValid() and videoGPU.GPU then
-      videoGPU.GPU.Entity = self
-      videoGPU.GPU:Render(
-       videoGPU.VM:ReadCell(65522), videoGPU.VM:ReadCell(65523)-videoGPU.VM:ReadCell(65518)/512, -- rotation, scale
-        512*math.Clamp(videoGPU.VM:ReadCell(65525),0,1), 512*math.Clamp(videoGPU.VM:ReadCell(65524),0,1)
-      )
-      videoGPU.GPU.Entity = videoGPU
-    end
-    Wire_Render(self)
-    return
-  end
+	-- Draw image from another GPU
+	local videoSource = MonitorLookup[self:EntIndex()]
+	if videoSource then
+		videoGPU = ents.GetByIndex(videoSource)
+		if videoGPU and videoGPU:IsValid() and videoGPU.GPU then
+			videoGPU.GPU.Entity = self
+			videoGPU.GPU:Render(
+				videoGPU.VM:ReadCell(65522), videoGPU.VM:ReadCell(65523)-videoGPU.VM:ReadCell(65518)/512, -- rotation, scale
+				512*math.Clamp(videoGPU.VM:ReadCell(65525),0,1), 512*math.Clamp(videoGPU.VM:ReadCell(65524),0,1)
+			)
+			videoGPU.GPU.Entity = videoGPU
+		end
+	else
+		if self.DeltaTime > 0 then
+			-- Run the per-frame GPU thread
+			if self.VM.Memory[65532] == 0 then
+				local FrameRate = wire_gpu_frameratio:GetFloat() or 4
+				self.FramesSinceRedraw = (self.FramesSinceRedraw or 0) + 1
+				self.FrameInstructions = 0
+				if self.FramesSinceRedraw >= FrameRate then
+				self.FramesSinceRedraw = 0
+				self:RenderGPU()
+				end
+			end
 
-  if self.DeltaTime > 0 then
-    -- Run the per-frame GPU thread
-    if self.VM.Memory[65532] == 0 then
-      local FrameRate = wire_gpu_frameratio:GetFloat() or 4
-      self.FramesSinceRedraw = (self.FramesSinceRedraw or 0) + 1
-      self.FrameInstructions = 0
-      if self.FramesSinceRedraw >= FrameRate then
-        self.FramesSinceRedraw = 0
-        self:RenderGPU()
-      end
-    end
+			-- Run asynchronous thread
+			if self.VM.Memory[65528] == 1 then
+				self.VM.VertexMode = 0
+				if self.VM.LastBuffer < 2
+				then self:SetRendertarget(self.VM.LastBuffer)
+				else self:SetRendertarget() end
 
-    -- Run asynchronous thread
-    if self.VM.Memory[65528] == 1 then
-      self.VM.VertexMode = 0
-      if self.VM.LastBuffer < 2
-      then self:SetRendertarget(self.VM.LastBuffer)
-      else self:SetRendertarget()
-      end
+				self.VM:RestoreAsyncThread()
+				self:Run(true)
+				self.VM:SaveAsyncThread()
 
-      self.VM:RestoreAsyncThread()
-      self:Run(true)
-      self.VM:SaveAsyncThread()
+				self:SetRendertarget()
+			end
+		end
 
-      self:SetRendertarget()
-    end
-  end
+	  -- Draw GPU to world
+		if self.ChipType == 0 then -- Not a microchip
+			if self.VM.Memory[65532] == 0 then
+				self.GPU:Render(
+				self.VM:ReadCell(65522), self.VM:ReadCell(65523)-self.VM:ReadCell(65518)/512, -- rotation, scale
+				1024*math.Clamp(self.VM:ReadCell(65525),0,1), 1024*math.Clamp(self.VM:ReadCell(65524),0,1), -- width, height
+				function(pos, ang, resolution, aspect, monitor) -- postrenderfunction
+					self:RenderMisc(pos, ang, resolution, aspect, monitor)
+				end,-0.5,-0.5
+			)
+			else
+				-- Custom render to world
+				local monitor, pos, ang = self.GPU:GetInfo()
 
-  -- Draw GPU to world
-  if self.ChipType == 0 then -- Not a microchip
-    if self.VM.Memory[65532] == 0 then
-      self.GPU:Render(
-        self.VM:ReadCell(65522), self.VM:ReadCell(65523)-self.VM:ReadCell(65518)/512, -- rotation, scale
-        1024*math.Clamp(self.VM:ReadCell(65525),0,1), 1024*math.Clamp(self.VM:ReadCell(65524),0,1), -- width, height
-        function(pos, ang, resolution, aspect, monitor) -- postrenderfunction
-          self:RenderMisc(pos, ang, resolution, aspect, monitor)
-        end,-0.5,-0.5
-      )
-    else
-      -- Custom render to world
-      local monitor, pos, ang = self.GPU:GetInfo()
+				--pos = pos + ang:Up()*zoffset
+				pos = pos - ang:Right()*(monitor.y2-monitor.y1)/2
+				pos = pos - ang:Forward()*(monitor.x2-monitor.x1)/2
 
-      --pos = pos + ang:Up()*zoffset
-      pos = pos - ang:Right()*(monitor.y2-monitor.y1)/2
-      pos = pos - ang:Forward()*(monitor.x2-monitor.x1)/2
+				local width,height = 1024*math.Clamp(self.VM.Memory[65525],0,1),
+									 1024*math.Clamp(self.VM.Memory[65524],0,1)
 
-      local width,height = 1024*math.Clamp(self.VM.Memory[65525],0,1),
-                           1024*math.Clamp(self.VM.Memory[65524],0,1)
+				local h = width and width*monitor.RatioX or height or 1024
+				local w = width or h/monitor.RatioX
+				local x = -w/2
+				local y = -h/2
 
-      local h = width and width*monitor.RatioX or height or 1024
-      local w = width or h/monitor.RatioX
-      local x = -w/2
-      local y = -h/2
-
-      local res = monitor.RS*1024/h
-      self.VertexCamSettings = { pos, ang, res }
-      cam.Start3D2D(pos, ang, res)
-      self.In3D2D = true
-        local ok, err = xpcall(function()
-          self:RenderVertex(1024,1024*monitor.RatioX)
-          self:RenderMisc(pos, ang, res, 1/monitor.RatioX, monitor)
-          end, debug.traceback)
-		if not ok then WireLib.ErrorNoHalt(err) end
-      if self.In3D2D then self.In3D2D = false cam.End3D2D() end
-      self.VertexCamSettings = nil
-    end
-  end
+				local res = monitor.RS*1024/h
+				self.VertexCamSettings = { pos, ang, res }
+				cam.Start3D2D(pos, ang, res)
+				self.In3D2D = true
+					local ok, err = xpcall(function()
+					self:RenderVertex(1024,1024*monitor.RatioX)
+					self:RenderMisc(pos, ang, res, 1/monitor.RatioX, monitor)
+					end, debug.traceback)
+					if not ok then WireLib.ErrorNoHalt(err) end
+				if self.In3D2D then self.In3D2D = false cam.End3D2D() end
+				self.VertexCamSettings = nil
+			end
+		end
+	end
   
 	render.SetToneMappingScaleLinear(tone)
-  Wire_Render(self)
+	Wire_Render(self)
 end
 
 


### PR DESCRIPTION
Fixes #2349

Not sure how this can be done better. I tried putting everything in `GPU:Render()` but that didn't work, so I assumed the issue was more complex than that (and maybe better solved like this anyway in that case).
Also wasn't sure if `VECTOR_1_1_1` being a global would breach the coding style or something like that, but I really feel it should be predefined somewhere as a global. Would like to know where that would go.

Note that this will make some old screen codes look over/under-exposed, most likely because they were compensating for this issue.