### PR TITLE
Add remote event as an alternative to datasignals/gtables

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/extloader.lua
+++ b/lua/entities/gmod_wire_expression2/core/extloader.lua
@@ -160,6 +160,7 @@ e2_include("strfunc.lua")
 e2_include("steamidconv.lua")
 e2_include("easings.lua")
 e2_include("damage.lua")
+e2_include("remote.lua")
 
 -- Load serverside files here, they need additional parsing
 do

--- a/lua/entities/gmod_wire_expression2/core/init.lua
+++ b/lua/entities/gmod_wire_expression2/core/init.lua
@@ -221,15 +221,17 @@ end
 
 ---@param name string
 ---@param args table?
-function E2Lib.triggerEvent(name, args)
+---@param ignore table<Entity, true>?
+function E2Lib.triggerEvent(name, args, ignore)
 	assert(E2Lib.Env.Events[name], "E2Lib.triggerEvent on nonexisting event: '" .. name .. "'")
 
 	for ent in pairs(E2Lib.Env.Events[name].listening) do
-		-- wtf
-		if ent.ExecuteEvent then
-			ent:ExecuteEvent(name, args)
-		else
-			E2Lib.Env.Events[name].listening[ent] = nil
+		if not ignore or not ignore[ent] then -- Don't trigger ignored chips
+			if ent.ExecuteEvent then
+				ent:ExecuteEvent(name, args)
+			else -- Destructor somehow wasn't run?
+				E2Lib.Env.Events[name].listening[ent] = nil
+			end
 		end
 	end
 end

--- a/lua/entities/gmod_wire_expression2/core/init.lua
+++ b/lua/entities/gmod_wire_expression2/core/init.lua
@@ -221,12 +221,26 @@ end
 
 ---@param name string
 ---@param args table?
----@param ignore table<Entity, true>?
-function E2Lib.triggerEvent(name, args, ignore)
+function E2Lib.triggerEvent(name, args)
 	assert(E2Lib.Env.Events[name], "E2Lib.triggerEvent on nonexisting event: '" .. name .. "'")
 
 	for ent in pairs(E2Lib.Env.Events[name].listening) do
-		if not ignore or not ignore[ent] then -- Don't trigger ignored chips
+		if ent.ExecuteEvent then
+			ent:ExecuteEvent(name, args)
+		else -- Destructor somehow wasn't run?
+			E2Lib.Env.Events[name].listening[ent] = nil
+		end
+	end
+end
+
+---@param name string
+---@param args table
+---@param ignore table<Entity, true>
+function E2Lib.triggerEventOmit(name, args, ignore)
+	assert(E2Lib.Env.Events[name], "E2Lib.triggerEventOmit on nonexisting event: '" .. name .. "'")
+
+	for ent in pairs(E2Lib.Env.Events[name].listening) do
+		if not ignore[ent] then -- Don't trigger ignored chips
 			if ent.ExecuteEvent then
 				ent:ExecuteEvent(name, args)
 			else -- Destructor somehow wasn't run?

--- a/lua/entities/gmod_wire_expression2/core/remote.lua
+++ b/lua/entities/gmod_wire_expression2/core/remote.lua
@@ -1,0 +1,30 @@
+-- New event based version of gtables/datasignals.
+-- Allows passing tables to other Expression 2 chips, triggering an event.
+-- So it is like datasignals in terms of being able to trigger actions, but also like gTables in sharing data (since the table is not copied).
+
+E2Lib.registerEvent("remote", {
+	{ "Sender", "e" },
+	{ "Player", "e" },
+	{ "Payload", "t" }
+})
+
+__e2setcost(100)
+e2function void entity:sendRemoteEvent(table payload)
+	if not IsValid(this) then return self:throw("Invalid entity!", nil) end
+	if this:GetClass() ~= "gmod_wire_expression2" then return self:throw("Expected an E2 chip, got Entity", nil) end
+
+	this:ExecuteEvent("remote", {
+		self.entity,
+		self.player,
+		payload
+	})
+end
+
+__e2setcost(200)
+e2function void broadcastRemoteEvent(table payload)
+	E2Lib.triggerEvent("remote", {
+		self.entity,
+		self.player,
+		payload
+	}, { [self.entity] = true })
+end

--- a/lua/entities/gmod_wire_expression2/core/remote.lua
+++ b/lua/entities/gmod_wire_expression2/core/remote.lua
@@ -22,7 +22,7 @@ end
 
 __e2setcost(200)
 e2function void broadcastRemoteEvent(table payload)
-	E2Lib.triggerEvent("remote", {
+	E2Lib.triggerEventOmit("remote", {
 		self.entity,
 		self.player,
 		payload

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -1282,6 +1282,10 @@ E2Helper.Descriptions["gResetGroup()"] = "Resets the group back to \"default\""
 E2Helper.Descriptions["gShare(n)"] = "Sets wether or not you want to share the variables. (1/0) Remember that there are two tables for each group: one which is shared and one which is not; values do not transition between the two"
 E2Helper.Descriptions["toTable(xgt:)"] = "Converts the GTable into a table"
 
+-- remote
+E2Helper.Descriptions["sendRemoteEvent(e:t)"] = "Sends a payload to an E2 chip via the 'remote' event. Note if you do this, they will have access to modify your table in any way they please."
+E2Helper.Descriptions["broadcastRemoteEvent(t)"] = "Sends a payload to all E2 chips via the 'remote' event. Note if you do this, they will have access to modify your table in any way they please."
+
 -- tables
 E2Helper.Descriptions["table"] = "Returns a table with the values specified in the array-part"
 E2Helper.Descriptions["clear(t:)"] = "Clears the table"


### PR DESCRIPTION
Added a `remote` event (name and idea pretty much from starfall) that is a combination of datasignals/gtables.
You can send payloads to E2 chips, triggering them (datasignals), and modify the given payload as a global table (gtables).

* Added `broadcastRemoteEvent(t)` and `e:sendRemoteEvent(t)`

```golo
@name Adder
@strict

event remote(Sender:entity, Player:entity, Payload:table) {
    if (Player == owner()) {
        Payload[1, number] = Payload[1, number] + 1
    }
}
```

```golo
@persist T:table
@strict

event tick() {
    broadcastRemoteEvent(T)
    print(T[1, number])
}
```

Being able to modify the table has the added bonus of not really having to support return values, although that's still on the table.

## RFC
* Different names?
* `Player` variable necessary? (You can just do `Sender:owner()`, but I see only having `Sender` may cause confusion thinking Sender is the player rather than the chip.)
* Different op costs? (broadcast is 200, send is 100)