### PR TITLE
Add damage inflicting functions

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/damage.lua
+++ b/lua/entities/gmod_wire_expression2/core/damage.lua
@@ -1,4 +1,4 @@
-E2Lib.RegisterExtension("damage", false, "Lets E2 chips trigger on entity damage, and in the future, cause damage.")
+E2Lib.RegisterExtension("damage", true, "Lets E2 chips trigger on entity damage, and cause damage if wire_expression2_damage_enabled is set to 1.")
 
 local M_CTakeDamageInfo = FindMetaTable("CTakeDamageInfo")
 
@@ -61,32 +61,77 @@ e2function number operator_is(damage dmg)
 	return dmg and 1 or 0
 end
 
+[nodiscard]
 e2function number damage:isType(number type)
 	return this:IsDamageType(type) and 1 or 0
 end
 
+[nodiscard]
 e2function number damage:getAmount()
 	return this:GetDamage()
 end
 
+[nodiscard]
 e2function vector damage:getPosition()
 	return this:GetDamagePosition()
 end
 
+[nodiscard]
 e2function vector damage:getForce()
 	return this:GetDamageForce()
 end
 
+[nodiscard]
 e2function entity damage:getInflictor()
 	return this:GetInflictor()
 end
 
+[nodiscard]
 e2function entity damage:getAttacker()
 	return this:GetAttacker()
 end
 
+[nodiscard]
 e2function number damage:getAmmoType()
 	return this:GetAmmoType()
+end
+
+local Enabled = CreateConVar("wire_expression2_damage_enabled", 0, FCVAR_ARCHIVE, "Whether to enable causing damage in the E2 'damage' extension.")
+local MaxRadius = CreateConVar("wire_expression2_damage_maxradius", 2000, FCVAR_ARCHIVE, "Maximum radius able to be applied with the blastDamage E2 function.")
+
+e2function void entity:takeDamage(number amount)
+	if not Enabled:GetBool() then return self:throw("Dealing damage is disabled via wire_expression2_damage_enabled") end
+	if not IsValid(this) then return self:throw("Invalid entity!", nil) end
+	if not WireLib.CanDamage(self.player, this) then return self:throw("You cannot damage this entity!", nil) end
+
+	this:TakeDamage(amount, self.player, self.entity)
+end
+
+e2function void entity:takeDamage(number amount, entity attacker)
+	if not Enabled:GetBool() then return self:throw("Dealing damage is disabled via wire_expression2_damage_enabled") end
+	if not IsValid(this) then return self:throw("Invalid entity!", nil) end
+	if not IsValid(attacker) then return self:throw("Invalid attacker entity!", nil) end
+	if not E2Lib.isOwner(attacker) then return self:throw("You do not own the attacker entity!", nil) end
+	if not WireLib.CanDamage(self.player, this) then return self:throw("You cannot damage this entity!", nil) end
+
+	this:TakeDamage(amount, attacker, self.entity)
+end
+
+e2function void entity:takeDamage(number amount, entity attacker, entity inflictor)
+	if not Enabled:GetBool() then return self:throw("Dealing damage is disabled via wire_expression2_damage_enabled") end
+	if not IsValid(this) then return self:throw("Invalid entity!", nil) end
+	if not IsValid(attacker) then return self:throw("Invalid attacker entity!", nil) end
+	if not E2Lib.isOwner(attacker) then return self:throw("You do not own the attacker entity!", nil) end
+	if not IsValid(inflictor) then return self:throw("Invalid inflictor entity!", nil) end
+	if not E2Lib.isOwner(inflictor) then return self:throw("You do not own the inflictor entity!", nil) end
+	if not WireLib.CanDamage(self.player, this) then self:throw("You cannot damage this entity!", nil) end
+
+	this:TakeDamage(amount, attacker, inflictor)
+end
+
+e2function void blastDamage(vector origin, number radius, number damage)
+	if not Enabled:GetBool() then return self:throw("Dealing damage is disabled via wire_expression2_damage_enabled") end
+	util.BlastDamage(self.entity, self.player, origin, math.Clamp(radius, 0, MaxRadius:GetInt()), damage)
 end
 
 E2Lib.registerEvent("entityDamage", {

--- a/lua/entities/gmod_wire_expression2/core/damage.lua
+++ b/lua/entities/gmod_wire_expression2/core/damage.lua
@@ -57,6 +57,8 @@ E2Lib.registerConstant("DMG_BUCKSHOT", DMG_BUCKSHOT)
 E2Lib.registerConstant("DMG_SNIPER", DMG_SNIPER)
 E2Lib.registerConstant("DMG_MISSILEDEFENSE", DMG_MISSILEDEFENSE)
 
+__e2setcost(1)
+
 e2function number operator_is(damage dmg)
 	return dmg and 1 or 0
 end
@@ -99,6 +101,8 @@ end
 local Enabled = CreateConVar("wire_expression2_damage_enabled", 0, FCVAR_ARCHIVE, "Whether to enable causing damage in the E2 'damage' extension.")
 local MaxRadius = CreateConVar("wire_expression2_damage_maxradius", 2000, FCVAR_ARCHIVE, "Maximum radius able to be applied with the blastDamage E2 function.")
 
+__e2setcost(20)
+
 e2function void entity:takeDamage(number amount)
 	if not Enabled:GetBool() then return self:throw("Dealing damage is disabled via wire_expression2_damage_enabled") end
 	if not IsValid(this) then return self:throw("Invalid entity!", nil) end
@@ -128,6 +132,8 @@ e2function void entity:takeDamage(number amount, entity attacker, entity inflict
 
 	this:TakeDamage(amount, attacker, inflictor)
 end
+
+__e2setcost(10)
 
 e2function void blastDamage(vector origin, number radius, number damage)
 	if not Enabled:GetBool() then return self:throw("Dealing damage is disabled via wire_expression2_damage_enabled") end

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -1597,3 +1597,9 @@ E2Helper.Descriptions["getForce(xdm:)"] = "Returns the force of the damage dealt
 E2Helper.Descriptions["getInflictor(xdm:)"] = "Returns the inflictor (weapon) which caused the damage to be dealt"
 E2Helper.Descriptions["getAttacker(xdm:)"] = "Returns the attacker which used the inflictor to deal the damage"
 E2Helper.Descriptions["getAmmoType(xdm:)"] = "Returns the ammo type id of the damage dealt"
+
+E2Helper.Descriptions["takeDamage(e:n)"] = "Applies an amount of damage to the player. Requires wire_expression2_damage_enabled to be set to 1."
+E2Helper.Descriptions["takeDamage(e:ne)"] = "Applies an amount of damage to the player with given attacker. Requires wire_expression2_damage_enabled to be set to 1."
+E2Helper.Descriptions["takeDamage(e:nee)"] = "Applies an amount of damage to the player with given attacker and inflictor. Requires wire_expression2_damage_enabled to be set to 1."
+
+E2Helper.Descriptions["blastDamage(vnn)"] = "Creates blast damage at the position provided with specified radius and damage amount. Requires wire_expression2_damage_enabled to be set to 1."

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1231,7 +1231,7 @@ else
 	---@param target Entity
 	function WireLib.CanDamage(player, target) ---@return boolean
 		if target:IsPlayer() then
-			return hook.Run("PlayerShouldTakeDamage", target, player)
+			return hook.Run("PlayerShouldTakeDamage", target, player) ~= false
 		else
 			return WireLib.CanTool(player, target, "")
 		end

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1218,16 +1218,23 @@ else
 end
 
 if CPPI and FindMetaTable("Entity").CPPICanDamage then
+	--- Returns if given player can damage the given entity.
 	---@param player Player
-	---@param target Player
-	function WireLib.CanDamage(player, target)
+	---@param target Entity
+	function WireLib.CanDamage(player, target) ---@return boolean
 		return target:CPPICanDamage(player)
 	end
 else
+	--- Returns if given player can damage the given entity.
+	--- Uses PlayerShouldTakeDamage for players, CanTool for entities.
 	---@param player Player
-	---@param target Player
-	function WireLib.CanDamage(player, target)
-		return hook.Run("PlayerShouldTakeDamage", target, player)
+	---@param target Entity
+	function WireLib.CanDamage(player, target) ---@return boolean
+		if target:IsPlayer() then
+			return hook.Run("PlayerShouldTakeDamage", target, player)
+		else
+			return WireLib.CanTool(player, target, "")
+		end
 	end
 end
 

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1217,6 +1217,20 @@ else
 	end
 end
 
+if CPPI and FindMetaTable("Entity").CPPICanDamage then
+	---@param player Player
+	---@param target Player
+	function WireLib.CanDamage(player, target)
+		return target:CPPICanDamage(player)
+	end
+else
+	---@param player Player
+	---@param target Player
+	function WireLib.CanDamage(player, target)
+		return hook.Run("PlayerShouldTakeDamage", target, player)
+	end
+end
+
 function WireLib.SetColor(ent, color)
 	color.r = math_clamp(color.r, 0, 255)
 	color.g = math_clamp(color.g, 0, 255)


### PR DESCRIPTION
* Add `WireLib.CanDamage` which uses CPPICanDamage or PlayerShouldTakeDamage if CPPI is absent.
* Enables the `damage` extension by default (only allows getter functions and the event by default)
* Add `blastDamage(vnn)`, `e:takeDamage(n)`, `e:takeDamage(ne)`, `e:takeDamage(nee)`, all disabled by default with `wire_expression2_damage_enabled` convar.
* Add `wire_expression2_damage_maxradius` to control max blastDamage radius, default 2000.
* Mark existing `damage` getter methods as `nodiscard`

Currently haven't implemented the equivalent of https://wiki.facepunch.com/gmod/Entity:TakeDamageInfo, mostly because apparently `CTakeDamageInfo` objects are shared, so I'd need to write a table wrapper in between E2 and GLua, and it just isn't worth it for the small extra functionality it would add, at least for now.

RFC:
* Different convar names?
* Should default max radius be adjusted?