### PR TITLE
Include forcer in Wire_ForcerCanUse hook

### DIFF
--- a/lua/entities/gmod_wire_forcer.lua
+++ b/lua/entities/gmod_wire_forcer.lua
@@ -81,7 +81,7 @@ function ENT:Think()
 		if not IsValid(self:GetPlayer()) or gamemode.Call( "GravGunPickupAllowed", self:GetPlayer(), ent )==false then return end
 	end
 
-	if hook.Run( "Wire_ForcerCanUse", self:GetPlayer(), ent ) == false then return end
+	if hook.Run( "Wire_ForcerCanUse", self:GetPlayer(), ent, self ) == false then return end
 	
 	if ent:GetMoveType() == MOVETYPE_VPHYSICS then
 		local phys = ent:GetPhysicsObject()


### PR DESCRIPTION
I'm not sure why it would have been left out to begin with. I think the first param should just be the forcer itself, personally, but I know we can't do that.

So anyway, this just adds the forcer itself as a new parameter to the `Wire_ForcerCanUse` hook 👍 