### PR TITLE
Add entityDamage event and `damage` type

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/damage.lua
+++ b/lua/entities/gmod_wire_expression2/core/damage.lua
@@ -61,12 +61,12 @@ e2function number operator_is(damage dmg)
 	return dmg and 1 or 0
 end
 
-e2function number damage:getAmount()
-	return this:GetDamage()
-end
-
 e2function number damage:isType(number type)
 	return this:IsDamageType(type)
+end
+
+e2function number damage:getAmount()
+	return this:GetDamage()
 end
 
 e2function vector damage:getPosition()

--- a/lua/entities/gmod_wire_expression2/core/damage.lua
+++ b/lua/entities/gmod_wire_expression2/core/damage.lua
@@ -1,0 +1,99 @@
+E2Lib.RegisterExtension("damage", false, "Lets E2 chips trigger on entity damage")
+
+local M_CTakeDamageInfo = FindMetaTable("CTakeDamageInfo")
+
+registerType("damage", "xdm", nil,
+	nil, nil,
+	function(retval)
+		if retval == nil then return end
+		if not istable(retval) then error("Return value is neither nil nor a table, but a " .. type(retval) .. "!",0) end
+		if getmetatable(retval) ~= M_CTakeDamageInfo then error("Return value is not a CTakeDamageInfo!", 0) end
+	end,
+	function(v)
+		return not istable(v) or getmetatable(v) ~= M_CTakeDamageInfo
+	end
+)
+
+registerOperator("ass", "xdm", "xdm", function(self, args) -- todo: remove with new compiler
+	local lhs, op2, scope = args[2], args[3], args[4]
+	local rhs = op2[1](self, op2)
+
+	self.Scopes[scope][lhs] = rhs
+	self.Scopes[scope].vclk[lhs] = true
+	return rhs
+end)
+
+E2Lib.registerConstant("DMG_GENERIC", DMG_GENERIC)
+E2Lib.registerConstant("DMG_CRUSH", DMG_CRUSH)
+E2Lib.registerConstant("DMG_BULLET", DMG_BULLET)
+E2Lib.registerConstant("DMG_SLASH", DMG_SLASH)
+E2Lib.registerConstant("DMG_BURN", DMG_BURN)
+E2Lib.registerConstant("DMG_VEHICLE", DMG_VEHICLE)
+E2Lib.registerConstant("DMG_FALL", DMG_FALL)
+E2Lib.registerConstant("DMG_BLAST", DMG_BLAST)
+E2Lib.registerConstant("DMG_CLUB", DMG_CLUB)
+E2Lib.registerConstant("DMG_SHOCK", DMG_SHOCK)
+E2Lib.registerConstant("DMG_SONIC", DMG_SONIC)
+E2Lib.registerConstant("DMG_ENERGYBEAM", DMG_ENERGYBEAM)
+E2Lib.registerConstant("DMG_PREVENT_PHYSICS_FORCE", DMG_PREVENT_PHYSICS_FORCE)
+E2Lib.registerConstant("DMG_NEVERGIB", DMG_NEVERGIB)
+E2Lib.registerConstant("DMG_ALWAYSGIB", DMG_ALWAYSGIB)
+E2Lib.registerConstant("DMG_DROWN", DMG_DROWN)
+E2Lib.registerConstant("DMG_PARALYZE", DMG_PARALYZE)
+E2Lib.registerConstant("DMG_NERVEGAS", DMG_NERVEGAS)
+E2Lib.registerConstant("DMG_POISON", DMG_POISON)
+E2Lib.registerConstant("DMG_RADIATION", DMG_RADIATION)
+E2Lib.registerConstant("DMG_DROWNRECOVER", DMG_DROWNRECOVER)
+E2Lib.registerConstant("DMG_ACID", DMG_ACID)
+E2Lib.registerConstant("DMG_SLOWBURN", DMG_SLOWBURN)
+E2Lib.registerConstant("DMG_REMOVENORAGDOLL", DMG_REMOVENORAGDOLL)
+E2Lib.registerConstant("DMG_PHYSGUN", DMG_PHYSGUN)
+E2Lib.registerConstant("DMG_PLASMA", DMG_PLASMA)
+E2Lib.registerConstant("DMG_AIRBOAT", DMG_AIRBOAT)
+E2Lib.registerConstant("DMG_DISSOLVE", DMG_DISSOLVE)
+E2Lib.registerConstant("DMG_BLAST_SURFACE", DMG_BLAST_SURFACE)
+E2Lib.registerConstant("DMG_DIRECT", DMG_DIRECT)
+E2Lib.registerConstant("DMG_BUCKSHOT", DMG_BUCKSHOT)
+E2Lib.registerConstant("DMG_SNIPER", DMG_SNIPER)
+E2Lib.registerConstant("DMG_MISSILEDEFENSE", DMG_MISSILEDEFENSE)
+
+e2function number operator_is(damage dmg)
+	return dmg and 1 or 0
+end
+
+e2function number damage:getDamage()
+	return this:GetDamage()
+end
+
+e2function number damage:isType(number type)
+	return this:IsDamageType(type)
+end
+
+e2function vector damage:getPosition()
+	return this:GetDamagePosition()
+end
+
+e2function vector damage:getForce()
+	return this:GetDamageForce()
+end
+
+e2function entity damage:getInflictor()
+	return this:GetInflictor()
+end
+
+e2function entity damage:getAttacker()
+	return this:GetAttacker()
+end
+
+e2function number damage:getAmmoType()
+	return this:GetAmmoType()
+end
+
+E2Lib.registerEvent("entityDamage", {
+	{ "Victim", "e" },
+	{ "Damage", "xdm" }
+})
+
+hook.Add("EntityTakeDamage", "E2_entityDamage", function(victim, dmg)
+	E2Lib.triggerEvent("entityDamage", { victim, dmg })
+end)

--- a/lua/entities/gmod_wire_expression2/core/damage.lua
+++ b/lua/entities/gmod_wire_expression2/core/damage.lua
@@ -1,4 +1,4 @@
-E2Lib.RegisterExtension("damage", false, "Lets E2 chips trigger on entity damage")
+E2Lib.RegisterExtension("damage", false, "Lets E2 chips trigger on entity damage, and in the future, cause damage.")
 
 local M_CTakeDamageInfo = FindMetaTable("CTakeDamageInfo")
 
@@ -61,7 +61,7 @@ e2function number operator_is(damage dmg)
 	return dmg and 1 or 0
 end
 
-e2function number damage:getDamage()
+e2function number damage:getAmount()
 	return this:GetDamage()
 end
 

--- a/lua/entities/gmod_wire_expression2/core/extloader.lua
+++ b/lua/entities/gmod_wire_expression2/core/extloader.lua
@@ -20,7 +20,7 @@ if ENT then
 			if not game.SinglePlayer() then MsgN( str ) end
 		end
 
-		timer.Destroy( "E2_AutoReloadTimer" )
+		timer.Remove( "E2_AutoReloadTimer" )
 
 		_Msg( "Calling destructors for all Expression 2 chips." )
 		local chips = ents.FindByClass( "gmod_wire_expression2" )
@@ -69,8 +69,6 @@ end
 
 -- parses typename/typeid associations from a file and stores info about the file for later use by e2_include_finalize/e2_include_pass2
 local function e2_include(name)
-	local path, filename = string.match(name, "^(.-/?)([^/]*)$")
-
 	local luaname = "entities/gmod_wire_expression2/core/" .. name
 	local contents = file.Read(luaname, "LUA") or ""
 	E2Lib.ExtPP.Pass1(contents)

--- a/lua/entities/gmod_wire_expression2/core/extloader.lua
+++ b/lua/entities/gmod_wire_expression2/core/extloader.lua
@@ -161,6 +161,7 @@ e2_include("functions.lua")
 e2_include("strfunc.lua")
 e2_include("steamidconv.lua")
 e2_include("easings.lua")
+e2_include("damage.lua")
 
 -- Load serverside files here, they need additional parsing
 do

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -1540,7 +1540,7 @@ E2Helper.Descriptions["toUnicodeChar(r)"] = "Returns the UTF-8 string from the g
 E2Helper.Descriptions["toUnicodeByte(s:nn)"] = "Returns the Unicode code-points from the given UTF-8 string"
 E2Helper.Descriptions["unicodeLength(s:nn)"] = "Returns the length of the given UTF-8 string"
 
--- Damage
+-- Deaths / Spawns
 E2Helper.Descriptions["runOnDeath(n)"] = "If set to 0, chip won't run on players dying"
 E2Helper.Descriptions["deathClk()"] = "Returns if the E2 was triggered by a death"
 E2Helper.Descriptions["lastDeathTime()"] = "Returns the last time a player died"
@@ -1580,12 +1580,19 @@ E2Helper.Descriptions["setSurfaceProp(xef:n)"] = "Sets the surface property inde
 E2Helper.Descriptions["effectCanPlay()"] = "Returns whether you can play an effect (or 0 if you've hit the burst limit)"
 E2Helper.Descriptions["effectCanPlay(s)"] = "Same as effectCanPlay(), but also checks if the specific effect is not allowed"
 
---Interpolations
+-- Interpolations
 
-local from_easings = {"OutElastic","OutCirc","InOutQuint","InCubic","InOutCubic","InOutBounce","InOutSine","OutQuad","InOutCirc","InElastic","OutBack","InQuint","InSine","InBounce","InQuart","OutSine","OutExpo","InOutExpo","InQuad","InOutElastic","InOutQuart","InExpo","OutCubic","OutQuint","OutBounce","InCirc","InBack","InOutQuad","OutQuart","InOutBack"}
-
-for k, v in pairs(from_easings) do
+for _, v in ipairs {"OutElastic","OutCirc","InOutQuint","InCubic","InOutCubic","InOutBounce","InOutSine","OutQuad","InOutCirc","InElastic","OutBack","InQuint","InSine","InBounce","InQuart","OutSine","OutExpo","InOutExpo","InQuad","InOutElastic","InOutQuart","InExpo","OutCubic","OutQuint","OutBounce","InCirc","InBack","InOutQuad","OutQuart","InOutBack"} do
 	local name = "ease" .. v
-	
 	E2Helper.Descriptions[name .. "(n)"] = "Performs " .. v .. " interpolation on the argument. You can see how all of these interpolation functions look here: https://imgur.com/XZPgymK"
 end
+
+-- Damage
+
+E2Helper.Descriptions["isType(xdm:n)"] = "Returns whether the damage contains the type flag provided. For example isType(_DMG_BLAST) would return 1 if the damage contains blast damage."
+E2Helper.Descriptions["getAmount(xdm:)"] = "Returns the amount of damage dealt"
+E2Helper.Descriptions["getPosition(xdm:)"] = "Returns the position where the damage was dealt"
+E2Helper.Descriptions["getForce(xdm:)"] = "Returns the force of the damage dealt"
+E2Helper.Descriptions["getInflictor(xdm:)"] = "Returns the inflictor (weapon) which caused the damage to be dealt"
+E2Helper.Descriptions["getAttacker(xdm:)"] = "Returns the attacker which used the inflictor to deal the damage"
+E2Helper.Descriptions["getAmmoType(xdm:)"] = "Returns the ammo type id of the damage dealt"


### PR DESCRIPTION
Adds a damage event and damage type, nearly making `damagecore` obsolete.

It doesn't provide any of the `CDamageTypeInfo` setter methods or any form of damage inflicting methods to entity. That could be done in another PR.

It is disabled by default.

Fixes #2623

```golo
event entityDamage(Victim:entity, Damage:damage) {
    print(Victim, Damage:isType(_DMG_BLAST))
}
```

RFC:
* Any potential better names than `entityDamage`?
* Any potential better method names? (Kind of torn on `isType`)
* Should it be disabled by default?