### PR TITLE
Fix effect playing inconsistency & remove useless effect object returns

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/effects.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/effects.lua
@@ -61,117 +61,102 @@ e2function effect effect()
 	return EffectData()
 end
 
-e2function effect effect:setOrigin(vector pos)
+e2function void effect:setOrigin(vector pos)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetOrigin(Vector( pos[1], pos[2], pos[3] ))
-	return this
 end
 
-e2function effect effect:setStart(vector pos)
+e2function void effect:setStart(vector pos)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetStart(Vector( pos[1], pos[2], pos[3] ))
-	return this
 end
 
-e2function effect effect:setMagnitude(number mag)
+e2function void effect:setMagnitude(number mag)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetMagnitude(mag)
-	return this
 end
 
-e2function effect effect:setAngles(angle ang)
+e2function void effect:setAngles(angle ang)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetAngles( Angle( ang[1] ,ang[2] ,ang[3] ))
-	return this
 end
 
-e2function effect effect:setScale(number scale)
+e2function void effect:setScale(number scale)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetScale(scale)
-	return this
 end
 
-e2function effect effect:setEntity(entity ent)
+e2function void effect:setEntity(entity ent)
 	if not this then return self:throw("Invalid effect!", nil) end
 	if not IsValid(ent) then return self:throw("Invalid entity!", nil) end
 
 	this:SetEntity(ent)
-	return this
 end
 
-e2function effect effect:setNormal(vector norm)
+e2function void effect:setNormal(vector norm)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetNormal(Vector( norm[1], norm[2], norm[3] ))
-	return this
 end
 
-e2function effect effect:setSurfaceProp(number prop)
+e2function void effect:setSurfaceProp(number prop)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetSurfaceProp(prop)
-	return this
 end
 
-e2function effect effect:setRadius(number radius)
+e2function void effect:setRadius(number radius)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetRadius(radius)
-	return this
 end
 
-e2function effect effect:setMaterialIndex(number index)
+e2function void effect:setMaterialIndex(number index)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetMaterialIndex(index)
-	return this
 end
 
-e2function effect effect:setHitBox(number index)
+e2function void effect:setHitBox(number index)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetHitBox(index)
-	return this
 end
 
-e2function effect effect:setFlags(number flags)
+e2function void effect:setFlags(number flags)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetFlags(flags)
-	return this
 end
 
-e2function effect effect:setEntIndex(number index)
+e2function void effect:setEntIndex(number index)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetEntIndex(index)
-	return this
 end
 
-e2function effect effect:setDamageType(number index)
+e2function void effect:setDamageType(number index)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetDamageType(index)
-	return this
 end
 
-e2function effect effect:setColor(number index)
+e2function void effect:setColor(number index)
 	if not this then return self:throw("Invalid effect!", nil) end
+	
 	index = math.Clamp(index,0,255)
 	this:SetColor(index)
-	return this
 end
 
-e2function effect effect:setAttachment(number index)
+e2function void effect:setAttachment(number index)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetAttachment(index)
-	return this
 end
 
 e2function void effect:play(string name)
@@ -180,7 +165,7 @@ e2function void effect:play(string name)
 	if effect_blacklist[name] then return self:throw("This effect is blacklisted!", nil) end
 	if hook.Run( "Expression2_CanEffect", name:lower(), self ) == false then return self:throw("A hook prevented this function from running", nil) end
 
-	util.Effect(name,this)
+	util.Effect(name, this, true, true)
 end
 
 e2function number effectCanPlay()

--- a/lua/entities/gmod_wire_expression2/core/custom/effects.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/effects.lua
@@ -162,7 +162,6 @@ end
 
 e2function effect effect:setColor(number index)
 	if not this then return self:throw("Invalid effect!", nil) end
-
 	index = math.Clamp(index,0,255)
 	this:SetColor(index)
 	return this

--- a/lua/entities/gmod_wire_expression2/core/custom/effects.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/effects.lua
@@ -162,7 +162,7 @@ end
 
 e2function effect effect:setColor(number index)
 	if not this then return self:throw("Invalid effect!", nil) end
-	
+
 	index = math.Clamp(index,0,255)
 	this:SetColor(index)
 	return this

--- a/lua/entities/gmod_wire_expression2/core/custom/effects.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/effects.lua
@@ -61,102 +61,118 @@ e2function effect effect()
 	return EffectData()
 end
 
-e2function void effect:setOrigin(vector pos)
+e2function effect effect:setOrigin(vector pos)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetOrigin(Vector( pos[1], pos[2], pos[3] ))
+	return this
 end
 
-e2function void effect:setStart(vector pos)
+e2function effect effect:setStart(vector pos)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetStart(Vector( pos[1], pos[2], pos[3] ))
+	return this
 end
 
-e2function void effect:setMagnitude(number mag)
+e2function effect effect:setMagnitude(number mag)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetMagnitude(mag)
+	return this
 end
 
-e2function void effect:setAngles(angle ang)
+e2function effect effect:setAngles(angle ang)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetAngles( Angle( ang[1] ,ang[2] ,ang[3] ))
+	return this
 end
 
-e2function void effect:setScale(number scale)
+e2function effect effect:setScale(number scale)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetScale(scale)
+	return this
 end
 
-e2function void effect:setEntity(entity ent)
+e2function effect effect:setEntity(entity ent)
 	if not this then return self:throw("Invalid effect!", nil) end
 	if not IsValid(ent) then return self:throw("Invalid entity!", nil) end
 
 	this:SetEntity(ent)
+	return this
 end
 
-e2function void effect:setNormal(vector norm)
+e2function effect effect:setNormal(vector norm)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetNormal(Vector( norm[1], norm[2], norm[3] ))
+	return this
 end
 
-e2function void effect:setSurfaceProp(number prop)
+e2function effect effect:setSurfaceProp(number prop)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetSurfaceProp(prop)
+	return this
 end
 
-e2function void effect:setRadius(number radius)
+e2function effect effect:setRadius(number radius)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetRadius(radius)
+	return this
 end
 
-e2function void effect:setMaterialIndex(number index)
+e2function effect effect:setMaterialIndex(number index)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetMaterialIndex(index)
+	return this
 end
 
-e2function void effect:setHitBox(number index)
+e2function effect effect:setHitBox(number index)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetHitBox(index)
+	return this
 end
 
-e2function void effect:setFlags(number flags)
+e2function effect effect:setFlags(number flags)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetFlags(flags)
+	return this
 end
 
-e2function void effect:setEntIndex(number index)
+e2function effect effect:setEntIndex(number index)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetEntIndex(index)
+	return this
 end
 
-e2function void effect:setDamageType(number index)
+e2function effect effect:setDamageType(number index)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetDamageType(index)
+	return this
 end
 
-e2function void effect:setColor(number index)
+e2function effect effect:setColor(number index)
 	if not this then return self:throw("Invalid effect!", nil) end
 	
 	index = math.Clamp(index,0,255)
 	this:SetColor(index)
+	return this
 end
 
-e2function void effect:setAttachment(number index)
+e2function effect effect:setAttachment(number index)
 	if not this then return self:throw("Invalid effect!", nil) end
 
 	this:SetAttachment(index)
+	return this
 end
 
 e2function void effect:play(string name)


### PR DESCRIPTION
Fixed problems from #2692 and removed the effect object returns from every function that isn't effect() as (probably) nobody uses that.