### PR TITLE
String library refactors

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/angle.lua
+++ b/lua/entities/gmod_wire_expression2/core/angle.lua
@@ -174,6 +174,16 @@ e2function number angle:operator[](index, value)
 	return value
 end
 
+e2function string operator+(string lhs, angle rhs)
+	self.prf = self.prf + #lhs * 0.01
+	return lhs .. ("ang(%d,%d,%d)"):format(rhs[1], rhs[2], rhs[3])
+end
+
+e2function string operator+(angle lhs, string rhs)
+	self.prf = self.prf + #rhs * 0.01
+	return ("ang(%d,%d,%d)"):format(rhs[1], rhs[2], rhs[3]) .. rhs
+end
+
 /******************************************************************************/
 
 __e2setcost(5)

--- a/lua/entities/gmod_wire_expression2/core/angle.lua
+++ b/lua/entities/gmod_wire_expression2/core/angle.lua
@@ -181,7 +181,7 @@ end
 
 e2function string operator+(angle lhs, string rhs)
 	self.prf = self.prf + #rhs * 0.01
-	return ("ang(%d,%d,%d)"):format(rhs[1], rhs[2], rhs[3]) .. rhs
+	return ("ang(%d,%d,%d)"):format(lhs[1], lhs[2], lhs[3]) .. rhs
 end
 
 /******************************************************************************/

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -233,18 +233,14 @@ end)
 
 --[[******************************************************************************]]--
 
-__e2setcost(20) -- temporary
+__e2setcost(2)
 
 e2function number string:toNumber()
-	local ret = tonumber(this)
-	if ret == nil then return 0 end
-	return ret
+	return tonumber(this) or 0
 end
 
 e2function number string:toNumber(number base)
-	local ret = tonumber(this, base)
-	if ret == nil then return 0 end
-	return ret
+	return tonumber(this, base) or 0
 end
 
 local string_char = string.char
@@ -252,21 +248,22 @@ local string_byte = string.byte
 local utf8_char = utf8.char
 local utf8_byte = utf8.codepoint
 
+__e2setcost(1)
+
 e2function string toChar(number n)
-	if n < 0 then return "" end
-	if n > 255 then return "" end
+	if n < 0 or n > 255 then return "" end
 	return string_char(n)
 end
 
 e2function number toByte(string c)
-	if c == "" then return -1 end
-	return string_byte(c)
+	return string_byte(c) or -1
 end
 
 e2function number toByte(string str, number idx)
-	if idx < 1 or idx > #str then return -1 end
-	return string_byte(str, idx)
+	return string_byte(str, idx) or -1
 end
+
+__e2setcost(5)
 
 local math_floor = math.floor
 
@@ -285,6 +282,8 @@ e2function number toUnicodeByte(string c)
 end
 
 --[[******************************************************************************]]--
+
+__e2setcost(2)
 
 [deprecated = "Use the indexing operator instead"]
 e2function string string:index(number idx)
@@ -323,6 +322,8 @@ e2function number string:length()
 	return #this
 end
 
+__e2setcost(10)
+
 e2function number string:unicodeLength()
 	-- the string.gsub method is inconsistent with how writeUnicodeString and toUnicodeByte handles badly-formed sequences.
 	-- local _, length = string.gsub (rv1, "[^\128-\191]", "")
@@ -347,6 +348,8 @@ end
 
 --[[******************************************************************************]]--
 
+__e2setcost(3)
+
 e2function string string:repeat(number times)
 	local len = #this * times
 	if len <= 0 then return "" end
@@ -356,6 +359,8 @@ e2function string string:repeat(number times)
 
 	return this:rep(times)
 end
+
+__e2setcost(2)
 
 e2function string string:trim()
 	return this:Trim()
@@ -370,6 +375,8 @@ e2function string string:trimRight()
 end
 
 --[[******************************************************************************]]--
+
+__e2setcost(10)
 
 local gsub = string.gsub
 local find = string.find
@@ -396,6 +403,8 @@ e2function number string:findRE(string pattern, start)
 	end
 end
 
+__e2setcost(6)
+
 --- Returns the 1st occurrence of the string <needle>, returns 0 if not found. Does not use LUA patterns.
 e2function number string:find(string needle)
 	return this:find( needle, 1, true) or 0
@@ -406,6 +415,8 @@ e2function number string:find(string needle, start)
 	return this:find( needle, start, true) or 0
 end
 
+__e2setcost(8)
+
 --- Finds and replaces every occurrence of <needle> with <new> without regular expressions
 e2function string string:replace(string needle, string new)
 	if needle == "" then return this end
@@ -413,6 +424,8 @@ e2function string string:replace(string needle, string new)
 	if self.prf > e2_tickquota then error("perf", 0) end
 	return this:Replace(needle, new)
 end
+
+__e2setcost(12)
 
 ---  Finds and replaces every occurrence of <pattern> with <new> using regular expressions. Prints malformed string errors to the chat area.
 e2function string string:replaceRE(string pattern, string new)
@@ -427,7 +440,7 @@ e2function string string:replaceRE(string pattern, string new)
 	end
 end
 
-__e2setcost(5)
+__e2setcost(2)
 
 --- Splits the string into an array, along the boundaries formed by the string <pattern>. See also [[string.Explode]]
 local string_Explode = string.Explode
@@ -436,6 +449,8 @@ e2function array string:explode(string delim)
 	self.prf = self.prf + #ret * 0.3 + #this * 0.1
 	return ret
 end
+
+__e2setcost(5)
 
 e2function array string:explodeRE( string delim )
 	local ok, ret = pcall(function() WireLib.CheckRegex(this, delim) return string_Explode( delim, this, true ) end)
@@ -447,7 +462,7 @@ e2function array string:explodeRE( string delim )
 	return ret
 end
 
-__e2setcost(10)
+__e2setcost(6)
 
 --- Returns a reversed version of <this>
 e2function string string:reverse()
@@ -458,8 +473,12 @@ end
 local string_format = string.format
 local gmatch = string.gmatch
 
+__e2setcost(3)
+
 --- Formats a values exactly like Lua's [http://www.lua.org/manual/5.1/manual.html#pdf-string.format string.format]. Any number and type of parameter can be passed through the "...". Prints errors to the chat area.
-e2function string format(string fmt, ...)
+e2function string format(string fmt, ...args)
+	self.prf = self.prf + select("#", ...) * 2
+
 	-- TODO: call toString for table-based types
 	local ok, ret = pcall(string_format, fmt, ...)
 	if not ok then
@@ -473,6 +492,8 @@ end
 -- string.match wrappers by Jeremydeath, 2009-08-30
 local string_match = string.match
 local table_remove = table.remove
+
+__e2setcost(10)
 
 --- runs [[string.match]](<this>, <pattern>) and returns the sub-captures as an array. Prints malformed pattern errors to the chat area.
 e2function array string:match(string pattern)
@@ -519,6 +540,8 @@ local function gmatch( self, this, pattern )
 	return ret
 end
 
+__e2setcost(12)
+
 --- runs [[string.gmatch]](<this>, <pattern>) and returns the captures in an array in a table. Prints malformed pattern errors to the chat area.
 -- (By Divran)
 e2function table string:gmatch(string pattern)
@@ -543,6 +566,8 @@ e2function table string:gmatch(string pattern, position)
 		return ret
 	end
 end
+
+__e2setcost(10)
 
 --- runs [[string.match]](<this>, <pattern>) and returns the first match or an empty string if the match failed. Prints malformed pattern errors to the chat area.
 e2function string string:matchFirst(string pattern)
@@ -588,7 +613,7 @@ local function ToUnicodeChar(self, args)
 	return utf8_char(unpack(codepoints))
 end
 
-__e2setcost(1)
+__e2setcost(3)
 
 --- Returns the UTF-8 string from the given Unicode code-points.
 e2function string toUnicodeChar(...args)

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -508,6 +508,8 @@ local utf8_len = utf8.len
 local function ToUnicodeChar(self, args)
 	local count = #args
 	if count == 0 then return "" end
+	self.prf = self.prf + count * 4
+
 	local codepoints = {}
 	for i = 1, count do
 		local value = args[i]
@@ -518,7 +520,7 @@ local function ToUnicodeChar(self, args)
 			end
 		end
 	end
-	self.prf = self.prf + count * 0.001
+
 	return utf8_char(unpack(codepoints))
 end
 
@@ -540,18 +542,18 @@ e2function array string:toUnicodeByte(number startPos, number endPos)
 	local codepoints = { pcall(utf8_byte, this, startPos, endPos) }
 	local ok = table.remove(codepoints, 1)
 	if not ok then return {} end
-	self.prf = self.prf + #codepoints * 0.001
+	self.prf = self.prf + #codepoints * 3
 	return codepoints
 end
 
 --- Returns the length of the given UTF-8 string.
 e2function number string:unicodeLength(number startPos, number endPos)
 	if #this == 0 then return 0 end
+	self.prf = self.prf + #this
+
 	local ok, length = pcall(utf8_len, this, startPos, endPos)
 	if ok and isnumber(length) then
-		self.prf = self.prf + length * 0.001
 		return length
 	end
-	self.prf = self.prf + #this * 0.001
 	return -1
 end

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -9,6 +9,12 @@
 
 local string = string -- optimization
 
+local string_sub, string_byte, string_char = string.sub, string.byte, string.char
+local string_gsub, string_find, string_match = string.gsub, string.find, string.match
+local string_gmatch, string_format = string.gmatch, string.format
+
+local string_Replace, string_Explode = string.Replace, string.Explode
+
 --[[******************************************************************************]]--
 
 registerType("string", "s", "",
@@ -36,7 +42,6 @@ end)
 
 --[[******************************************************************************]]--
 
-local string_sub = string.sub
 registerOperator("fea", "nss", "", function(self, args)
 	local keyname, valname = args[2], args[3]
 	local str = args[4]
@@ -67,7 +72,6 @@ registerOperator("fea", "nss", "", function(self, args)
 	end
 end)
 
-local string_byte = string.byte
 registerOperator("fea", "nns", "", function(self, args)
 	local keyname, valname = args[2], args[3]
 
@@ -167,8 +171,6 @@ e2function number string:toNumber(number base)
 	return tonumber(this, base) or 0
 end
 
-local string_char = string.char
-local string_byte = string.byte
 local utf8_char = utf8.char
 local utf8_byte = utf8.codepoint
 
@@ -207,31 +209,31 @@ end
 
 --[[******************************************************************************]]--
 
-__e2setcost(2)
+__e2setcost(1)
 
 [deprecated = "Use the indexing operator instead"]
 e2function string string:index(number idx)
-	return this:sub(idx, idx)
+	return string_sub(this, idx, idx)
 end
 
 e2function string string:left(number idx)
-	return this:Left(idx)
+	return string_sub(this, 1, idx)
 end
 
 e2function string string:right(number idx)
-	return this:Right(idx)
+	return string_sub(this, -idx)
 end
 
 e2function string string:sub(number start, number finish)
-	return this:sub(start, finish)
+	return string_sub(this, start, finish)
 end
 
 e2function string string:sub(start)
-	return this:sub(start)
+	return string_sub(this, start)
 end
 
 e2function string string:operator[](index)
-	return this:sub(index,index)
+	return string_sub(this, index, index)
 end
 
 e2function string string:upper()
@@ -302,12 +304,9 @@ end
 
 __e2setcost(10)
 
-local gsub = string.gsub
-local find = string.find
-
 --- Returns the 1st occurrence of the string <pattern>, returns 0 if not found. Prints malformed string errors to the chat area.
 e2function number string:findRE(string pattern)
-	local OK, Ret = pcall(function() WireLib.CheckRegex(this, pattern) return string.find(this, pattern) end)
+	local OK, Ret = pcall(function() WireLib.CheckRegex(this, pattern) return string_find(this, pattern) end)
 	if not OK then
 		return self:throw(Ret, 0)
 	else
@@ -317,7 +316,7 @@ end
 
 ---  Returns the 1st occurrence of the string <pattern> starting at <start> and going to the end of the string, returns 0 if not found. Prints malformed string errors to the chat area.
 e2function number string:findRE(string pattern, start)
-	local OK, Ret = pcall(function() WireLib.CheckRegex(this, pattern) return find(this, pattern, start) end)
+	local OK, Ret = pcall(function() WireLib.CheckRegex(this, pattern) return string_find(this, pattern, start) end)
 	if not OK then
 		return self:throw(Ret, 0)
 	else
@@ -329,12 +328,12 @@ __e2setcost(6)
 
 --- Returns the 1st occurrence of the string <needle>, returns 0 if not found. Does not use LUA patterns.
 e2function number string:find(string needle)
-	return this:find( needle, 1, true) or 0
+	return string_find(this, needle, 1, true) or 0
 end
 
 ---  Returns the 1st occurrence of the string <needle> starting at <start> and going to the end of the string, returns 0 if not found. Does not use LUA patterns.
 e2function number string:find(string needle, start)
-	return this:find( needle, start, true) or 0
+	return string_find(this, needle, start, true) or 0
 end
 
 __e2setcost(8)
@@ -344,7 +343,7 @@ e2function string string:replace(string needle, string new)
 	if needle == "" then return this end
 	self.prf = self.prf + #this * 0.1 + #new * 0.1
 	if self.prf > e2_tickquota then error("perf", 0) end
-	return this:Replace(needle, new)
+	return string_Replace(this, needle, new)
 end
 
 __e2setcost(12)
@@ -353,7 +352,7 @@ __e2setcost(12)
 e2function string string:replaceRE(string pattern, string new)
 	self.prf = self.prf + #this * 0.1 + #new * 0.1
 	if self.prf > e2_tickquota then error("perf", 0) end
-	local OK, Ret = pcall(function() WireLib.CheckRegex(this, pattern) return gsub(this, pattern, new) end)
+	local OK, Ret = pcall(function() WireLib.CheckRegex(this, pattern) return string_gsub(this, pattern, new) end)
 	if not OK then
 		return self:throw(Ret, "")
 	else
@@ -364,7 +363,6 @@ end
 __e2setcost(2)
 
 --- Splits the string into an array, along the boundaries formed by the string <pattern>. See also [[string.Explode]]
-local string_Explode = string.Explode
 e2function array string:explode(string delim)
 	local ret = string_Explode( delim, this )
 	self.prf = self.prf + #ret * 0.3 + #this * 0.1
@@ -392,9 +390,6 @@ e2function string string:reverse()
 end
 
 --[[******************************************************************************]]--
-local string_format = string.format
-local gmatch = string.gmatch
-
 __e2setcost(3)
 
 --- Formats a values exactly like Lua's [http://www.lua.org/manual/5.1/manual.html#pdf-string.format string.format]. Any number and type of parameter can be passed through the "...". Prints errors to the chat area.
@@ -411,7 +406,6 @@ end
 
 --[[******************************************************************************]]--
 -- string.match wrappers by Jeremydeath, 2009-08-30
-local string_match = string.match
 local table_remove = table.remove
 
 __e2setcost(10)
@@ -445,7 +439,7 @@ local newE2Table = E2Lib.newE2Table
 local function gmatch( self, this, pattern )
 	local ret = newE2Table()
 	local num = 0
-	local iter = this:gmatch( pattern )
+	local iter = string_gmatch( this, pattern )
 	local v
 	while true do
 		v = {iter()}

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -393,7 +393,7 @@ end
 __e2setcost(3)
 
 --- Formats a values exactly like Lua's [http://www.lua.org/manual/5.1/manual.html#pdf-string.format string.format]. Any number and type of parameter can be passed through the "...". Prints errors to the chat area.
-e2function string format(string fmt, ...args)
+e2function string format(string fmt, ...)
 	self.prf = self.prf + select("#", ...) * 2
 
 	-- TODO: call toString for table-based types

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -240,6 +240,7 @@ e2function number string:toNumber()
 end
 
 e2function number string:toNumber(number base)
+	if base < 2 or base > 36 then return self:throw("Base out of range", 0) end
 	return tonumber(this, base) or 0
 end
 

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -386,7 +386,6 @@ local find = string.find
 e2function number string:findRE(string pattern)
 	local OK, Ret = pcall(function() WireLib.CheckRegex(this, pattern) return string.find(this, pattern) end)
 	if not OK then
-		self.player:ChatPrint(Ret)
 		return self:throw(Ret, 0)
 	else
 		return Ret or 0
@@ -397,7 +396,6 @@ end
 e2function number string:findRE(string pattern, start)
 	local OK, Ret = pcall(function() WireLib.CheckRegex(this, pattern) return find(this, pattern, start) end)
 	if not OK then
-		self.player:ChatPrint(Ret)
 		return self:throw(Ret, 0)
 	else
 		return Ret or 0
@@ -434,7 +432,6 @@ e2function string string:replaceRE(string pattern, string new)
 	if self.prf > e2_tickquota then error("perf", 0) end
 	local OK, Ret = pcall(function() WireLib.CheckRegex(this, pattern) return gsub(this, pattern, new) end)
 	if not OK then
-		self.player:ChatPrint(Ret)
 		return self:throw(Ret, "")
 	else
 		return Ret or ""
@@ -484,7 +481,6 @@ e2function string format(string fmt, ...args)
 	-- TODO: call toString for table-based types
 	local ok, ret = pcall(string_format, fmt, ...)
 	if not ok then
-		self.player:ChatPrint(ret)
 		return self:throw(ret, "")
 	end
 	return ret
@@ -501,7 +497,6 @@ __e2setcost(10)
 e2function array string:match(string pattern)
 	local args = {pcall(function() WireLib.CheckRegex(this, pattern) return string_match(this, pattern) end)}
 	if not args[1] then
-		self.player:ChatPrint(args[2] or "Unknown error in str:match")
 		return self:throw(args[2], {})
 	else
 		table_remove( args, 1) -- Remove "OK" boolean
@@ -513,7 +508,6 @@ end
 e2function array string:match(string pattern, position)
 	local args = {pcall(function() WireLib.CheckRegex(this, pattern) return string_match(this, pattern, position) end)}
 	if not args[1] then
-		self.player:ChatPrint(args[2] or "Unknown error in str:match")
 		return self:throw(args[2], {})
 	else
 		table_remove( args, 1 ) -- Remove "OK" boolean
@@ -561,7 +555,6 @@ e2function table string:gmatch(string pattern, position)
 	this = this:Right( -position-1 )
 	local OK, ret = pcall(function() WireLib.CheckRegex(this, pattern) return gmatch(self, this, pattern) end)
 	if not OK then
-		self.player:ChatPrint( ret or "Unknown error in str:gmatch" )
 		return self:throw(ret, newE2Table())
 	else
 		return ret
@@ -574,7 +567,6 @@ __e2setcost(10)
 e2function string string:matchFirst(string pattern)
 	local OK, Ret = pcall(function() WireLib.CheckRegex(this, pattern) return string_match(this, pattern) end)
 	if not OK then
-		self.player:ChatPrint(Ret)
 		return self:throw(Ret, "")
 	else
 		return Ret or ""
@@ -585,7 +577,6 @@ end
 e2function string string:matchFirst(string pattern, position)
 	local OK, Ret = pcall(function() WireLib.CheckRegex(this, pattern) return string_match(this, pattern, position) end)
 	if not OK then
-		self.player:ChatPrint(Ret)
 		return self:throw(Ret, "")
 	else
 		return Ret or ""

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -101,135 +101,82 @@ end)
 
 --[[******************************************************************************]]--
 
-registerOperator("is", "s", "n", function(self, args)
-	local op1 = args[2]
-	local rv1 = op1[1](self, op1)
+e2function number operator_is(string this)
+	return this ~= "" and 1 or 0
+end
 
-	return rv1 ~= "" and 1 or 0
-end)
+e2function number operator==(string lhs, string rhs)
+	return lhs == rhs and 1 or 0
+end
 
-registerOperator("eq", "ss", "n", function(self, args)
-	local op1, op2 = args[2], args[3]
-	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
+e2function number operator!=(string lhs, string rhs)
+	return lhs ~= rhs and 1 or 0
+end
 
-	return rv1 == rv2 and 1 or 0
-end)
+e2function number operator>=(string lhs, string rhs)
+	self.prf = self.prf + math.min(#lhs, #rhs) / 10
+	return lhs >= rhs and 1 or 0
+end
 
-registerOperator("neq", "ss", "n", function(self, args)
-	local op1, op2 = args[2], args[3]
-	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
+e2function number operator<=(string lhs, string rhs)
+	self.prf = self.prf + math.min(#lhs, #rhs) / 10
+	return lhs <= rhs and 1 or 0
+end
 
-	return rv1 ~= rv2 and 1 or 0
-end)
+e2function number operator>(string lhs, string rhs)
+	self.prf = self.prf + math.min(#lhs, #rhs) / 10
+	return lhs > rhs and 1 or 0
+end
 
-registerOperator("geq", "ss", "n", function(self, args)
-	local op1, op2 = args[2], args[3]
-	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
-
-	self.prf = self.prf + math.min(#rv1, #rv2) / 10
-
-	return rv1 >= rv2 and 1 or 0
-end)
-
-registerOperator("leq", "ss", "n", function(self, args)
-	local op1, op2 = args[2], args[3]
-	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
-
-	self.prf = self.prf + math.min(#rv1, #rv2) / 10
-
-	return rv1 <= rv2 and 1 or 0
-end)
-
-registerOperator("gth", "ss", "n", function(self, args)
-	local op1, op2 = args[2], args[3]
-	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
-
-	self.prf = self.prf + math.min(#rv1, #rv2) / 10
-
-	return rv1 > rv2 and 1 or 0
-end)
-
-registerOperator("lth", "ss", "n", function(self, args)
-	local op1, op2 = args[2], args[3]
-	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
-
-	self.prf = self.prf + math.min(#rv1, #rv2) / 10
-
-	return rv1 < rv2 and 1 or 0
-end)
+e2function number operator<(string lhs, string rhs)
+	self.prf = self.prf + math.min(#lhs, #rhs) / 10
+	return lhs < rhs and 1 or 0
+end
 
 --[[******************************************************************************]]--
 
-__e2setcost(10) -- temporary
+__e2setcost(1) -- temporary
 
-registerOperator("add", "ss", "s", function(self, args)
-	local op1, op2 = args[2], args[3]
-	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
-
-	self.prf = self.prf + #rv1*0.01 + #rv2*0.01
-
-	return rv1 .. rv2
-end)
+e2function string operator+(string lhs, string rhs)
+	self.prf = self.prf + #lhs * 0.01 + #rhs * 0.01
+	return lhs .. rhs
+end
 
 --[[******************************************************************************]]--
 
-registerOperator("add", "sn", "s", function(self, args)
-	local op1, op2 = args[2], args[3]
-	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
+e2function string operator+(string lhs, number rhs)
+	self.prf = self.prf + #lhs * 0.01
+	return lhs .. rhs --[[ concatenating a number to a string is valid without tostring. ]]
+end
 
-	self.prf = self.prf + #rv1*0.01
-
-	return rv1 .. tostring(rv2)
-end)
-
-registerOperator("add", "ns", "s", function(self, args)
-	local op1, op2 = args[2], args[3]
-	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
-
-	self.prf = self.prf + #rv2*0.01
-
-	return tostring(rv1) .. rv2
-end)
+e2function string operator+(number lhs, string rhs)
+	self.prf = self.prf + #rhs * 0.01
+	return lhs .. rhs --[[ concatenating a strings to a number is valid without tostring. ]]
+end
 
 --[[******************************************************************************]]--
 
-registerOperator("add", "sv", "s", function(self, args)
-	local op1, op2 = args[2], args[3]
-	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
+e2function string operator+(string lhs, vector rhs)
+	self.prf = self.prf + #lhs * 0.01
+	return lhs .. ("vec(%.2f,%.2f,%.2f)"):format(rhs[1], rhs[2], rhs[3])
+end
 
-	self.prf = self.prf + #rv1*0.01
-
-	return ("%s[%s,%s,%s]"):format( rv1, rv2[1], rv2[2], rv2[3] )
-end)
-
-registerOperator("add", "vs", "s", function(self, args)
-	local op1, op2 = args[2], args[3]
-	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
-
-	self.prf = self.prf + #rv2*0.01
-
-	return ("[%s,%s,%s]%s"):format( rv1[1],rv1[2],rv1[3],rv2)
-end)
+e2function string operator+(vector lhs, string rhs)
+	self.prf = self.prf + #rhs * 0.01
+	return ("vec(%.2f,%.2f,%.2f)"):format(rhs[1], rhs[2], rhs[3]) .. rhs
+end
 
 --[[******************************************************************************]]--
 
-registerOperator("add", "sa", "s", function(self, args)
-	local op1, op2 = args[2], args[3]
-	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
+e2function string operator+(string lhs, angle rhs)
+	self.prf = self.prf + #lhs * 0.01
+	return lhs .. ("ang(%d,%d,%d)"):format(rhs[1], rhs[2], rhs[3])
+end
 
-	self.prf = self.prf + #rv1*0.01
-
-	return ("%s[%s,%s,%s]"):format( rv1,rv2[1],rv2[2],rv2[3] )
-end)
-
-registerOperator("add", "as", "s", function(self, args)
-	local op1, op2 = args[2], args[3]
-	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
-
-	self.prf = self.prf + #rv2*0.01
-
-	return ("[%s,%s,%s]%s"):format( rv1[1],rv1[2],rv1[3],rv2)
-end)
+e2function string operator+(angle lhs, string rhs)
+	self.prf = self.prf + #rhs * 0.01
+	return ("ang(%d,%d,%d)"):format(rhs[1], rhs[2], rhs[3]) .. rhs
+end
 
 --[[******************************************************************************]]--
 

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -156,30 +156,6 @@ end
 
 --[[******************************************************************************]]--
 
-e2function string operator+(string lhs, vector rhs)
-	self.prf = self.prf + #lhs * 0.01
-	return lhs .. ("vec(%.2f,%.2f,%.2f)"):format(rhs[1], rhs[2], rhs[3])
-end
-
-e2function string operator+(vector lhs, string rhs)
-	self.prf = self.prf + #rhs * 0.01
-	return ("vec(%.2f,%.2f,%.2f)"):format(rhs[1], rhs[2], rhs[3]) .. rhs
-end
-
---[[******************************************************************************]]--
-
-e2function string operator+(string lhs, angle rhs)
-	self.prf = self.prf + #lhs * 0.01
-	return lhs .. ("ang(%d,%d,%d)"):format(rhs[1], rhs[2], rhs[3])
-end
-
-e2function string operator+(angle lhs, string rhs)
-	self.prf = self.prf + #rhs * 0.01
-	return ("ang(%d,%d,%d)"):format(rhs[1], rhs[2], rhs[3]) .. rhs
-end
-
---[[******************************************************************************]]--
-
 __e2setcost(2)
 
 e2function number string:toNumber()

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -387,7 +387,7 @@ e2function number string:findRE(string pattern)
 	local OK, Ret = pcall(function() WireLib.CheckRegex(this, pattern) return string.find(this, pattern) end)
 	if not OK then
 		self.player:ChatPrint(Ret)
-		return 0
+		return self:throw(Ret, 0)
 	else
 		return Ret or 0
 	end
@@ -398,7 +398,7 @@ e2function number string:findRE(string pattern, start)
 	local OK, Ret = pcall(function() WireLib.CheckRegex(this, pattern) return find(this, pattern, start) end)
 	if not OK then
 		self.player:ChatPrint(Ret)
-		return 0
+		return self:throw(Ret, 0)
 	else
 		return Ret or 0
 	end
@@ -435,7 +435,7 @@ e2function string string:replaceRE(string pattern, string new)
 	local OK, Ret = pcall(function() WireLib.CheckRegex(this, pattern) return gsub(this, pattern, new) end)
 	if not OK then
 		self.player:ChatPrint(Ret)
-		return ""
+		return self:throw(Ret, "")
 	else
 		return Ret or ""
 	end
@@ -454,12 +454,13 @@ end
 __e2setcost(5)
 
 e2function array string:explodeRE( string delim )
+	self.prf = self.prf + #this * 0.1
 	local ok, ret = pcall(function() WireLib.CheckRegex(this, delim) return string_Explode( delim, this, true ) end)
 	if not ok then
-		self.player:ChatPrint(ret)
-		ret = {}
+		return self:throw(ret, {})
 	end
-	self.prf = self.prf + #ret * 0.3 + #this * 0.1
+
+	self.prf = self.prf + #ret * 0.3
 	return ret
 end
 
@@ -484,7 +485,7 @@ e2function string format(string fmt, ...args)
 	local ok, ret = pcall(string_format, fmt, ...)
 	if not ok then
 		self.player:ChatPrint(ret)
-		return ""
+		return self:throw(ret, "")
 	end
 	return ret
 end
@@ -501,9 +502,9 @@ e2function array string:match(string pattern)
 	local args = {pcall(function() WireLib.CheckRegex(this, pattern) return string_match(this, pattern) end)}
 	if not args[1] then
 		self.player:ChatPrint(args[2] or "Unknown error in str:match")
-		return {}
+		return self:throw(args[2], {})
 	else
-		table_remove( args, 1 ) -- Remove "OK" boolean
+		table_remove( args, 1) -- Remove "OK" boolean
 		return args or {}
 	end
 end
@@ -513,7 +514,7 @@ e2function array string:match(string pattern, position)
 	local args = {pcall(function() WireLib.CheckRegex(this, pattern) return string_match(this, pattern, position) end)}
 	if not args[1] then
 		self.player:ChatPrint(args[2] or "Unknown error in str:match")
-		return {}
+		return self:throw(args[2], {})
 	else
 		table_remove( args, 1 ) -- Remove "OK" boolean
 		return args or {}
@@ -548,8 +549,7 @@ __e2setcost(12)
 e2function table string:gmatch(string pattern)
 	local OK, ret = pcall(function() WireLib.CheckRegex(this, pattern) return gmatch(self, this, pattern) end)
 	if not OK then
-		self.player:ChatPrint( ret or "Unknown error in str:gmatch" )
-		return newE2Table()
+		return self:throw(ret, newE2Table())
 	else
 		return ret
 	end
@@ -562,7 +562,7 @@ e2function table string:gmatch(string pattern, position)
 	local OK, ret = pcall(function() WireLib.CheckRegex(this, pattern) return gmatch(self, this, pattern) end)
 	if not OK then
 		self.player:ChatPrint( ret or "Unknown error in str:gmatch" )
-		return newE2Table()
+		return self:throw(ret, newE2Table())
 	else
 		return ret
 	end
@@ -575,7 +575,7 @@ e2function string string:matchFirst(string pattern)
 	local OK, Ret = pcall(function() WireLib.CheckRegex(this, pattern) return string_match(this, pattern) end)
 	if not OK then
 		self.player:ChatPrint(Ret)
-		return ""
+		return self:throw(Ret, "")
 	else
 		return Ret or ""
 	end
@@ -586,7 +586,7 @@ e2function string string:matchFirst(string pattern, position)
 	local OK, Ret = pcall(function() WireLib.CheckRegex(this, pattern) return string_match(this, pattern, position) end)
 	if not OK then
 		self.player:ChatPrint(Ret)
-		return ""
+		return self:throw(Ret, "")
 	else
 		return Ret or ""
 	end

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -306,21 +306,21 @@ __e2setcost(10)
 
 --- Returns the 1st occurrence of the string <pattern>, returns 0 if not found. Prints malformed string errors to the chat area.
 e2function number string:findRE(string pattern)
-	local OK, Ret = pcall(function() WireLib.CheckRegex(this, pattern) return string_find(this, pattern) end)
-	if not OK then
-		return self:throw(Ret, 0)
+	local ok, ret = pcall(function() WireLib.CheckRegex(this, pattern) return string_find(this, pattern) end)
+	if not ok then
+		return self:throw(ret, 0)
 	else
-		return Ret or 0
+		return ret or 0
 	end
 end
 
 ---  Returns the 1st occurrence of the string <pattern> starting at <start> and going to the end of the string, returns 0 if not found. Prints malformed string errors to the chat area.
 e2function number string:findRE(string pattern, start)
-	local OK, Ret = pcall(function() WireLib.CheckRegex(this, pattern) return string_find(this, pattern, start) end)
-	if not OK then
-		return self:throw(Ret, 0)
+	local ok, ret = pcall(function() WireLib.CheckRegex(this, pattern) return string_find(this, pattern, start) end)
+	if not ok then
+		return self:throw(ret, 0)
 	else
-		return Ret or 0
+		return ret or 0
 	end
 end
 
@@ -352,11 +352,11 @@ __e2setcost(12)
 e2function string string:replaceRE(string pattern, string new)
 	self.prf = self.prf + #this * 0.1 + #new * 0.1
 	if self.prf > e2_tickquota then error("perf", 0) end
-	local OK, Ret = pcall(function() WireLib.CheckRegex(this, pattern) return string_gsub(this, pattern, new) end)
-	if not OK then
-		return self:throw(Ret, "")
+	local ok, ret = pcall(function() WireLib.CheckRegex(this, pattern) return string_gsub(this, pattern, new) end)
+	if not ok then
+		return self:throw(ret, "")
 	else
-		return Ret or ""
+		return ret or ""
 	end
 end
 
@@ -458,8 +458,8 @@ __e2setcost(12)
 --- runs [[string.gmatch]](<this>, <pattern>) and returns the captures in an array in a table. Prints malformed pattern errors to the chat area.
 -- (By Divran)
 e2function table string:gmatch(string pattern)
-	local OK, ret = pcall(function() WireLib.CheckRegex(this, pattern) return gmatch(self, this, pattern) end)
-	if not OK then
+	local ok, ret = pcall(function() WireLib.CheckRegex(this, pattern) return gmatch(self, this, pattern) end)
+	if not ok then
 		return self:throw(ret, newE2Table())
 	else
 		return ret
@@ -470,8 +470,8 @@ end
 -- (By Divran)
 e2function table string:gmatch(string pattern, position)
 	this = this:Right( -position-1 )
-	local OK, ret = pcall(function() WireLib.CheckRegex(this, pattern) return gmatch(self, this, pattern) end)
-	if not OK then
+	local ok, ret = pcall(function() WireLib.CheckRegex(this, pattern) return gmatch(self, this, pattern) end)
+	if not ok then
 		return self:throw(ret, newE2Table())
 	else
 		return ret
@@ -482,21 +482,21 @@ __e2setcost(10)
 
 --- runs [[string.match]](<this>, <pattern>) and returns the first match or an empty string if the match failed. Prints malformed pattern errors to the chat area.
 e2function string string:matchFirst(string pattern)
-	local OK, Ret = pcall(function() WireLib.CheckRegex(this, pattern) return string_match(this, pattern) end)
-	if not OK then
-		return self:throw(Ret, "")
+	local ok, ret = pcall(function() WireLib.CheckRegex(this, pattern) return string_match(this, pattern) end)
+	if not ok then
+		return self:throw(ret, "")
 	else
-		return Ret or ""
+		return ret or ""
 	end
 end
 
 --- runs [[string.match]](<this>, <pattern>, <position>) and returns the first match or an empty string if the match failed. Prints malformed pattern errors to the chat area.
 e2function string string:matchFirst(string pattern, position)
-	local OK, Ret = pcall(function() WireLib.CheckRegex(this, pattern) return string_match(this, pattern, position) end)
-	if not OK then
-		return self:throw(Ret, "")
+	local ok, ret = pcall(function() WireLib.CheckRegex(this, pattern) return string_match(this, pattern, position) end)
+	if not ok then
+		return self:throw(ret, "")
 	else
-		return Ret or ""
+		return ret or ""
 	end
 end
 

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -252,7 +252,7 @@ local utf8_byte = utf8.codepoint
 __e2setcost(1)
 
 e2function string toChar(number n)
-	if n < 0 or n > 255 then return "" end
+	if n < 0 or n > 255 then return self:throw("Invalid argument (" .. n .. ") (must be between 0 and 255)", "") end
 	return string_char(n)
 end
 
@@ -271,7 +271,7 @@ local math_floor = math.floor
 e2function string toUnicodeChar(number byte)
 	-- upper limit used to be 2097152, new limit acquired using pcall and a for loop
 	-- above this limit, the function causes a lua error
-	if byte < 1 or byte > 1114112 then return "" end
+	if byte < 1 or byte > 1114112 then return self:throw("Invalid argument (" .. byte .. ") (must be between 1 and 1,114,112)", "") end
 	return utf8_char(byte)
 end
 

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -2,13 +2,6 @@
 --  String support
 --[[******************************************************************************]]--
 
--- TODO: is string.left() faster than s:left()?
--- TODO: is string.sub faster than both left and right?
--- TODO: these return bad results when used with negative numbers!
--- TODO: benchmarks!
-
-local string = string -- optimization
-
 local string_sub, string_byte, string_char = string.sub, string.byte, string.char
 local string_gsub, string_find, string_match = string.gsub, string.find, string.match
 local string_gmatch, string_format = string.gmatch, string.format

--- a/lua/entities/gmod_wire_expression2/core/vector.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector.lua
@@ -179,7 +179,7 @@ end
 
 e2function string operator+(vector lhs, string rhs)
 	self.prf = self.prf + #rhs * 0.01
-	return ("vec(%.2f,%.2f,%.2f)"):format(rhs[1], rhs[2], rhs[3]) .. rhs
+	return ("vec(%.2f,%.2f,%.2f)"):format(lhs[1], lhs[2], lhs[3]) .. rhs
 end
 
 --------------------------------------------------------------------------------

--- a/lua/entities/gmod_wire_expression2/core/vector.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector.lua
@@ -172,6 +172,16 @@ e2function number vector:operator[](index, value)
 	return value
 end
 
+e2function string operator+(string lhs, vector rhs)
+	self.prf = self.prf + #lhs * 0.01
+	return lhs .. ("vec(%.2f,%.2f,%.2f)"):format(rhs[1], rhs[2], rhs[3])
+end
+
+e2function string operator+(vector lhs, string rhs)
+	self.prf = self.prf + #rhs * 0.01
+	return ("vec(%.2f,%.2f,%.2f)"):format(rhs[1], rhs[2], rhs[3]) .. rhs
+end
+
 --------------------------------------------------------------------------------
 
 __e2setcost(10) -- temporary


### PR DESCRIPTION
This refactors the string library to use `e2function` syntax, optimizes it, and lowers the op costs for everything.

Worst offender was a "temporary" 20 ops cost that covered most of the functions, which has been removed