### PR TITLE
Fix wire damage detector error

### DIFF
--- a/lua/entities/gmod_wire_damage_detector.lua
+++ b/lua/entities/gmod_wire_damage_detector.lua
@@ -23,7 +23,7 @@ local function CheckWireDamageDetectors( ent, inflictor, attacker, amount, dmgin
 						detector.updated = true
 						detector:NextThink(CurTime()) -- Update link info once per tick per detector at most
 					end
-					if detector.key_ents[ent] then
+					if detector.key_ents and detector.key_ents[ent] then
 						detector:UpdateDamage( dmginfo, ent )
 					end
 				end

--- a/lua/entities/gmod_wire_damage_detector.lua
+++ b/lua/entities/gmod_wire_damage_detector.lua
@@ -35,8 +35,7 @@ local function CheckWireDamageDetectors( ent, inflictor, attacker, amount, dmgin
 end
 hook.Add("EntityTakeDamage", "CheckWireDamageDetectors", function( ent, dmginfo )
 	if not next(Wire_Damage_Detectors) then return end
-	local r, e = xpcall( CheckWireDamageDetectors, debug.traceback, ent, dmginfo:GetInflictor(), dmginfo:GetAttacker(), dmginfo:GetDamage(), dmginfo )
-	if not r then print( "Wire damage detector error: " .. e ) end
+	CheckWireDamageDetectors( ent, dmginfo:GetInflictor(), dmginfo:GetAttacker(), dmginfo:GetDamage(), dmginfo )
 end)
 
 

--- a/lua/entities/gmod_wire_damage_detector.lua
+++ b/lua/entities/gmod_wire_damage_detector.lua
@@ -23,7 +23,7 @@ local function CheckWireDamageDetectors( ent, inflictor, attacker, amount, dmgin
 						detector.updated = true
 						detector:NextThink(CurTime()) -- Update link info once per tick per detector at most
 					end
-					if detector.key_ents and detector.key_ents[ent] then
+					if detector.key_ents[ent] then
 						detector:UpdateDamage( dmginfo, ent )
 					end
 				end
@@ -64,6 +64,7 @@ function ENT:Initialize()
 	self:LinkEnt( self )
 
 	self.count = 0
+	self.key_ents = {}
 
 	-- Store output damage info
 	self.victims = table.Copy(DEFAULT)

--- a/lua/entities/gmod_wire_damage_detector.lua
+++ b/lua/entities/gmod_wire_damage_detector.lua
@@ -45,10 +45,10 @@ function ENT:Initialize()
 	self:SetSolid( SOLID_VPHYSICS )
 
 	self.Outputs = WireLib.CreateSpecialOutputs(self, { "Clk", "Damage", "Attacker", "Victim", "Victims", "Position", "Force", "Type" } , { "NORMAL", "NORMAL", "ENTITY", "ENTITY", "TABLE", "VECTOR", "VECTOR", "STRING" } )
-	self.Inputs = WireLib.CreateInputs(self, { 
-		"On", 
+	self.Inputs = WireLib.CreateInputs(self, {
+		"On",
 		"Entity (This entity will be added whenever this input changes to a valid entity) [ENTITY]",
-		"Entities (These entities will be added whenever this input changes.\nCan be changed at most once per second.) [ARRAY]", 
+		"Entities (These entities will be added whenever this input changes.\nCan be changed at most once per second.) [ARRAY]",
 		"Reset"
 	})
 
@@ -105,7 +105,7 @@ function ENT:LinkEnt( ent, dontupdateoutput )
 	if not ent or not ent:IsValid() then return end
 
 	if self.linked_entities_lookup[ent] then return false end
-	
+
 	self.linked_entities_lookup[ent] = true
 	self.linked_entities[#self.linked_entities+1] = ent
 	ent:CallOnRemove( "DDetector.Unlink", function( ent )
@@ -265,8 +265,8 @@ function ENT:UpdateDamage( dmginfo, ent ) -- Update damage table
 
 		-- Damage type (handle almost all types)
 		self.dmgtype = damageTypes[dmginfo:GetDamageType()] or "Other"
-		
-		
+
+
 
 		self.victims = table.Copy(DEFAULT)
 		self.firsthit_dmginfo[5] = self.dmgtype


### PR DESCRIPTION
Prevents this error from spamming:
```
Wire damage detector error: addons/wire/lua/entities/gmod_wire_damage_detector.lua:26: attempt to index field 'key_ents' (a nil value)
stack traceback:
addons/wire/lua/entities/gmod_wire_damage_detector.lua:26: in function <addons/wire/lua/entities/gmod_wire_damage_detector.lua:15>
[C]: in function 'xpcall'
addons/wire/lua/entities/gmod_wire_damage_detector.lua:38: in function 'func'
addons/ulib/lua/includes/includes/modules/hook.lua:260: in function <addons/ulib/lua/includes/includes/modules/hook.lua:253>
```

Also removes the unnecessary pcall that prevent this error from being found earlier.