### PR TITLE
Show file name before deletion

### DIFF
--- a/lua/wire/client/wire_expression2_browser.lua
+++ b/lua/wire/client/wire_expression2_browser.lua
@@ -258,10 +258,13 @@ function PANEL:Init()
 			end)
 	end)
 	self:AddRightClick(self.filemenu, nil, "Delete", function()
-		Derma_Query("Delete this file?", "Delete",
+		local filePath = self.File:GetFileName()
+		local message = string.format("Delete this file?\n\n%s", fileName(filePath))
+
+		Derma_Query(message, "Delete",
 			"Delete", function()
-				if (file.Exists(self.File:GetFileName(), "DATA")) then
-					file.Delete(self.File:GetFileName())
+				if (file.Exists(filePath, "DATA")) then
+					file.Delete(filePath)
 					self:UpdateFolders()
 				end
 			end,

--- a/lua/wire/client/wire_expression2_browser.lua
+++ b/lua/wire/client/wire_expression2_browser.lua
@@ -259,9 +259,8 @@ function PANEL:Init()
 	end)
 	self:AddRightClick(self.filemenu, nil, "Delete", function()
 		local filePath = self.File:GetFileName()
-		local message = string.format("Delete this file?\n\n%s", fileName(filePath))
 
-		Derma_Query(message, "Delete",
+		Derma_Query("Delete this file?\n\n" .. fileName(filePath), "Delete",
 			"Delete", function()
 				if (file.Exists(filePath, "DATA")) then
 					file.Delete(filePath)


### PR DESCRIPTION
This minor detail can help to avoid deleting the wrong files that were mistakenly right-clicked on the file browser.