### PR TITLE
Better `print` function

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/angle.lua
+++ b/lua/entities/gmod_wire_expression2/core/angle.lua
@@ -414,7 +414,7 @@ e2function vector angle:up()
 end
 
 e2function string toString(angle a)
-	return ("[%s,%s,%s]"):format(a[1],a[2],a[3])
+	return ("ang(%d,%d,%d)"):format(a[1], a[2], a[3])
 end
 
 e2function string angle:toString() = e2function string toString(angle a)

--- a/lua/entities/gmod_wire_expression2/core/angle.lua
+++ b/lua/entities/gmod_wire_expression2/core/angle.lua
@@ -176,12 +176,12 @@ end
 
 e2function string operator+(string lhs, angle rhs)
 	self.prf = self.prf + #lhs * 0.01
-	return lhs .. ("ang(%d,%d,%d)"):format(rhs[1], rhs[2], rhs[3])
+	return lhs .. ("ang(%g,%g,%g)"):format(rhs[1], rhs[2], rhs[3])
 end
 
 e2function string operator+(angle lhs, string rhs)
 	self.prf = self.prf + #rhs * 0.01
-	return ("ang(%d,%d,%d)"):format(lhs[1], lhs[2], lhs[3]) .. rhs
+	return ("ang(%g,%g,%g)"):format(lhs[1], lhs[2], lhs[3]) .. rhs
 end
 
 /******************************************************************************/
@@ -414,7 +414,7 @@ e2function vector angle:up()
 end
 
 e2function string toString(angle a)
-	return ("ang(%d,%d,%d)"):format(a[1], a[2], a[3])
+	return ("ang(%g,%g,%g)"):format(a[1], a[2], a[3])
 end
 
 e2function string angle:toString() = e2function string toString(angle a)

--- a/lua/entities/gmod_wire_expression2/core/array.lua
+++ b/lua/entities/gmod_wire_expression2/core/array.lua
@@ -581,9 +581,9 @@ e2function string toString(array array)
 		local ty = type(val)
 
 		if ty == "Vector" then
-			buf[i] = ("vec(%.2f,%.2f,%.2f)"):format(val[1], val[2], val[3])
+			buf[i] = ("vec(%g,%g,%g)"):format(val[1], val[2], val[3])
 		elseif ty == "Angle" then
-			buf[i] = ("ang(%d,%d,%d)"):format(val[1], val[2], val[3])
+			buf[i] = ("ang(%g,%g,%g)"):format(val[1], val[2], val[3])
 		elseif ty == "string" then
 			buf[i] = ("%q"):format(val)
 		else

--- a/lua/entities/gmod_wire_expression2/core/array.lua
+++ b/lua/entities/gmod_wire_expression2/core/array.lua
@@ -569,9 +569,14 @@ e2function array array:merge( array other )
 	return ret
 end
 
+__e2setcost(2)
 e2function string toString(array array)
-	local buf = {}
-	for i = 1, #array do
+	local buf, len = {}, #array
+
+	self.prf = self.prf + len
+	if self.prf > e2_tickquota then error("perf", 0) end
+
+	for i = 1, len do
 		buf[i] = tostring(array[i])
 	end
 

--- a/lua/entities/gmod_wire_expression2/core/array.lua
+++ b/lua/entities/gmod_wire_expression2/core/array.lua
@@ -577,7 +577,18 @@ e2function string toString(array array)
 	if self.prf > e2_tickquota then error("perf", 0) end
 
 	for i = 1, len do
-		buf[i] = tostring(array[i])
+		local val = array[i]
+		local ty = type(val)
+
+		if ty == "Vector" then
+			buf[i] = ("vec(%.2f,%.2f,%.2f)"):format(val[1], val[2], val[3])
+		elseif ty == "Angle" then
+			buf[i] = ("ang(%d,%d,%d)"):format(val[1], val[2], val[3])
+		elseif ty == "string" then
+			buf[i] = ("%q"):format(val)
+		else
+			buf[i] = tostring(val)
+		end
 	end
 
 	return "array(" .. table.concat(buf, ", ") .. ")"

--- a/lua/entities/gmod_wire_expression2/core/array.lua
+++ b/lua/entities/gmod_wire_expression2/core/array.lua
@@ -568,3 +568,14 @@ e2function array array:merge( array other )
 	self.prf = self.prf + #ret / 3
 	return ret
 end
+
+e2function string toString(array array)
+	local buf = {}
+	for i = 1, #array do
+		buf[i] = tostring(array[i])
+	end
+
+	return "array(" .. table.concat(buf, ", ") .. ")"
+end
+
+e2function string array:toString() = e2function string toString(array array)

--- a/lua/entities/gmod_wire_expression2/core/cl_debug.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_debug.lua
@@ -1,4 +1,5 @@
 CreateClientConVar( "wire_expression2_print_max", 15, true, true )
+CreateClientConVar( "wire_expression2_print_max_length", 1000, true, true )
 CreateClientConVar( "wire_expression2_print_delay", 0.3, true, true )
 
 local chips = {}
@@ -22,4 +23,8 @@ net.Receive("wire_expression2_printColor", function( len, ply )
 	else
 		chat.AddText(unpack(net.ReadTable()))
 	end
+end)
+
+net.Receive("wire_expression2_print", function(len, ply)
+	chat.AddText(net.ReadString())
 end)

--- a/lua/entities/gmod_wire_expression2/core/debug.lua
+++ b/lua/entities/gmod_wire_expression2/core/debug.lua
@@ -2,7 +2,6 @@
 local IsValid  = IsValid
 local isOwner      = E2Lib.isOwner
 local Clamp        = math.Clamp
-local seq = table.IsSequential
 
 /******************************************************************************/
 
@@ -104,7 +103,7 @@ hook.Add("PlayerDisconnected", "e2_print_delays_player_dc", function(ply) printD
 -- Returns whether or not the next print-message will be printed or omitted by antispam
 e2function number playerCanPrint()
 	if not checkOwner(self) then return end
-	return (canPrint(self.player) and 1 or 0)
+	return canPrint(self.player) and 1 or 0
 end
 
 local function repr(self, value, typeid)
@@ -252,7 +251,7 @@ do
 			local value = t[ key ]
 			Msg( string.rep( "\t", indent ) )
 
-			if  ( istable( value ) and !done[ value ] ) then
+			if  ( istable( value ) and not done[ value ] ) then
 
 				done[ value ] = true
 				Msg( tostring( key ) .. ":" .. "\n" )
@@ -332,8 +331,8 @@ local printColor_types = {
 	Vector = function(v) return Color(v[1],v[2],v[3]) end,
 	table = function(tbl)
 		for i,v in pairs(tbl) do
-			if !isnumber(i) then return "" end
-			if !isnumber(v) then return "" end
+			if not isnumber(i) then return "" end
+			if not isnumber(v) then return "" end
 			if i < 1 or i > 4 then return "" end
 		end
 		return Color(tbl[1] or 0, tbl[2] or 0,tbl[3] or 0,tbl[4])

--- a/lua/entities/gmod_wire_expression2/core/debug.lua
+++ b/lua/entities/gmod_wire_expression2/core/debug.lua
@@ -119,6 +119,8 @@ local function repr(self, value, typeid)
 	end
 end
 
+local maxLength = CreateConVar("wire_expression2_print_max_length", "10000", FCVAR_ARCHIVE, "Hard limit for how much E2 users can print with a single call. Here to avoid extensive net use.", 0, 65532)
+
 -- Prints <...> like lua's print(...), except to the chat area
 e2function void print(...args)
 	if not checkOwner(self) then return end
@@ -126,7 +128,7 @@ e2function void print(...args)
 
 	local nargs = #args
 	if nargs > 0 then
-		local max_len = self.player:GetInfoNum("wire_expression2_print_max_length", defaultMaxLength)
+		local max_len = math.min(maxLength:GetInt(), self.player:GetInfoNum("wire_expression2_print_max_length", defaultMaxLength))
 		for i = 1, math.min(nargs, 256) do
 			local v, ty = args[i], typeids[i]
 			args[i] = E2Lib.limitString(repr(self, v, ty), max_len / nargs)

--- a/lua/entities/gmod_wire_expression2/core/vector.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector.lua
@@ -174,12 +174,12 @@ end
 
 e2function string operator+(string lhs, vector rhs)
 	self.prf = self.prf + #lhs * 0.01
-	return lhs .. ("vec(%.2f,%.2f,%.2f)"):format(rhs[1], rhs[2], rhs[3])
+	return lhs .. ("vec(%g,%g,%g)"):format(rhs[1], rhs[2], rhs[3])
 end
 
 e2function string operator+(vector lhs, string rhs)
 	self.prf = self.prf + #rhs * 0.01
-	return ("vec(%.2f,%.2f,%.2f)"):format(lhs[1], lhs[2], lhs[3]) .. rhs
+	return ("vec(%g,%g,%g)"):format(lhs[1], lhs[2], lhs[3]) .. rhs
 end
 
 --------------------------------------------------------------------------------
@@ -715,7 +715,7 @@ end
 __e2setcost( 5 )
 
 e2function string toString(vector v)
-	return ("vec(%.2f,%.2f,%.2f)"):format(v[1], v[2], v[3])
+	return ("vec(%g,%g,%g)"):format(v[1], v[2], v[3])
 end
 
 --- Gets the vector nicely formatted as a string "[X,Y,Z]"

--- a/lua/entities/gmod_wire_expression2/core/vector.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector.lua
@@ -714,9 +714,8 @@ end
 
 __e2setcost( 5 )
 
---- Gets the vector nicely formatted as a string "[X,Y,Z]"
 e2function string toString(vector v)
-	return ("[%s,%s,%s]"):format(v[1],v[2],v[3])
+	return ("vec(%.2f,%.2f,%.2f)"):format(v[1], v[2], v[3])
 end
 
 --- Gets the vector nicely formatted as a string "[X,Y,Z]"

--- a/lua/entities/gmod_wire_expression2/core/vector.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector.lua
@@ -76,7 +76,7 @@ registerOperator("ass", "v", "v", function(self, args)
 
 	local Scope = self.Scopes[scope]
 	local lookup = Scope.lookup
-	if !lookup then lookup = {} Scope.lookup = lookup end
+	if not lookup then lookup = {} Scope.lookup = lookup end
 	if lookup[rhs] then lookup[rhs][lhs] = true else lookup[rhs] = {[lhs] = true} end
 
 	Scope[lhs] = rhs
@@ -593,7 +593,6 @@ local cache_concatenated_parts = setmetatable({ [0] = "empty" }, cachemeta)
 
 local function generateContents( n )
 	local parts_array, lookup_table = {}, {}
-	local ret = {}
 
 	for i = 0,30 do
 		if bit.band(n, (2^i)) ~= 0 then
@@ -651,7 +650,7 @@ end
 
 --- Converts a local position/angle to a world position/angle and returns the angle
 e2function angle toWorldAng( vector localpos, angle localang, vector worldpos, angle worldang )
-	local pos, ang = LocalToWorld(localpos, localang, worldpos, worldang)
+	local _, ang = LocalToWorld(localpos, localang, worldpos, worldang)
 	return ang
 end
 
@@ -667,7 +666,7 @@ end
 
 --- Converts a world position/angle to a local position/angle and returns the angle
 e2function angle toLocalAng( vector localpos, angle localang, vector worldpos, angle worldang )
-	local vec, ang = WorldToLocal(localpos,localang,worldpos,worldang)
+	local _, ang = WorldToLocal(localpos,localang,worldpos,worldang)
 	return ang
 end
 

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -1339,6 +1339,9 @@ E2Helper.Descriptions["shift(r:)"] = "Removes the first element of the array; al
 E2Helper.Descriptions["remove(r:n)"] = "Removes the specified entry, moving subsequent entries down to compensate and returns 1 if removed"
 E2Helper.Descriptions["unset(r:n)"] = "Force removes the specified entry, without moving subsequent entries down and returns 1 if removed"
 
+E2Helper.Descriptions["toString(r)"] = "Returns a string representation of the array and its contents for debugging purposes. Return format may change in the future and should not be relied on."
+E2Helper.Descriptions["toString(r:)"] = "Returns a string representation of the array and its contents for debugging purposes. Return format may change in the future and should not be relied on."
+
 -- binary
 E2Helper.Descriptions["bOr(nn)"] = "Performs bitwise OR against the two numbers"
 E2Helper.Descriptions["bAnd(nn)"] = "Performs bitwise AND against the two numbers"


### PR DESCRIPTION
* Make print use net messages instead of ChatPrint, allowing longer print lengths
* Added clientside convar `wire_expression2_print_max_length` (Default 1,000)
* Added serverside convar `wire_expression2_print_max_length` (Default 10,000)
* `print` now uses the **e2** types (rather than lua type) of the argument to locate any `toString` methods for the type, if any are found, they will be used to display the value.
* `print` now cuts off with E2Lib.limitString (which shows a trailing ... if it was cut off)
* Created `toString(r:)` and `toString(r)`, which show as `array(1, 2, 3)`
* Change vector and angle's `toString` methods to return as the new print() format was (`vec()` / `ang()`) 
* `print` no longer has a limit of 256 arguments (although nobody will ever make use of this)
* `print` costs more ops the longer the combined string

```golo
print("Hi", vec(1, 2, 3), table("foo" = "bar"), array(1, "string", vec(), 4))
print(opcounter())

# "Hi"	vec(1.00,2.00,3.00)	foo	=	bar
# 	array(1, "string", vec(0.00,0.00,0.00), 4)
# 130
```

## RFC:

* Worth changing `table`'s `toString` method to be streamlined with array, vec, ang? Code is really gross so I didn't want to mess with it.
* Max print length fine? Higher? Lower?
* Op costs fine? Higher? Lower?
