### PR TITLE
Clean up interpolation functions

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/vector.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector.lua
@@ -28,7 +28,7 @@ registerType("vector", "v", Vector(0, 0, 0),
 	function(self, output) return Vector(output) end,
 	function(retval)
 		if isvector(retval) then return end
-		error("Return value is not a Vector, but a "..type(retval).."!",0)
+		error("Return value is not a Vector, but a " .. type(retval) .. "!", 0)
 	end,
 	function(v)
 		return not isvector(v)
@@ -78,8 +78,8 @@ registerOperator("ass", "v", "v", function(self, args)
 
 	local Scope = self.Scopes[scope]
 	local lookup = Scope.lookup
-	if !lookup then lookup = {} Scope.lookup = lookup end
-	if lookup[rhs] then lookup[rhs][lhs] = true else lookup[rhs] = {[lhs] = true} end
+	if not lookup then lookup = {} Scope.lookup = lookup end
+	if lookup[rhs] then lookup[rhs][lhs] = true else lookup[rhs] = { [lhs] = true } end
 
 	Scope[lhs] = rhs
 	Scope.vclk[lhs] = true
@@ -190,7 +190,7 @@ __e2setcost(10) -- temporary
 
 --- Returns a uniformly distributed, random, normalized direction vector.
 e2function vector randvec()
-	local s,a, x,y
+	local s, a, x, y
 
 	--[[
 	  This is a variant of the algorithm for computing a random point
@@ -591,10 +591,9 @@ local cache_concatenated_parts = setmetatable({ [0] = "empty" }, cachemeta)
 
 local function generateContents( n )
 	local parts_array, lookup_table = {}, {}
-	local ret = {}
 
 	for i = 0,30 do
-		if bit.band(n, (2^i)) ~= 0 then
+		if bit.band(n, 2 ^ i) ~= 0 then
 			local name = contents[2^i]
 			lookup_table[name] = true
 			parts_array[#parts_array+1] = name
@@ -649,7 +648,7 @@ end
 
 --- Converts a local position/angle to a world position/angle and returns the angle
 e2function angle toWorldAng( vector localpos, angle localang, vector worldpos, angle worldang )
-	local pos, ang = LocalToWorld(localpos, localang, worldpos, worldang)
+	local _, ang = LocalToWorld(localpos, localang, worldpos, worldang)
 	return ang
 end
 
@@ -665,7 +664,7 @@ end
 
 --- Converts a world position/angle to a local position/angle and returns the angle
 e2function angle toLocalAng( vector localpos, angle localang, vector worldpos, angle worldang )
-	local vec, ang = WorldToLocal(localpos,localang,worldpos,worldang)
+	local _, ang = WorldToLocal(localpos, localang, worldpos, worldang)
 	return ang
 end
 

--- a/lua/entities/gmod_wire_expression2/core/vector.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector.lua
@@ -14,6 +14,8 @@ local atan2 = math.atan2
 local asin = math.asin
 local rad2deg = 180 / pi
 local deg2rad = pi / 180
+local quadraticBezier = math.QuadraticBezier
+local cubicBezier = math.CubicBezier
 
 -- TODO: add reflect?
 -- TODO: add absdotproduct?
@@ -522,19 +524,15 @@ end
 
 --- Mix two vectors by a given proportion (between 0 and 1)
 e2function vector mix(vector vec1, vector vec2, ratio)
-	return Vector(
-		vec1[1] * ratio + vec2[1] * (1-ratio),
-		vec1[2] * ratio + vec2[2] * (1-ratio),
-		vec1[3] * ratio + vec2[3] * (1-ratio)
-	)
+	return vec1 * ratio + vec2 * (1 - ratio)
 end
 
-e2function vector bezier(vector startVec, vector control, vector endVec, ratio)
-	return Vector(
-		(1-ratio)^2 * startVec[1] + (2 * (1-ratio) * ratio * control[1]) + ratio^2 * endVec[1],
-		(1-ratio)^2 * startVec[2] + (2 * (1-ratio) * ratio * control[2]) + ratio^2 * endVec[2],
-		(1-ratio)^2 * startVec[3] + (2 * (1-ratio) * ratio * control[3]) + ratio^2 * endVec[3]
-	)
+e2function vector bezier(vector startVec, vector tangent, vector endVec, ratio)
+	return quadraticBezier(ratio, startVec, tangent, endVec)
+end
+
+e2function vector bezier(vector startVec, vector tangent1, vector tangent2, vector endVec, ratio)
+	return cubicBezier(ratio, startVec, tangent1, tangent2, endVec)
 end
 
 __e2setcost(2)

--- a/lua/entities/gmod_wire_expression2/core/vector.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector.lua
@@ -592,9 +592,10 @@ local cache_concatenated_parts = setmetatable({ [0] = "empty" }, cachemeta)
 local function generateContents( n )
 	local parts_array, lookup_table = {}, {}
 
-	for i = 0,30 do
-		if bit.band(n, 2 ^ i) ~= 0 then
-			local name = contents[2^i]
+	for i = 0, 30 do
+		local v = bit.lshift(1, i)
+		if bit.band(n, v) ~= 0 then
+			local name = contents[v]
 			lookup_table[name] = true
 			parts_array[#parts_array+1] = name
 		end

--- a/lua/entities/gmod_wire_expression2/core/vector2.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector2.lua
@@ -454,20 +454,20 @@ registerFunction("clamp", "xv2xv2xv2", "xv2", function(self, args)
 	return { x, y }
 end)
 
-// Mix two vectors by a given proportion (between 0 and 1)
-registerFunction("mix", "xv2xv2n", "xv2", function(self, args)
-	local op1, op2, op3 = args[2], args[3], args[4]
-	local rv1, rv2, rv3 = op1[1](self, op1), op2[1](self, op2), op3[1](self, op3)
-
-	local x = rv1[1] * rv3 + rv2[1] * (1-rv3)
-	local y = rv1[2] * rv3 + rv2[2] * (1-rv3)
-	return { x, y }
-end)
+--- Mix two vectors by a given proportion (between 0 and 1)
+e2function vector2 mix(vector2 vec1, vector2 vec2, ratio)
+	return { vec1[1] * ratio + vec2[1] * (1 - ratio),
+			 vec1[2] * ratio + vec2[2] * (1 - ratio) }
+end
 
 e2function vector2 bezier(vector2 startVec, vector2 control, vector2 endVec, ratio)
+	local dif = 1 - ratio
+	local dif2 = dif ^ 2
+	local ratio2 = ratio ^ 2
+
 	return {
-		(1-ratio)^2 * startVec[1] + (2 * (1-ratio) * ratio * control[1]) + ratio^2 * endVec[1],
-		(1-ratio)^2 * startVec[2] + (2 * (1-ratio) * ratio * control[2]) + ratio^2 * endVec[2]
+		dif2 * startVec[1] + (2 * dif * ratio * control[1]) + ratio2 * endVec[1],
+		dif2 * startVec[2] + (2 * dif * ratio * control[2]) + ratio2 * endVec[2]
 	}
 end
 
@@ -1058,17 +1058,13 @@ e2function vector4 clamp(vector4 Input, Min, Max)
 	return { x*length, y*length, z*length, w*length }
 end
 
-// Mix two vectors by a given proportion (between 0 and 1)
-registerFunction("mix", "xv4xv4n", "xv4", function(self, args)
-	local op1, op2, op3 = args[2], args[3], args[4]
-	local rv1, rv2, rv3 = op1[1](self, op1), op2[1](self, op2), op3[1](self, op3)
-
-	local x = rv1[1] * rv3 + rv2[1] * (1-rv3)
-	local y = rv1[2] * rv3 + rv2[2] * (1-rv3)
-	local z = rv1[3] * rv3 + rv2[3] * (1-rv3)
-	local w = rv1[4] * rv3 + rv2[4] * (1-rv3)
-	return {x, y, z, w}
-end)
+--- Mix two vectors by a given proportion (between 0 and 1)
+e2function vector4 mix(vector4 vec1, vector4 vec2, ratio)
+	return { vec1[1] * ratio + vec2[1] * (1 - ratio),
+			 vec1[2] * ratio + vec2[2] * (1 - ratio),
+			 vec1[3] * ratio + vec2[3] * (1 - ratio),
+			 vec1[4] * ratio + vec2[4] * (1 - ratio) }
+end
 
 __e2setcost(4)
 

--- a/lua/entities/gmod_wire_expression2/core/vector2.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector2.lua
@@ -258,12 +258,12 @@ end)
 
 __e2setcost(2)
 
-// Convert the magnitude of the vector to radians
+-- Convert the magnitude of the vector to radians
 e2function vector2 toRad(vector2 xv2)
 	return {xv2[1] * pi / 180, xv2[2] * pi / 180}
 end
 
-// Convert the magnitude of the vector to degrees
+-- Convert the magnitude of the vector to degrees
 e2function vector2 toDeg(vector2 xv2)
 	return {xv2[1] * 180 / pi, xv2[2] * 180 / pi}
 end
@@ -304,8 +304,8 @@ registerFunction("y", "xv2:", "n", function(self, args)
 	return rv1[2]
 end)
 
-// SET methods that returns vectors - you shouldn't need these for 2D vectors, but I've added them anyway for consistency
-// NOTE: does not change the original vector!
+-- SET methods that returns vectors - you shouldn't need these for 2D vectors, but I've added them anyway for consistency
+-- NOTE: does not change the original vector!
 registerFunction("setX", "xv2:n", "xv2", function(self, args)
 	local op1, op2 = args[2], args[3]
 	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
@@ -367,7 +367,7 @@ e2function vector2 floor(vector2 rv1, decimals)
 	}
 end
 
-// min/max based on vector length - returns shortest/longest vector
+-- min/max based on vector length - returns shortest/longest vector
 registerFunction("min", "xv2xv2", "xv2", function(self, args)
 	local op1, op2 = args[2], args[3]
 	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
@@ -384,7 +384,7 @@ registerFunction("max", "xv2xv2", "xv2", function(self, args)
 	if length1 > length2 then return rv1 else return rv2 end
 end)
 
-// component-wise min/max
+-- component-wise min/max
 registerFunction("maxVec", "xv2xv2", "xv2", function(self, args)
 	local op1, op2 = args[2], args[3]
 	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
@@ -403,7 +403,7 @@ registerFunction("minVec", "xv2xv2", "xv2", function(self, args)
     return {x, y}
 end)
 
-// Performs modulo on x,y separately
+-- Performs modulo on x,y separately
 registerFunction("mod", "xv2n", "xv2", function(self, args)
 	local op1, op2 = args[2], args[3]
 	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
@@ -420,7 +420,7 @@ registerFunction("mod", "xv2n", "xv2", function(self, args)
 	return { x, y }
 end)
 
-// Modulo where divisors are defined as a vector
+-- Modulo where divisors are defined as a vector
 registerFunction("mod", "xv2xv2", "xv2", function(self, args)
 	local op1, op2 = args[2], args[3]
 	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
@@ -437,7 +437,7 @@ registerFunction("mod", "xv2xv2", "xv2", function(self, args)
 	return { x, y }
 end)
 
-// Clamp according to limits defined by two min/max vectors
+-- Clamp according to limits defined by two min/max vectors
 registerFunction("clamp", "xv2xv2xv2", "xv2", function(self, args)
 	local op1, op2, op3 = args[2], args[3], args[4]
 	local rv1, rv2, rv3 = op1[1](self, op1), op2[1](self, op2), op3[1](self, op3)
@@ -473,14 +473,14 @@ end
 
 __e2setcost(2)
 
-// swap x/y
+--- swap x/y
 registerFunction("shift", "xv2", "xv2", function(self, args)
 	local op1 = args[2]
 	local rv1 = op1[1](self, op1)
 	return { rv1[2], rv1[1] }
 end)
 
-// Returns 1 if the vector lies between (or is equal to) the min/max vectors
+--- Returns 1 if the vector lies between (or is equal to) the min/max vectors
 registerFunction("inrange", "xv2xv2xv2", "n", function(self, args)
 	local op1, op2, op3 = args[2], args[3], args[4]
 	local rv1, rv2, rv3 = op1[1](self, op1), op2[1](self, op2), op3[1](self, op3)
@@ -540,7 +540,7 @@ end
   4D Vector support
 \******************************************************************************/
 
-//NOTE: These are purely cartesian 4D vectors, so "w" denotes the 4th coordinate rather than a scaling factor as with an homogeneous coordinate system
+-- NOTE: These are purely cartesian 4D vectors, so "w" denotes the 4th coordinate rather than a scaling factor as with an homogeneous coordinate system
 
 /******************************************************************************/
 
@@ -848,8 +848,8 @@ end)
 
 __e2setcost(3)
 
-// SET methods that returns vectors
-// NOTE: does not change the original vector!
+-- SET methods that returns vectors
+-- NOTE: does not change the original vector!
 registerFunction("setX", "xv4:n", "xv4", function(self, args)
 	local op1, op2 = args[2], args[3]
 	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
@@ -937,7 +937,7 @@ end
 
 __e2setcost(13)
 
-// min/max based on vector length - returns shortest/longest vector
+-- min/max based on vector length - returns shortest/longest vector
 registerFunction("min", "xv4xv4", "xv4", function(self, args)
 	local op1, op2 = args[2], args[3]
 	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
@@ -954,7 +954,7 @@ registerFunction("max", "xv4xv4", "xv4", function(self, args)
 	if length1 > length2 then return rv1 else return rv2 end
 end)
 
-// component-wise min/max
+-- component-wise min/max
 registerFunction("maxVec", "xv4xv4", "xv4", function(self, args)
 	local op1, op2 = args[2], args[3]
 	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
@@ -977,7 +977,7 @@ registerFunction("minVec", "xv4xv4", "xv4", function(self, args)
     return {x, y, z, w}
 end)
 
-// Performs modulo on x,y,z separately
+-- Performs modulo on x, y, z separately
 registerFunction("mod", "xv4n", "xv4", function(self, args)
 	local op1, op2 = args[2], args[3]
 	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
@@ -997,7 +997,7 @@ registerFunction("mod", "xv4n", "xv4", function(self, args)
 	return {x, y, z, w}
 end)
 
-// Modulo where divisors are defined as a vector
+-- Modulo where divisors are defined as a vector
 registerFunction("mod", "xv4xv4", "xv4", function(self, args)
 	local op1, op2 = args[2], args[3]
 	local rv1, rv2 = op1[1](self, op1), op2[1](self, op2)
@@ -1017,7 +1017,7 @@ registerFunction("mod", "xv4xv4", "xv4", function(self, args)
 	return {x, y, z, w}
 end)
 
-// Clamp according to limits defined by two min/max vectors
+-- Clamp according to limits defined by two min/max vectors
 registerFunction("clamp", "xv4xv4xv4", "xv4", function(self, args)
 	local op1, op2, op3 = args[2], args[3], args[4]
 	local rv1, rv2, rv3 = op1[1](self, op1), op2[1](self, op2), op3[1](self, op3)
@@ -1068,7 +1068,7 @@ end
 
 __e2setcost(4)
 
-// Circular shift function: shiftR( x,y,z,w ) = ( w,x,y,z )
+-- Circular shift function: shiftR( x,y,z,w ) = ( w,x,y,z )
 registerFunction("shiftR", "xv4", "xv4", function(self, args)
 	local op1 = args[2]
 	local rv1 = op1[1](self, op1)
@@ -1081,7 +1081,7 @@ registerFunction("shiftL", "xv4", "xv4", function(self, args)
 	return {rv1[2], rv1[3], rv1[4], rv1[1]}
 end)
 
-// Returns 1 if the vector lies between (or is equal to) the min/max vectors
+-- Returns 1 if the vector lies between (or is equal to) the min/max vectors
 registerFunction("inrange", "xv4xv4xv4", "n", function(self, args)
 	local op1, op2, op3 = args[2], args[3], args[4]
 	local rv1, rv2, rv3 = op1[1](self, op1), op2[1](self, op2), op3[1](self, op3)
@@ -1101,12 +1101,12 @@ end)
 
 __e2setcost(5)
 
-// Convert the magnitude of the vector to radians
+-- Convert the magnitude of the vector to radians
 e2function vector4 toRad(vector4 xv4)
 	return {xv4[1] * pi / 180, xv4[2] * pi / 180, xv4[3] * pi / 180, xv4[4] * pi / 180}
 end
 
-// Convert the magnitude of the vector to degrees
+-- Convert the magnitude of the vector to degrees
 e2function vector4 toDeg(vector4 xv4)
 	return {xv4[1] * 180 / pi, xv4[2] * 180 / pi, xv4[3] * 180 / pi, xv4[4] * 180 / pi}
 end

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -529,6 +529,7 @@ E2Helper.Descriptions["pointContentsArray(v)"] = "Returns an array with all the 
 E2Helper.Descriptions["pointHasContent(vs)"] = "'S' can be a string containing the last half of the CONTENTS_ enums (ie without the \"CONTENTS_\"). Multiple CONTENTS types can be seperated by a comma. Check: Enumeration_List:Contents for a full list. Examples: \"water,solid\" or \"empty,transparent\". The function returns 1 if any one of the types are found in the vector point"
 E2Helper.Descriptions["bezier(xv2xv2xv2n)"] = "Returns the 2D position on the bezier curve between the starting and ending 2D vector, given by the ratio (value between 0 and 1)"
 E2Helper.Descriptions["bezier(vvvn)"] = "Returns the 3D vector position on the bezier curve between the starting and ending 3D vector, given by the ratio (value between 0 and 1)"
+E2Helper.Descriptions["bezier(vvvvn)"] = "Returns the 3D vector position on the bezier curve between the starting and ending 3D vector, given by the ratio (value between 0 and 1)"
 
 -- Matrix
 E2Helper.Descriptions["identity2()"] = "Creates a 2x2 identity matrix"


### PR DESCRIPTION
Cleans up interpolation functions, minor optimizations, and adds one new function (`bezier(vvvn)`) taking advantage of [newly released bezier functions](https://steamcommunity.com/games/garrysmod/announcements/detail/3664293140704541927).

This PR should be delayed until widespread adoption of [the latest Gmod update](https://steamcommunity.com/games/garrysmod/announcements/detail/3664293140704541927) has occurred.

Would like to mention #2716 as I had intended to add a replacement function `lerp(...)` but wasn't sure if I should just replace the original `mix` to the peril of any previous users.

[Test code](https://gist.github.com/Denneisk/56ca0f41c0954e95401b880d3a2d343f)