### PR TITLE
Fix Unpredictable EGP Order Behavior

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
@@ -71,7 +71,6 @@ end
 
 e2function void wirelink:egpOrder( number index, number order )
 	if (!EGP:IsAllowed( self, this )) then return end
-	if (index == order) then return end
 	local bool, k, v = EGP:HasObject( this, index )
 	if (bool) then
 		local bool2 = EGP:SetOrder( this, k, order )


### PR DESCRIPTION
I don't fully know why, but `EGP:SetOrder` doesn't work sometimes. It's probably a problem with order of execution which is why this fixes it.

This changes `EGP:PerformReorder` and `EGP:PerformReorder_Ex` to be more efficient and coincidentally fixes issues with ordering not applying.

[Test code](https://gist.github.com/Denneisk/b306e8a75a873b08f23b595935a08682) - Running this on the current version will cause the red box to never go down in the render order.