### PR TITLE
Validate I/O in case addons pass incorrect values

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/init.lua
+++ b/lua/entities/gmod_wire_expression2/core/init.lua
@@ -14,7 +14,7 @@ local wire_expression2_debug = CreateConVar("wire_expression2_debug", 0, 0)
 
 if SERVER then
 	cvars.AddChangeCallback("wire_expression2_debug", function(CVar, PreviousValue, NewValue)
-		if (PreviousValue) == NewValue then return end
+		if PreviousValue == NewValue then return end
 		wire_expression2_reload()
 	end)
 end

--- a/lua/entities/gmod_wire_expression2/core/init.lua
+++ b/lua/entities/gmod_wire_expression2/core/init.lua
@@ -47,7 +47,7 @@ local function makecheck(signature)
 	if signature == "op:seq()" then return end
 	local name = signature:match("^([^(]*)")
 	local entry = wire_expression2_funcs[signature]
-	local oldfunc, signature, rets, func, cost = entry.oldfunc, unpack(entry)
+	local oldfunc, signature, rets, func = entry.oldfunc, unpack(entry)
 
 	if oldfunc then return end
 	oldfunc = namefunc(func, "e2_" .. name)

--- a/lua/entities/gmod_wire_expression2/core/init.lua
+++ b/lua/entities/gmod_wire_expression2/core/init.lua
@@ -119,7 +119,14 @@ function registerType(name, id, def, input_serialize, output_serialize, type_che
 
 	if not WireLib.DT[string.upper(name)] then
 		WireLib.DT[string.upper(name)] = {
-			Zero = def,
+			Zero = istable(def) and function()
+				-- Don't need to handle Vector or Angle case since WireLib.DT already defines them.
+				return table.Copy(def)
+			end or function()
+				-- If not a table, don't need to run table.Copy.
+				return def
+			end,
+
 			Validator = is_invalid and function(v)
 				return not is_invalid(v)
 			end or function()

--- a/lua/entities/gmod_wire_gate.lua
+++ b/lua/entities/gmod_wire_gate.lua
@@ -28,14 +28,14 @@ function ENT:Setup( action, noclip )
 	self.WireDebugName = gate.name
 
 	WireLib.AdjustSpecialInputs(self, gate.inputs, gate.inputtypes )
-	if (gate.outputs) then
+	if gate.outputs then
 		WireLib.AdjustSpecialOutputs(self, gate.outputs, gate.outputtypes)
 	else
 		--Wire_AdjustOutputs(self, { "Out" })
 		WireLib.AdjustSpecialOutputs(self, { "Out" }, gate.outputtypes)
 	end
 
-	if (gate.reset) then
+	if gate.reset then
 		gate.reset(self)
 	end
 
@@ -57,7 +57,7 @@ function ENT:Setup( action, noclip )
 		self.WriteCell = nil
 	end
 
-	if (noclip) then
+	if noclip then
 		self:SetCollisionGroup( COLLISION_GROUP_WORLD )
 	end
 	self.noclip = noclip
@@ -75,20 +75,20 @@ end
 
 
 function ENT:OnInputWireLink(iname, itype, src, oname, otype)
-	if (self.Action) and (self.Action.OnInputWireLink) then
+	if self.Action and self.Action.OnInputWireLink then
 		self.Action.OnInputWireLink(self, iname, itype, src, oname, otype)
 	end
 end
 
 function ENT:OnOutputWireLink(oname, otype, dst, iname, itype)
-	if (self.Action) and (self.Action.OnOutputWireLink) then
+	if self.Action and self.Action.OnOutputWireLink then
 		self.Action.OnOutputWireLink(self, oname, otype, dst, iname, itype)
 	end
 end
 
 function ENT:TriggerInput(iname, value, iter)
 	if self.Updating then return end
-	if (self.Action) and (not self.Action.timed) then
+	if self.Action and not self.Action.timed then
 		self:CalcOutput(iter)
 		self:ShowOutput()
 	end
@@ -97,7 +97,7 @@ end
 function ENT:Think()
 	BaseClass.Think(self)
 
-	if (self.Action) and (self.Action.timed) then
+	if self.Action and self.Action.timed then
 		self:CalcOutput()
 		self:ShowOutput()
 
@@ -108,8 +108,8 @@ end
 
 
 function ENT:CalcOutput(iter)
-	if (self.Action) and (self.Action.output) then
-		if (self.Action.outputs) then
+	if self.Action and self.Action.output then
+		if self.Action.outputs then
 			local result = { self.Action.output(self, unpack(self:GetActionInputs(), 1, #self.Action.inputs)) }
 
 			for k,v in ipairs(self.Action.outputs) do
@@ -126,9 +126,9 @@ end
 function ENT:ShowOutput()
 	local txt
 
-	if (self.Action) then
+	if self.Action then
 		txt = (self.Action.name or "No Name")
-		if (self.Action.label) then
+		if self.Action.label then
 			txt = txt.."\n"..self.Action.label(self:GetActionOutputs(), unpack(self:GetActionInputs(Wire_EnableGateInputValues:GetBool()), 1, #self.Action.inputs))
 		end
 	else
@@ -149,17 +149,17 @@ end
 function ENT:GetActionInputs(as_names)
 	local Args = {}
 
-	if (self.Action.compact_inputs) then
+	if self.Action.compact_inputs then
 		-- If a gate has compact inputs (like Arithmetic - Add), nil inputs are truncated so {0, nil, nil, 5, nil, 1} becomes {0, 5, 1}
 		for k,v in ipairs(self.Action.inputs) do
-		    local input = self.Inputs[v]
-			if (not input) then
+			local input = self.Inputs[v]
+			if not input then
 				ErrorNoHalt("Wire Gate ("..self.action..") error: Missing input! ("..k..","..v..")\n")
 				return {}
 			end
 
 			if IsValid(input.Src) then
-				if (as_names) then
+				if as_names then
 					table.insert(Args, input.Src.WireName or input.Src.WireDebugName or v)
 				else
 					table.insert(Args, input.Value)
@@ -167,8 +167,8 @@ function ENT:GetActionInputs(as_names)
 			end
 		end
 
-		while (#Args < self.Action.compact_inputs) do
-			if (as_names) then
+		while #Args < self.Action.compact_inputs do
+			if as_names then
 				table.insert(Args, self.Action.inputs[#Args+1] or "*Not enough inputs*")
 			else
 				table.insert( Args, WireLib.GetDefaultForType(self.Inputs[ self.Action.inputs[#Args+1] ].Type) )
@@ -176,13 +176,13 @@ function ENT:GetActionInputs(as_names)
 		end
 	else
 		for k,v in ipairs(self.Action.inputs) do
-		    local input = self.Inputs[v]
-			if (not input) then
+			local input = self.Inputs[v]
+			if not input then
 				ErrorNoHalt("Wire Gate ("..self.action..") error: Missing input! ("..k..","..v..")\n")
 				return {}
 			end
 
-			if (as_names) then
+			if as_names then
 				Args[k] = IsValid(input.Src) and (input.Src.WireName or input.Src.WireDebugName) or v
 			else
 				Args[k] = IsValid(input.Src) and input.Value or WireLib.GetDefaultForType(self.Inputs[v].Type)
@@ -194,7 +194,7 @@ function ENT:GetActionInputs(as_names)
 end
 
 function ENT:GetActionOutputs()
-	if (self.Action.outputs) then
+	if self.Action.outputs then
 		local result = {}
 		for _,v in ipairs(self.Action.outputs) do
 			result[v] = self.Outputs[v].Value or WireLib.GetDefaultForType(self.Outputs[v].Type)

--- a/lua/entities/gmod_wire_gate.lua
+++ b/lua/entities/gmod_wire_gate.lua
@@ -113,10 +113,10 @@ function ENT:CalcOutput(iter)
 			local result = { self.Action.output(self, unpack(self:GetActionInputs(), 1, #self.Action.inputs)) }
 
 			for k,v in ipairs(self.Action.outputs) do
-				Wire_TriggerOutput(self, v, result[k] or WireLib.DT[ self.Outputs[v].Type ].Zero, iter)
+				Wire_TriggerOutput(self, v, result[k] or WireLib.GetDefaultForType(self.Outputs[v].Type), iter)
 			end
 		else
-			local value = self.Action.output(self, unpack(self:GetActionInputs(), 1, #self.Action.inputs)) or WireLib.DT[ self.Outputs.Out.Type ].Zero
+			local value = self.Action.output(self, unpack(self:GetActionInputs(), 1, #self.Action.inputs)) or WireLib.GetDefaultForType(self.Outputs.Out.Type)
 
 			Wire_TriggerOutput(self, "Out", value, iter)
 		end
@@ -171,8 +171,7 @@ function ENT:GetActionInputs(as_names)
 			if (as_names) then
 				table.insert(Args, self.Action.inputs[#Args+1] or "*Not enough inputs*")
 			else
-				--table.insert( Args, WireLib.DT[ (self.Action.inputtypes[#Args+1] or "NORMAL") ].Zero )
-				table.insert( Args, WireLib.DT[ self.Inputs[ self.Action.inputs[#Args+1] ].Type ].Zero )
+				table.insert( Args, WireLib.GetDefaultForType(self.Inputs[ self.Action.inputs[#Args+1] ].Type) )
 			end
 		end
 	else
@@ -186,7 +185,7 @@ function ENT:GetActionInputs(as_names)
 			if (as_names) then
 				Args[k] = IsValid(input.Src) and (input.Src.WireName or input.Src.WireDebugName) or v
 			else
-				Args[k] = IsValid(input.Src) and input.Value or WireLib.DT[ self.Inputs[v].Type ].Zero
+				Args[k] = IsValid(input.Src) and input.Value or WireLib.GetDefaultForType(self.Inputs[v].Type)
 			end
 		end
 	end
@@ -198,13 +197,13 @@ function ENT:GetActionOutputs()
 	if (self.Action.outputs) then
 		local result = {}
 		for _,v in ipairs(self.Action.outputs) do
-		    result[v] = self.Outputs[v].Value or WireLib.DT[ self.Outputs[v].Type ].Zero
+			result[v] = self.Outputs[v].Value or WireLib.GetDefaultForType(self.Outputs[v].Type)
 		end
 
 		return result
 	end
 
-	return self.Outputs.Out.Value or WireLib.DT[ self.Outputs.Out.Type ].Zero
+	return self.Outputs.Out.Value or WireLib.GetDefaultForType(self.Outputs.Out.Type)
 end
 
 function WireLib.MakeWireGate(pl, Pos, Ang, model, action, noclip, frozen, nocollide)

--- a/lua/weapons/gmod_tool/stools/wire_debugger.lua
+++ b/lua/weapons/gmod_tool/stools/wire_debugger.lua
@@ -272,7 +272,7 @@ if (SERVER) then
 				end
 				for k, Input in pairs_sortvalues(cmp.Inputs, WireLib.PortComparator) do
 					if formatPort[Input.Type] then
-						dbginfo = dbginfo .. k .. ":" .. formatPort[Input.Type](Input.Value or WireLib.DT[Input.Type].Zero, OrientVertical)
+						dbginfo = dbginfo .. k .. ":" .. formatPort[Input.Type](Input.Value or WireLib.GetDefaultForType(Input.Type), OrientVertical)
 						if OrientVertical then
 							dbginfo = dbginfo .. "\n"
 						else
@@ -295,7 +295,7 @@ if (SERVER) then
 				end
 				for k, Output in pairs_sortvalues(cmp.Outputs, WireLib.PortComparator) do
 					if formatPort[Output.Type] then
-						dbginfo = dbginfo .. k .. ":" .. formatPort[Output.Type](Output.Value or WireLib.DT[Output.Type].Zero, OrientVertical)
+						dbginfo = dbginfo .. k .. ":" .. formatPort[Output.Type](Output.Value or WireLib.GetDefaultForType(Output.Type), OrientVertical)
 						if OrientVertical then
 							dbginfo = dbginfo .. "\n"
 						else

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -60,7 +60,7 @@ function WireLib.TriggerInput(ent, name, value, ...)
 	local ty = WireLib.DT[input.Type]
 	if ty and not ty.Validator(value) then
 		-- Not copying here is fine since data types are immutable outside E2.
-		value = ty.Zero
+		value = ty.Zero()
 	end
 
 	input.Value = value
@@ -90,18 +90,22 @@ function WireLib.TriggerInput(ent, name, value, ...)
 end
 
 --- Array of data types for Wiremod.
----@type table<string, { Zero: any, Validator: fun(val: any): boolean }>
+---@type table<string, { Zero: (fun(): any), Validator: (fun(val: any): boolean) }>
 WireLib.DT = {
 	NORMAL = {
-		Zero = 0,
+		Zero = function()
+			return 0
+		end,
 		Validator = isnumber
 	},	-- Numbers
 	VECTOR = {
-		Zero = Vector(0, 0, 0),
+		Zero = Vector,
 		Validator = isvector
 	},
 	VECTOR2 = {
-		Zero = { 0, 0 },
+		Zero = function()
+			return { 0, 0 }
+		end,
 		Validator = function(v2)
 			return istable(v2)
 				and isnumber(v2[1])
@@ -109,7 +113,9 @@ WireLib.DT = {
 		end
 	},
 	VECTOR4 = {
-		Zero = { 0, 0, 0, 0 },
+		Zero = function()
+			return { 0, 0, 0, 0 }
+		end,
 		Validator = function(v4)
 			return istable(v4)
 				and isnumber(v4[1])
@@ -119,23 +125,31 @@ WireLib.DT = {
 		end
 	},
 	ANGLE = {
-		Zero = Angle(0, 0, 0),
+		Zero = Angle,
 		Validator = isangle
 	},
 	COLOR = {
-		Zero = Color(0, 0, 0),
+		Zero = function()
+			return Color(0, 0, 0)
+		end,
 		Validator = IsColor
 	},
 	ENTITY = {
-		Zero = NULL,
+		Zero = function()
+			return NULL
+		end,
 		Validator = IsEntity
 	},
 	STRING = {
-		Zero = "",
+		Zero = function()
+			return ""
+		end,
 		Validator = isstring
 	},
 	TABLE = {
-		Zero = { n = {}, ntypes = {}, s = {}, stypes = {}, size = 0 },
+		Zero = function()
+			return { n = {}, ntypes = {}, s = {}, stypes = {}, size = 0 }
+		end,
 		Validator = function(t)
 			return istable(t)
 				and istable(t.n)
@@ -146,7 +160,9 @@ WireLib.DT = {
 		end
 	},
 	BIDIRTABLE = {
-		Zero = { n = {}, ntypes = {}, s = {}, stypes = {}, size = 0 },
+		Zero = function()
+			return { n = {}, ntypes = {}, s = {}, stypes = {}, size = 0 }
+		end,
 		Validator = function(t)
 			return istable(t)
 				and istable(t.n)
@@ -158,21 +174,35 @@ WireLib.DT = {
 		BiDir = true
 	},
 	ANY = {
-		Zero = 0,
+		Zero = function()
+			return 0
+		end,
 		Validator = function()
 			return true
 		end
 	},
 	ARRAY = {
-		Zero = {},
+		Zero = function()
+			return {}
+		end,
 		Validator = istable
 	},
 	BIDIRARRAY = {
-		Zero = {},
+		Zero = function()
+			return {}
+		end,
 		Validator = istable,
 		BiDir = true
 	},
 }
+
+--- Gets default value of a WireLib type.
+--- Assumes `type` is a valid string type in the WireLib.DT table.
+--- For example `VECTOR` / `NORMAL` / `ARRAY`
+---@param type string
+function WireLib.GetDefaultForType(type)
+	return WireLib.DT[type].Zero()
+end
 
 function WireLib.CreateSpecialInputs(ent, names, types, descs)
 	types = types or {}
@@ -187,7 +217,7 @@ function WireLib.CreateSpecialInputs(ent, names, types, descs)
 			Name = name,
 			Desc = desc,
 			Type = tp,
-			Value = WireLib.DT[ tp ].Zero,
+			Value = WireLib.GetDefaultForType(tp),
 			Material = "tripmine_laser",
 			Color = Color(255, 255, 255, 255),
 			Width = 1,
@@ -222,7 +252,7 @@ function WireLib.CreateSpecialOutputs(ent, names, types, descs)
 			Name = name,
 			Desc = desc,
 			Type = tp,
-			Value = WireLib.DT[ tp ].Zero,
+			Value = WireLib.GetDefaultForType(tp),
 			Connected = {},
 			TriggerLimit = 8,
 			Num = n,
@@ -254,7 +284,7 @@ function WireLib.AdjustSpecialInputs(ent, names, types, descs)
 		if (ent_ports[name]) then
 			if tp ~= ent_ports[name].Type then
 				timer.Simple(0, function() WireLib.Link_Clear(ent, name) end)
-				ent_ports[name].Value = WireLib.DT[tp].Zero
+				ent_ports[name].Value = WireLib.GetDefaultForType(tp)
 				ent_ports[name].Type = tp
 			end
 			ent_ports[name].Keep = true
@@ -266,7 +296,7 @@ function WireLib.AdjustSpecialInputs(ent, names, types, descs)
 				Name = name,
 				Desc = desc,
 				Type = tp,
-				Value = WireLib.DT[ tp ].Zero,
+				Value = WireLib.GetDefaultForType(tp),
 				Material = "tripmine_laser",
 				Color = Color(255, 255, 255, 255),
 				Width = 1,
@@ -331,7 +361,7 @@ function WireLib.AdjustSpecialOutputs(ent, names, types, descs)
 				Name = name,
 				Desc = desc,
 				Type = tp,
-				Value = WireLib.DT[ tp ].Zero,
+				Value = WireLib.GetDefaultForType(tp),
 				Connected = {},
 				TriggerLimit = 8,
 				Num = n,
@@ -383,7 +413,7 @@ function WireLib.RetypeInputs(ent, iname, itype, descs)
 		ent_ports[iname].Type = itype
 	end
 	ent_ports[iname].Desc = descs
-	ent_ports[iname].Value = WireLib.DT[itype].Zero
+	ent_ports[iname].Value = WireLib.GetDefaultForType(itype)
 
 	WireLib._SetInputs(ent)
 end
@@ -399,7 +429,7 @@ function WireLib.RetypeOutputs(ent, oname, otype, descs)
 		ent_ports[oname].Type = otype
 	end
 	ent_ports[oname].Desc = descs
-	ent_ports[oname].Value = WireLib.DT[otype].Zero
+	ent_ports[oname].Value = WireLib.GetDefaultForType(otype)
 
 	WireLib._SetOutputs(ent)
 end
@@ -585,7 +615,7 @@ function WireLib.TriggerOutput(ent, oname, value, iter)
 	local ty = WireLib.DT[output.Type]
 	if ty and not ty.Validator(value) then
 		-- Not copying here is fine since data types are immutable outside E2.
-		value = ty.Zero
+		value = ty.Zero()
 	end
 
 	if output and (value ~= output.Value or output.Type == "ARRAY" or output.Type == "TABLE" or (output.Type == "ENTITY" and not rawequal(value, output.Value) --[[Covers the NULL==NULL case]])) then
@@ -655,7 +685,7 @@ local function Wire_Unlink(ent, iname, DontSendToCL, Removing)
 		input.Path = nil
 
 		if (Removing) then return end
-		WireLib.TriggerInput(ent, iname, WireLib.DT[input.Type].Zero, nil)
+		WireLib.TriggerInput(ent, iname, WireLib.GetDefaultForType(input.Type), nil)
 
 		if (DontSendToCL) then return end
 		WireLib._SetLink(input)


### PR DESCRIPTION
This applies to wiremod as a whole, now inputs and outputs will be validated to ensure correctness on TriggerInput/TriggerOutput (E2 wirelinks use this as well).

In this case the value will be replaced with the default value for the type.