### PR TITLE
New `README.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Coding Guidelines
 
-Please see https://github.com/wiremod/wire/wiki/Coding-style for information on how code formatting is standardized in the Wiremod project.
+Please see https://github.com/wiremod/wire/wiki/Developer-Style-Guide for information on how code formatting is standardized in the Wiremod project.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,37 +1,26 @@
-# Wiremod
+# Wiremod [![License](https://img.shields.io/github/license/wiremod/wire?color=red)](LICENSE) [![Discord](https://img.shields.io/discord/824727565948157963?label=Discord&logo=discord&logoColor=ffffff&labelColor=7289DA&color=2c2f33)](https://discord.gg/H8UKY3Y) [![Workshop](https://img.shields.io/steam/subscriptions/160250458?color=yellow&logo=steam)](https://steamcommunity.com/sharedfiles/filedetails/?id=160250458)
 
-Wiremod is a [Garry's Mod][] addon which adds entities that communicate via data wires. It can be used to control robots, vehicles, to make computers inside Garry's Mod, and much more!
 
-# Workshop Installation
+> An addon for [Garry's Mod](https://garrysmod.com) which adds entities that communicate via wires. It can be used to create robots, vehicles, computers and much more inside Garry's Mod!
 
-The Wiremod Collection is available on the Steam Workshop! Go to the [Workshop page][WireTeam Workshop Collection] and press `Subscribe` on the addons you want
 
-# Manual Installation
+## ⬇️ Installation
 
-Clone this repository into your `steamapps\common\GarrysMod\garrysmod\addons` folder using this command if you are using git:
+### **Workshop**
+Download Wiremod from [the workshop](https://steamcommunity.com/sharedfiles/filedetails/?id=160250458), or AdvDupe2 and other addons from [our collection](https://steamcommunity.com/id/wireteam/myworkshopfiles/?appid=4000).
 
-    git clone https://github.com/wiremod/wire.git wire
+### **Git**
+Otherwise, clone the repository with git:  
+```bash
+git clone https://github.com/wiremod/wire
+```
 
-# License
 
-Copyright 2008 onwards by the Wire Team
+## 📖 Documentation
 
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+You can find documentation [on our wiki](https://github.com/wiremod/wire/wiki)!
 
-http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+## 🤝 Contributing
 
-# Links
-
-[Garry's Mod]: <http://garrysmod.com/>
-
-[WireTeam Workshop Collection]: <https://steamcommunity.com/id/wireteam/myworkshopfiles/?appid=4000>
-
-[Wiremod landing page](http://wiremod.com)
-
-[Wiremod Official Discord](https://discord.gg/H8UKY3Y)
-
-# Contributor Guidelines
-
-See CONTRIBUTING.md for guidelines on contributing and participating in the wiremod project.
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for guidelines on contributing and participating in the wiremod project.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Wiremod [![License](https://img.shields.io/github/license/wiremod/wire?color=red)](LICENSE) [![Discord](https://img.shields.io/discord/231131817640460288?label=Discord&logo=discord&logoColor=ffffff&labelColor=7289DA&color=2c2f33)](https://discord.gg/H8UKY3Y) [![Workshop](https://img.shields.io/steam/subscriptions/160250458?logo=steam)](https://steamcommunity.com/sharedfiles/filedetails/?id=160250458)
 
-
 > An addon for [Garry's Mod](https://garrysmod.com) which adds entities that communicate via wires. It can be used to create robots, vehicles, computers and much more!
-
 
 ## ⬇️ Installation
 
@@ -10,9 +8,9 @@
 |  ---  |   ---    |   ---  |
 |**Wiremod**| [![Wiremod](https://img.shields.io/steam/subscriptions/160250458?logo=steam)](https://steamcommunity.com/sharedfiles/filedetails/?id=160250458) | https://github.com/wiremod/wire |
 |**AdvDupe2**| [![AdvDupe2](https://img.shields.io/steam/subscriptions/160250458?logo=steam)](https://steamcommunity.com/sharedfiles/filedetails/?id=773402917)| https://github.com/wiremod/advdupe2 |
-|**Wire Extras**| None yet | https://github.com/wiremod/wire-extras |
+|**Wire Extras**| [None yet](https://github.com/wiremod/wire-extras/issues/113) | https://github.com/wiremod/wire-extras |
 
-For git, inside of `steamapps/common/Garrysmod/garrysmod/addons`, run: ``git clone https://github.com/wiremod/wire``.
+For git, inside of `steamapps/common/Garrysmod/garrysmod/addons`, run ``git clone https://github.com/wiremod/wire``.
 
 ## 📖 Documentation
 
@@ -20,14 +18,17 @@ You can find documentation [on our wiki](https://github.com/wiremod/wire/wiki)!
 
 
 ## 🤝 Contributing
->By contributing to wiremod, you agree to the [code of conduct](CODE_OF_CONDUCT.md).
+
+> Before contributing to wiremod, take a look at the [code of conduct](CODE_OF_CONDUCT.md).
 
 ### 💡 Suggestions
+
 To submit a suggestion, [use the discussions page](https://github.com/wiremod/wire/discussions/new?category=suggestions).
 
 ### 🐛 Bug Reports
+
 To submit a bug report, [make an issue](https://github.com/wiremod/wire/issues/new/choose).
 
 ### 🧑‍💻 Pull Requests
 
-Before making a PR, you must ensure your code follows the [Developer Style Guide](https://github.com/wiremod/wire/wiki/Developer-Style-Guide).
+Before making a PR, you must ensure your code follows the [developer style guide](https://github.com/wiremod/wire/wiki/Developer-Style-Guide).

--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ To submit a bug report, [make an issue](https://github.com/wiremod/wire/issues/n
 
 ### 🧑‍💻 Pull Requests
 
-Before making a PR, you must ensure your code follows the [developer style guide](https://github.com/wiremod/wire/wiki/Developer-Style-Guide).
+Before making a PR, ensure your code follows the [developer style guide](https://github.com/wiremod/wire/wiki/Developer-Style-Guide).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Wiremod [![License](https://img.shields.io/github/license/wiremod/wire?color=red)](LICENSE) [![Discord](https://img.shields.io/discord/231131817640460288?label=Discord&logo=discord&logoColor=ffffff&labelColor=7289DA&color=2c2f33)](https://discord.gg/H8UKY3Y) [![Workshop](https://img.shields.io/steam/subscriptions/160250458?color=yellow&logo=steam)](https://steamcommunity.com/sharedfiles/filedetails/?id=160250458)
+# Wiremod [![License](https://img.shields.io/github/license/wiremod/wire?color=red)](LICENSE) [![Discord](https://img.shields.io/discord/231131817640460288?label=Discord&logo=discord&logoColor=ffffff&labelColor=7289DA&color=2c2f33)](https://discord.gg/H8UKY3Y) [![Workshop](https://img.shields.io/steam/subscriptions/160250458?logo=steam)](https://steamcommunity.com/sharedfiles/filedetails/?id=160250458)
 
 
 > An addon for [Garry's Mod](https://garrysmod.com) which adds entities that communicate via wires. It can be used to create robots, vehicles, computers and much more!

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 |**AdvDupe2**| [![AdvDupe2](https://img.shields.io/steam/subscriptions/160250458?logo=steam)](https://steamcommunity.com/sharedfiles/filedetails/?id=773402917)| https://github.com/wiremod/advdupe2 |
 |**Wire Extras**| None yet | https://github.com/wiremod/wire-extras |
 
+To install using git, inside of `steamapps/common/Garrysmod/garrysmod/addons`, run ``git clone https://github.com/wiremod/wire``.
 
 ## 📖 Documentation
 
@@ -19,5 +20,14 @@ You can find documentation [on our wiki](https://github.com/wiremod/wire/wiki)!
 
 
 ## 🤝 Contributing
+By contributing to wiremod, you agree to the [code of conduct](CODE_OF_CONDUCT.md).
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for guidelines on contributing and participating in the wiremod project.
+### 💡 Suggestions
+If you want to submit a suggestion, [use the discussions page](https://github.com/wiremod/wire/discussions/new?category=suggestions).
+
+### 🐛 Bug Reports
+To submit a bug report, [make an issue](https://github.com/wiremod/wire/issues/new/choose).
+
+### 🧑‍💻 Pull Requests
+
+Before making a PR, you must ensure your code follows the [Developer Style Guide](https://github.com/wiremod/wire/wiki/Developer-Style-Guide).

--- a/README.md
+++ b/README.md
@@ -1,19 +1,16 @@
 # Wiremod [![License](https://img.shields.io/github/license/wiremod/wire?color=red)](LICENSE) [![Discord](https://img.shields.io/discord/824727565948157963?label=Discord&logo=discord&logoColor=ffffff&labelColor=7289DA&color=2c2f33)](https://discord.gg/H8UKY3Y) [![Workshop](https://img.shields.io/steam/subscriptions/160250458?color=yellow&logo=steam)](https://steamcommunity.com/sharedfiles/filedetails/?id=160250458)
 
 
-> An addon for [Garry's Mod](https://garrysmod.com) which adds entities that communicate via wires. It can be used to create robots, vehicles, computers and much more inside Garry's Mod!
+> An addon for [Garry's Mod](https://garrysmod.com) which adds entities that communicate via wires. It can be used to create robots, vehicles, computers and much more!
 
 
 ## ⬇️ Installation
 
-### **Workshop**
-Download Wiremod from [the workshop](https://steamcommunity.com/sharedfiles/filedetails/?id=160250458), or AdvDupe2 and other addons from [our collection](https://steamcommunity.com/id/wireteam/myworkshopfiles/?appid=4000).
-
-### **Git**
-Otherwise, clone the repository with git:  
-```bash
-git clone https://github.com/wiremod/wire
-```
+| Addon | Workshop | Github |
+|  ---  |   ---    |   ---  |
+|**Wiremod**| [![Wiremod](https://img.shields.io/steam/subscriptions/160250458?logo=steam)](https://steamcommunity.com/sharedfiles/filedetails/?id=160250458) | https://github.com/wiremod/wire |
+|**AdvDupe2**| [![AdvDupe2](https://img.shields.io/steam/subscriptions/160250458?logo=steam)](https://steamcommunity.com/sharedfiles/filedetails/?id=773402917)| https://github.com/wiremod/advdupe2 |
+|**Wire Extras**| None yet | https://github.com/wiremod/wire-extras |
 
 
 ## 📖 Documentation

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ You can find documentation [on our wiki](https://github.com/wiremod/wire/wiki)!
 
 
 ## 🤝 Contributing
-By contributing to wiremod, you agree to the [code of conduct](CODE_OF_CONDUCT.md).
+>By contributing to wiremod, you agree to the [code of conduct](CODE_OF_CONDUCT.md).
 
 ### 💡 Suggestions
-If you want to submit a suggestion, [use the discussions page](https://github.com/wiremod/wire/discussions/new?category=suggestions).
+To submit a suggestion, [use the discussions page](https://github.com/wiremod/wire/discussions/new?category=suggestions).
 
 ### 🐛 Bug Reports
 To submit a bug report, [make an issue](https://github.com/wiremod/wire/issues/new/choose).

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 ## ⬇️ Installation
 
-| Addon | Workshop | Github |
+| Addon | Workshop | GitHub |
 |  ---  |   ---    |   ---  |
 |**Wiremod**| [![Wiremod](https://img.shields.io/steam/subscriptions/160250458?logo=steam)](https://steamcommunity.com/sharedfiles/filedetails/?id=160250458) | https://github.com/wiremod/wire |
 |**AdvDupe2**| [![AdvDupe2](https://img.shields.io/steam/subscriptions/160250458?logo=steam)](https://steamcommunity.com/sharedfiles/filedetails/?id=773402917)| https://github.com/wiremod/advdupe2 |
 |**Wire Extras**| None yet | https://github.com/wiremod/wire-extras |
 
-To install using git, inside of `steamapps/common/Garrysmod/garrysmod/addons`, run ``git clone https://github.com/wiremod/wire``.
+For git, inside of `steamapps/common/Garrysmod/garrysmod/addons`, run: ``git clone https://github.com/wiremod/wire``.
 
 ## 📖 Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Wiremod [![License](https://img.shields.io/github/license/wiremod/wire?color=red)](LICENSE) [![Discord](https://img.shields.io/discord/824727565948157963?label=Discord&logo=discord&logoColor=ffffff&labelColor=7289DA&color=2c2f33)](https://discord.gg/H8UKY3Y) [![Workshop](https://img.shields.io/steam/subscriptions/160250458?color=yellow&logo=steam)](https://steamcommunity.com/sharedfiles/filedetails/?id=160250458)
+# Wiremod [![License](https://img.shields.io/github/license/wiremod/wire?color=red)](LICENSE) [![Discord](https://img.shields.io/discord/231131817640460288?label=Discord&logo=discord&logoColor=ffffff&labelColor=7289DA&color=2c2f33)](https://discord.gg/H8UKY3Y) [![Workshop](https://img.shields.io/steam/subscriptions/160250458?color=yellow&logo=steam)](https://steamcommunity.com/sharedfiles/filedetails/?id=160250458)
 
 
 > An addon for [Garry's Mod](https://garrysmod.com) which adds entities that communicate via wires. It can be used to create robots, vehicles, computers and much more!


### PR DESCRIPTION
Freshened up the readme after not really being changed since its creation a decade ago.

Needed to condense a bunch of things the typical user doesn't care about like the license and git installation.

So I've replaced the installation guide with the table from the wiki which links all of the addons under the wiremod name (advdupe2/wiremod/wire-extras) and created badges for the license, discord link and a steam link.

[Preview here](https://github.com/Vurv78/wire/tree/new-readme)

RFC:
* Any other ideas on what to put here?
* Emojis Y/N?