### PR TITLE
Trim all trailing whitespace

### DIFF
--- a/lua/entities/gmod_wire_adv_emarker.lua
+++ b/lua/entities/gmod_wire_adv_emarker.lua
@@ -16,10 +16,10 @@ function ENT:Initialize()
 	for i=3,12 do
 		outputs[i] = "Entity" .. (i-2) .. " [ENTITY]"
 	end
-	self.Inputs = WireLib.CreateInputs( self, { 
-		"Entity (This entity will be added or removed once the other two inputs are changed) [ENTITY]", 
-		"Add Entity (Change to non-zero value to add the entity specified by the 'Entity' input)", 
-		"Remove Entity (Change to non-zero value to remove the entity specified by the 'Entity' input)", 
+	self.Inputs = WireLib.CreateInputs( self, {
+		"Entity (This entity will be added or removed once the other two inputs are changed) [ENTITY]",
+		"Add Entity (Change to non-zero value to add the entity specified by the 'Entity' input)",
+		"Remove Entity (Change to non-zero value to remove the entity specified by the 'Entity' input)",
 		"Clear Entities (Removes all entities from the marker)"
 	} )
 	self.Outputs = WireLib.CreateOutputs( self, outputs )

--- a/lua/entities/gmod_wire_cameracontroller.lua
+++ b/lua/entities/gmod_wire_cameracontroller.lua
@@ -9,7 +9,7 @@ local function doRotate(curpos,curang,ply,parent,AutoMove,LocalMove,distance)
 		-- TODO: remove this check at some point in the future when LocalEyeAngles is available in the stable version of gmod
 		if ply.LocalEyeAngles then
 			curang =  ply:LocalEyeAngles()
-		else 
+		else
 			curang = ply:EyeAngles()
 			local veh = ply:GetVehicle()
 			if SERVER and IsValid( veh ) then curang = veh:WorldToLocalAngles( curang ) end
@@ -360,25 +360,25 @@ end
 
 function ENT:Initialize()
 	BaseClass.Initialize(self)
-	WireLib.CreateOutputs( self, { 	
-		"On", 
-		"HitPos (The hitpos of a trace emitted from the user) [VECTOR]", 
-		"CamPos (The position of the camera.\nTakes clientside rotation into account, but not clientside zooming.) [VECTOR]", 
+	WireLib.CreateOutputs( self, {
+		"On",
+		"HitPos (The hitpos of a trace emitted from the user) [VECTOR]",
+		"CamPos (The position of the camera.\nTakes clientside rotation into account, but not clientside zooming.) [VECTOR]",
 		"CamDir (The direction of the camera, in vector form.\nTakes clientside rotation into account.) [VECTOR]",
-		"CamAng (The direction of the camera, in angle form.\nTakes clientside rotation into account.) [ANGLE]", 
+		"CamAng (The direction of the camera, in angle form.\nTakes clientside rotation into account.) [ANGLE]",
 		"Trace (A trace emitted from the user) [RANGER]"
 	})
-	WireLib.CreateInputs( self, {	
-		"Activated", 
-		"Direction (Sets the direction of the camera, in vector form.\nIf clientside movement is enabled, this is ignored.) [VECTOR]", 
-		"Angle (Sets the direction of the camera, in angle form.\nIf clientside movement is enabled, this is ignored.) [ANGLE]", 
+	WireLib.CreateInputs( self, {
+		"Activated",
+		"Direction (Sets the direction of the camera, in vector form.\nIf clientside movement is enabled, this is ignored.) [VECTOR]",
+		"Angle (Sets the direction of the camera, in angle form.\nIf clientside movement is enabled, this is ignored.) [ANGLE]",
 		"Position (Sets the position of the camera.\nIf clientside movement is enabled, this specifies the center of the camera's orbit.) [VECTOR]",
-		"Distance (Sets the 'distance' of the camera.\nIn other words, the camera will be moved away from the specified position by this amount.\nIf clientside zooming is enabled, this is the farthest you can zoom in.)", 
-		"UnRoll (If free movement is enabled, this resets the roll back to zero.)", 
-		"Parent (Parents the camera to this entity.) [ENTITY]", 
-		"FilterEntities (In addition to ignoring the contraption of the 'Parent' entity, or the cam controller itself\nif parent isn't used, entities in this list will be ignored by the 'HitPos' and 'Trace' outputs) [ARRAY]", 
-		"FLIR", 
-		"FOV" 
+		"Distance (Sets the 'distance' of the camera.\nIn other words, the camera will be moved away from the specified position by this amount.\nIf clientside zooming is enabled, this is the farthest you can zoom in.)",
+		"UnRoll (If free movement is enabled, this resets the roll back to zero.)",
+		"Parent (Parents the camera to this entity.) [ENTITY]",
+		"FilterEntities (In addition to ignoring the contraption of the 'Parent' entity, or the cam controller itself\nif parent isn't used, entities in this list will be ignored by the 'HitPos' and 'Trace' outputs) [ARRAY]",
+		"FLIR",
+		"FOV"
 	})
 
 	self.Activated = false -- Whether or not to activate the cam controller for all players sitting in linked vehicles, or as soon as a player sits in a linked vehicle

--- a/lua/entities/gmod_wire_characterlcd/cl_init.lua
+++ b/lua/entities/gmod_wire_characterlcd/cl_init.lua
@@ -6,7 +6,7 @@ function ENT:Initialize()
 	for i = 0, 1023 do
 		mem[i] = 0
 	end
-	
+
 	-- Screen control:
 	-- [1003] - Background red
 	-- [1004] - Background green
@@ -14,7 +14,7 @@ function ENT:Initialize()
 	-- [1006] - Text red
 	-- [1007] - Text green
 	-- [1008] - Text blue
-	-- [1009] - Width 
+	-- [1009] - Width
 	-- [1010] - Height
 
 	-- Character control:
@@ -199,11 +199,11 @@ local specialCharacters = {
 		{ x = 0.5, y = 1 },
 		{ x = 0, y = 1 },
 	},
-	
-	
-	
-	
-	
+
+
+
+
+
 	[136] = {
 		{ x = 0, y = 0 },
 		{ x = 0.5, y = 0 },
@@ -251,7 +251,7 @@ local specialCharacters = {
 		{ x = 0.5, y = 1 },
 	},
 	[142] = {
-		
+
 		{ x = 1, y = 0 },
 		{ x = 1, y = 1 },
 		{ x = 0.5, y = 1 },
@@ -259,7 +259,7 @@ local specialCharacters = {
 		{ x = 0, y = 0.5},
 		{ x = 0, y = 0 },
 	},
-	
+
 	[143] = {
 		{ x = 0, y = 0.5 },
 		{ x = 1, y = 0.5 },
@@ -418,7 +418,7 @@ end
 local VECTOR_1_1_1 = Vector(1, 1, 1)
 function ENT:Draw()
 	self:DrawModel()
-	
+
 	local tone = render.GetToneMappingScaleLinear()
 	render.SetToneMappingScaleLinear(VECTOR_1_1_1)
 
@@ -428,7 +428,7 @@ function ENT:Draw()
 
 	if mem[1023] >= 1 then
 		mem[1023] = 0
- 
+
 		self.GPU:RenderToGPU(function()
 			-- Draw terminal here
 			-- W/H = 16
@@ -437,12 +437,12 @@ function ENT:Draw()
 			local br = (1-bc)*mem[1003]+bc*mem[1006]
 			local bg = (1-bc)*mem[1004]+bc*mem[1007]
 			local bb = (1-bc)*mem[1005]+bc*mem[1008]
-			
+
 			local sqc = math.min(1,math.max(0,mem[1016]-0.9))
 			local sqr = (1-sqc)*mem[1003]+sqc*mem[1006]
 			local sqg = (1-sqc)*mem[1004]+sqc*mem[1007]
 			local sqb = (1-sqc)*mem[1005]+sqc*mem[1008]
-			
+
 			local fc = math.min(1,math.max(sqc,mem[1016]))
 			local fr = (1-fc)*mem[1003]+fc*mem[1006]
 			local fg = (1-fc)*mem[1004]+fc*mem[1007]
@@ -468,7 +468,7 @@ function ENT:Draw()
 					surface.DrawRect((tx)*szx+1,(ty)*szy+1,szx-2,szy-2)
 					surface.SetDrawColor(sqr,sqg,sqb,127)
 					surface.DrawRect((tx)*szx+2,(ty)*szy+2,szx-2,szy-2)
-					
+
 					if (c1 ~= 0) then
 						-- Note: the source engine does not handle unicode characters above 65535 properly.
 						local utf8 = ""

--- a/lua/entities/gmod_wire_characterlcd/init.lua
+++ b/lua/entities/gmod_wire_characterlcd/init.lua
@@ -34,10 +34,10 @@ function ENT:Initialize()
 	self.Memory[1020] = 0.25
 	self.Memory[1021] = 0
 	self.Memory[1022] = 1
-	
+
 	self.ScreenWidth = 16
 	self.ScreenHeight = 2
-	
+
 	self.Cache = GPUCacheManager(self,true)
 end
 function ENT:Setup(ScreenWidth, ScreenHeight, bgred,bggreen,bgblue,fgred,fggreen,fgblue)
@@ -55,7 +55,7 @@ function ENT:SendPixel()
 		local pixelno = math.floor(self.CharAddress)
 
 		self:WriteCell(pixelno, self.Char)
-		
+
 	end
 end
 
@@ -145,7 +145,7 @@ function ENT:ClientWriteCell(Address, value)
 	if Address == 1009 and (value*self.Memory[1010] > 1003 or value*18 > 1024) then return false end
 	if Address == 1010 and (value*self.Memory[1009] > 1003 or value*24 > 1024) then return false end
 	if Address == 1011 then
-		
+
 		if self.Memory[1015] >= 1 then
 			if self.Memory[1014] >= 1 then
 				self:ShiftScreenRight()
@@ -161,7 +161,7 @@ function ENT:ClientWriteCell(Address, value)
 				self.Memory[1021] = math.min(1023,self.Memory[1021] + 1)
 			end
 		end
-		
+
 	end
 	if Address == 1017 then
 		for i = 0, self.ScreenWidth-1 do

--- a/lua/entities/gmod_wire_consolescreen/cl_init.lua
+++ b/lua/entities/gmod_wire_consolescreen/cl_init.lua
@@ -315,11 +315,11 @@ local specialCharacters = {
 		{ x = 0.5, y = 1 },
 		{ x = 0, y = 1 },
 	},
-	
-	
-	
-	
-	
+
+
+
+
+
 	[136] = {
 		{ x = 0, y = 0 },
 		{ x = 0.5, y = 0 },
@@ -367,7 +367,7 @@ local specialCharacters = {
 		{ x = 0.5, y = 1 },
 	},
 	[142] = {
-		
+
 		{ x = 1, y = 0 },
 		{ x = 1, y = 1 },
 		{ x = 0.5, y = 1 },
@@ -375,7 +375,7 @@ local specialCharacters = {
 		{ x = 0, y = 0.5},
 		{ x = 0, y = 0 },
 	},
-	
+
 	[143] = {
 		{ x = 0, y = 0.5 },
 		{ x = 1, y = 0.5 },
@@ -534,7 +534,7 @@ end
 local VECTOR_1_1_1 = Vector(1, 1, 1)
 function ENT:Draw()
 	self:DrawModel()
-	
+
 	local tone = render.GetToneMappingScaleLinear()
 	render.SetToneMappingScaleLinear(VECTOR_1_1_1)
 	local curtime = CurTime()

--- a/lua/entities/gmod_wire_digitalscreen/cl_init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/cl_init.lua
@@ -111,7 +111,7 @@ function ENT:Think()
 		while SysTime() < maxtime and self.buffer[1] do
 			if not self.co or coroutine.status(self.co) == "dead" then
 				self.co = coroutine.create( function()
-					 self:ProcessBuffer() 
+					 self:ProcessBuffer()
 				end )
 			end
 
@@ -279,7 +279,7 @@ end
 local VECTOR_1_1_1 = Vector(1, 1, 1)
 function ENT:Draw()
 	self:DrawModel()
-	
+
 	local tone = render.GetToneMappingScaleLinear()
 	render.SetToneMappingScaleLinear(VECTOR_1_1_1)
 
@@ -317,7 +317,7 @@ function ENT:Draw()
 			end
 		end)
 	end
-	
+
 	self.GPU:Render(0,0,1024,1024,nil,-(1024-self.ScreenWidth)/1024,-(1024-self.ScreenHeight)/1024)
 	render.SetToneMappingScaleLinear(tone)
 	Wire_Render(self)

--- a/lua/entities/gmod_wire_digitalscreen/init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/init.lua
@@ -105,9 +105,9 @@ local function calcGlobalBW()
 	local n = 0
 
 	-- count the number of digi screens currently sending data
-	for digi in pairs(globalBandwidthLookup) do 
+	for digi in pairs(globalBandwidthLookup) do
 		if not IsValid(digi) then globalBandwidthLookup[digi] = nil end -- this most likely won't trigger due to OnRemove, but just in case
-		n = n + 1 
+		n = n + 1
 	end
 
 	-- player count also seems to affect lag somewhat
@@ -124,7 +124,7 @@ local function calcGlobalBW()
 
 	maxBandwidth = math.max(100,math.Round(math.min(defaultMaxBandwidth,maxBandwidth / n),2))
 end
-local function addGlobalBW(e) 
+local function addGlobalBW(e)
 	globalBandwidthLookup[e] = true
 	calcGlobalBW()
 end
@@ -193,14 +193,14 @@ function ENT:FlushCache(ply)
 	self.deltaStep = (self.deltaStep or 0) * 0.5 + self.ChangedStep * 0.5
 	self.deltaN = (self.deltaN or 0) * 0.5 + n * 0.5
 
-	if 
+	if
 		-- reset queue if we've reached the end
 		self.ChangedStep > n or
 
 		-- if the queue length keeps growing faster than we can process it, just clear it
 		-- this check is mostly to detect the worst possible case where the user spams single random pixels
 		(n > self.ScreenWidth * self.ScreenHeight and self.deltaStep * 4 < self.deltaN) then
-		
+
 		self.ChangedCellRanges = {}
 		self.ChangedStep = 1
 	end

--- a/lua/entities/gmod_wire_egp/cl_init.lua
+++ b/lua/entities/gmod_wire_egp/cl_init.lua
@@ -74,7 +74,7 @@ local VECTOR_1_1_1 = Vector(1, 1, 1)
 function ENT:Draw()
 	self:DrawModel()
 	Wire_Render(self)
-	
+
 	local tone = render.GetToneMappingScaleLinear()
 	render.SetToneMappingScaleLinear(VECTOR_1_1_1)
 	if self.UpdateConstantly or self.NeedsUpdate then

--- a/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
@@ -476,7 +476,7 @@ end
 function EGP.WorldToLocal(egp, object, x, y)
 	local _, realpos = EGP:GetGlobalPos(egp, object.index)
 	x, y = x - realpos.x, y - realpos.y
-	
+
 	local theta = math.rad(realpos.angle)
 	if theta ~= 0 then
 		local cos_theta, sin_theta = math.cos(theta), math.sin(theta)
@@ -484,6 +484,6 @@ function EGP.WorldToLocal(egp, object, x, y)
 			x * cos_theta - y * sin_theta,
 			y * cos_theta + x * sin_theta
 	end
-	
+
 	return x, y
 end

--- a/lua/entities/gmod_wire_egp/lib/objects/box.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/box.lua
@@ -26,10 +26,10 @@ Obj.DataStreamInfo = function( self )
 end
 function Obj:Contains(egp, x, y)
 	x, y = EGP.WorldToLocal(egp, self, x, y)
-	
+
 	local w, h = self.w / 2, self.h / 2
 	if egp.TopLeft then x, y = x - w, y - h end
-	
+
 	return -w <= x and x <= w and
 	       -h <= y and y <= h
 end

--- a/lua/entities/gmod_wire_egp/lib/objects/roundedbox.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/roundedbox.lua
@@ -54,10 +54,10 @@ Obj.DataStreamInfo = function( self )
 end
 function Obj:Contains(egp, x, y)
 	x, y = EGP.WorldToLocal(egp, self, x, y)
-	
+
 	local w, h = self.w / 2, self.h / 2
 	if egp.TopLeft then x, y = x - w, y - h end
-	
+
 	local r = math.min(math.min(w, h), self.radius)
 	x, y = math.abs(x), math.abs(y)
 	if x > w or y > h then return false end

--- a/lua/entities/gmod_wire_egp/lib/objects/wedge.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/wedge.lua
@@ -57,7 +57,7 @@ end
 function Obj:Contains(egp, x, y)
 	x, y = EGP.WorldToLocal(egp, self, x, y)
 	x, y = x / self.w, y / self.h
-	
+
 	if x * x + y * y > 1 then return false end
 	theta = math.deg(math.atan2(y, x))
 	return theta <= -self.size or 0 <= theta

--- a/lua/entities/gmod_wire_egp_emitter.lua
+++ b/lua/entities/gmod_wire_egp_emitter.lua
@@ -21,10 +21,10 @@ if SERVER then
 		self:SetDrawScale(DrawScale)
 		self:AddEFlags( EFL_FORCE_CHECK_TRANSMIT )
 
-		WireLib.CreateInputs(self, { 
-			"Scale (Increase or decrease draw scale. Limited between 0.04 and 2)", 
-			"Position (Offsets the draw position. Limited between -150 to +150 in any direction away from the emitter.) [VECTOR]", 
-			"Angle (Offsets the draw angle.) [ANGLE]" 
+		WireLib.CreateInputs(self, {
+			"Scale (Increase or decrease draw scale. Limited between 0.04 and 2)",
+			"Position (Offsets the draw position. Limited between -150 to +150 in any direction away from the emitter.) [VECTOR]",
+			"Angle (Offsets the draw angle.) [ANGLE]"
 		})
 	end
 

--- a/lua/entities/gmod_wire_exit_point.lua
+++ b/lua/entities/gmod_wire_exit_point.lua
@@ -8,11 +8,11 @@ function ENT:Initialize()
 	BaseClass.Initialize(self)
 
 	self.Inputs = WireLib.CreateInputs(self, {
-		"Entity (Links the exit point controller to a single specified vehicle and unlinks all others.) [ENTITY]", 
-		"Entities (Links the exit point controller to the specified array of vehicles.\nEntities will be linked one by one and this value can't be changed during this time.) [ARRAY]", 
-		"Position (Whenever a player exits a linked vehicle, they will be teleported to this position.\nOnly either this or 'Local Position' can be used at a time. The last changed input is used.) [VECTOR]", 
-		"Local Position (Whenever a player exits a linked vehicle, they will be teleported to this position, relative to the vehicle they just exited.\nOnly either this or 'Position' can be used at a time. The last changed input is used.) [VECTOR]", 
-		"Angle (Whenever a player exits a linked vehicle, they will be rotated to face this angle.\nOnly either this or 'Local Angle' can be used at a time. The last changed input is used.) [ANGLE]", 
+		"Entity (Links the exit point controller to a single specified vehicle and unlinks all others.) [ENTITY]",
+		"Entities (Links the exit point controller to the specified array of vehicles.\nEntities will be linked one by one and this value can't be changed during this time.) [ARRAY]",
+		"Position (Whenever a player exits a linked vehicle, they will be teleported to this position.\nOnly either this or 'Local Position' can be used at a time. The last changed input is used.) [VECTOR]",
+		"Local Position (Whenever a player exits a linked vehicle, they will be teleported to this position, relative to the vehicle they just exited.\nOnly either this or 'Position' can be used at a time. The last changed input is used.) [VECTOR]",
+		"Angle (Whenever a player exits a linked vehicle, they will be rotated to face this angle.\nOnly either this or 'Local Angle' can be used at a time. The last changed input is used.) [ANGLE]",
 		"Local Angle (Whenever a player exits a linked vehicle, they will rotated to face this angle, relative to the vehicle they just exited.\nOnly either this or 'Angle' can be used at a time. The last changed input is used.) [ANGLE]"
 	})
 
@@ -58,9 +58,9 @@ end
 
 function ENT:ShowOutput()
 	self:SetOverlayText(string.format(
-		"Entities linked: %i\n%sPosition: (%.2f, %.2f, %.2f)%s", 
-		table.Count(self.Entities), 
-		self.Global and "" or "Local ", 
+		"Entities linked: %i\n%sPosition: (%.2f, %.2f, %.2f)%s",
+		table.Count(self.Entities),
+		self.Global and "" or "Local ",
 		self.Position.x, self.Position.y, self.Position.z,
 		(self.ToLink and self.ToLinkCounter) and "\nLinking " .. (#self.ToLink-self.ToLinkCounter) .. " entities..." or ""
 	))

--- a/lua/entities/gmod_wire_expression2/core/bone.lua
+++ b/lua/entities/gmod_wire_expression2/core/bone.lua
@@ -37,7 +37,7 @@ function getBone(entity, index)
 		bone = entity:GetPhysicsObjectNum(index)
 		if not bone then return nil end
 		entity2bone[entity][index] = bone
-		
+
 		bone2entity[bone] = entity
 		bone2index[bone] = index
 	end

--- a/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
@@ -361,14 +361,14 @@ local function createHydraulic(self, index, ent1, ent2, v1, v2, width, bone1, bo
 
 	local existing = constraints[index]
 	if IsValid( existing ) then existing:Remove() end
-	
+
 	if color ~= nil then
 		color = Color(color[1], color[2], color[3])
 	end
 	if not constant or not damping then
 		constant, damping = CalcElasticConsts( getBone(ent1,bone1), getBone(ent2,bone2), ent1, ent2 )
 	end
-	
+
 	local cons, rope = constraint.Elastic( ent1, ent2, bone1 or 0, bone2 or 0, v1, v2, constant, damping, rdamping or 0, mat ~= "" and mat or "cable/cable2", width or 1, stretch ~= 0, color )
 	if not verifyConstraint( self, cons ) then return end
 
@@ -450,7 +450,7 @@ local function createRope(self, index, ent1, ent2, v1, v2, bone1, bone2, addleng
 	if color then
 		color = Color(color[1], color[2], color[3])
 	end
-	
+
 	local cons, rope = constraint.Rope( ent1, ent2, bone1 or 0, bone2 or 0, v1, v2, length, addlength or 0, 0, width or 1, mat ~= "" and mat or "cable/rope", rigid ~= 0,  color )
 	if not verifyConstraint( self, cons ) then return end
 
@@ -574,11 +574,11 @@ local function createSlider(self, ent1, ent2, v1, v2, width, bone1, bone2, mat, 
 	if not checkEnts( self, ent1, ent2 ) then return end
 	if not checkCount( self, "Slider", ent1, ent2 ) then return end
 	if not checkEdicts( self ) then return end
-	
+
 	if color then
 		color = Color(color[1],color[2],color[3],255)
 	end
-	
+
 	local cons, rope = constraint.Slider( ent1, ent2, bone1 or 0, bone2 or 0, v1, v2, width or 1, mat ~= "" and mat or "cable/cable2", color )
 	if not verifyConstraint( self, cons ) then return end
 
@@ -626,7 +626,7 @@ end
 local function noCollideCreate(self, ent1, ent2, bone1, bone2)
 	if not checkEnts(self, ent1, ent2) then return end
 	if not checkCount(self, "NoCollide", ent1, ent2) then return end
-	
+
 	local cons = constraint.NoCollide(ent1, ent2, bone1 or 0, bone2 or 0)
 	if not verifyConstraint(self, cons) then return end
 

--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -65,12 +65,12 @@ function PropCore.ValidAction(self, entity, cmd, bone)
 	if not IsValid(entity) then return self:throw("Invalid entity!", false) end
 	if not isOwner(self, entity) then return self:throw("You do not own this entity!", false) end
 	if entity:IsPlayer() then return self:throw("You cannot modify players", false) end
-	
+
 	-- For cases when we'd only want to check an entity
 	if cmd then
 		if not canHaveInvalidPhysics[cmd] and not validPhysics(entity) then return self:throw("Invalid physics object!", false) end
 		if bone then
-			if not entity["bone" .. bone] then 
+			if not entity["bone" .. bone] then
 				entity["bone" .. bone] = {}
 			end
 			entity = entity["bone" .. bone]
@@ -500,14 +500,14 @@ end
 e2function void bone:boneManipulate(vector pos, angle rot, isFrozen, gravity, collision)
 	local ent, index = boneVerify(self, this)
 	if not ValidAction(self, ent, "manipulate", index) then return end
-	
+
 	setPos(this, pos)
 	setAng(this, rot)
-	
+
 	this:EnableMotion(isFrozen == 0)
 	this:EnableGravity(gravity ~= 0)
 	this:EnableCollisions(collision ~= 0)
-	
+
 	ent:PhysWake()
 end
 
@@ -585,11 +585,11 @@ e2function void entity:makeStatue(enable)
 
 	local bones = this:GetPhysicsObjectCount()
 	if bones < 2 then return self:throw("You can only makeStatue on ragdolls!", nil) end
-	
+
 	if enable ~= 0 then
 		if this.StatueInfo then return end
 		local ply = self.player
-		
+
 		this.StatueInfo = {}
 
 		for bone = 1, bones - 1 do
@@ -602,7 +602,7 @@ e2function void entity:makeStatue(enable)
 		end
 
 		this:SetNWBool("IsStatue", true)
-		
+
 	else
 		if not this.StatueInfo then return end
 
@@ -655,7 +655,7 @@ e2function void bone:setPos(vector pos)
 	setPos(this, pos)
 	ent:PhysWake()
 end
-	
+
 e2function void bone:setAng(angle rot)
 	local ent, index = boneVerify(self, this)
 	if not ValidAction(self, ent, "ang", index) then return end
@@ -667,34 +667,34 @@ __e2setcost(60)
 
 e2function void entity:ragdollFreeze(isFrozen)
 	if not ValidAction(self, this, "freeze") then return end
-	
+
 	for _, bone in pairs(GetBones(this)) do
 		bone:EnableMotion(isFrozen == 0)
 		bone:Wake()
 	end
-	
-	
+
+
 end
 
 __e2setcost(150)
 
 e2function void entity:ragdollSetPos(vector pos)
 	if not ValidAction(self, this, "pos") then return end
-	
+
 	for _, bone in pairs(GetBones(this)) do
 		setPos(bone, this:WorldToLocal(bone:GetPos()) + pos)
 	end
-	
+
 	this:PhysWake()
 end
 
 e2function void entity:ragdollSetAng(angle rot)
 	if not ValidAction(self, this, "rot") then return end
-	
+
 	for _, bone in pairs(GetBones(this)) do
 		setAng(bone, bone:AlignAngles(this:GetForward():Angle(), rot))
 	end
-	
+
 	this:PhysWake()
 end
 
@@ -703,22 +703,22 @@ e2function table entity:ragdollGetPose()
 	local pose = E2Lib.newE2Table()
 	local bones = GetBones(this)
 	local originPos, originAng = bones[0]:GetPos(), bones[0]:GetAngles()
-	
+
 	-- We want to skip bone 0 as that will be the reference point
 	for k, bone in pairs(bones) do
 		local value = E2Lib.newE2Table()
 		local pos, ang = WorldToLocal(bone:GetPos(), bone:GetAngles(), originPos, originAng)
-		
+
 		value.n[1] = pos
 		value.n[2] = ang
 		value.ntypes[1] = "v"
 		value.ntypes[2] = "a"
 		value.size = 2
-		
+
 		pose.n[k] = value
 		pose.ntypes[k] = "t"
 	end
-	
+
 	pose.size = #pose.n
 	return pose
 end
@@ -728,20 +728,20 @@ e2function void entity:ragdollSetPose(table pose, rotate)
 	if pose.size == 0 then return end
 	local bones = GetBones(this)
 	local originPos, originAng = bones[0]:GetPos()
-	if rotate ~= 0 then 
+	if rotate ~= 0 then
 		originAng = bones[0]:GetAngles()
 	else
 		originAng = this:GetForward():Angle()
 	end
-	
+
 	for k, v in pairs(pose.n) do
 		local pos, ang = LocalToWorld(v.n[1], v.n[2], originPos, originAng)
 		setAng(bones[k], ang)
 		setPos(bones[k], pos)
 	end
-	
+
 	this:PhysWake()
-	
+
 end
 
 e2function void entity:ragdollSetPose(table pose)
@@ -749,15 +749,15 @@ e2function void entity:ragdollSetPose(table pose)
 	if pose.size == 0 then return end
 	local bones = GetBones(this)
 	local originPos, originAng = bones[0]:GetPos(), bones[0]:GetAngles() -- Rotate by default.
-	
+
 	for k, v in pairs(pose.n) do
 		local pos, ang = LocalToWorld(v.n[1], v.n[2], originPos, originAng)
 		setAng(bones[k], ang)
 		setPos(bones[k], pos)
 	end
-	
+
 	this:PhysWake()
-	
+
 end
 
 

--- a/lua/entities/gmod_wire_expression2/core/custom/wiring.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/wiring.lua
@@ -121,7 +121,7 @@ __e2setcost(10)
 e2function number entity:linkTo(entity ent2)
 	if not IsValid(this) or not IsValid(ent2) then return self:throw("Invalid Entity!", 0) end
 	if not isOwner(self, this) or not isOwner(self, ent2) then return self:throw("You do not own this entity", 0) end
-	
+
 	if not this.LinkEnt then return self:throw("Entity can't be linked", 0) end
 	return this:LinkEnt(ent2) and 1 or 0
 end
@@ -135,7 +135,7 @@ e2function number entity:unlinkFrom(entity ent2)
 	return this:UnlinkEnt(ent2) and 1 or 0
 end
 
---- Clears <this>'s links if applicable 
+--- Clears <this>'s links if applicable
 e2function void entity:clearLinks()
 	if not IsValid(this) then return self:throw("Invalid Entity!", nil) end
 	if not isOwner(self, this) then return self:throw("You do not own this entity!", nil) end
@@ -144,7 +144,7 @@ e2function void entity:clearLinks()
 		this:ClearEntities()
 	elseif this.UnlinkEnt then
 		this:UnlinkEnt()
-	else 
+	else
 		self:throw("Entity links cannot be cleared!")
 	end
 end

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -1012,7 +1012,7 @@ local function makeContext(owner)
 	ctx:InitScope()
 
 	-- Construct the context to run code.
-	-- If not done, 
+	-- If not done,
 	local ok, why = pcall(wire_expression2_CallHook, "construct", ctx)
 	if not ok then
 		pcall(wire_expression2_CallHook, "destruct", ctx)

--- a/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
@@ -1143,7 +1143,7 @@ e2function void wirelink:egpHudToggle()
 	if not EGP:ValidEGP(this) then return self:throw("Invalid wirelink!", nil) end
 	if antispam[self.player] and antispam[self.player] > CurTime() then return end
 	antispam[self.player] = CurTime() + 0.1
-	
+
 	timer.Simple(0, function()
 		EGP.EGPHudConnect(this, not (this.Users ~= nil and this.Users[self.player] ~= nil), self.player)
 	end)
@@ -1153,7 +1153,7 @@ e2function void wirelink:egpHudEnable(enable)
 	if not EGP:ValidEGP(this) then return self:throw("Invalid wirelink!", nil) end
 	if antispam[self.player] and antispam[self.player] > CurTime() then return end
 	antispam[self.player] = CurTime() + 0.1
-	
+
 	timer.Simple(0, function()
 		EGP.EGPHudConnect(this, enable ~= 0, self.player)
 	end)
@@ -1162,7 +1162,7 @@ end
 e2function array wirelink:egpConnectedUsers()
 	if not EGP:ValidEGP(this) then return self:throw("Invalid wirelink!", nil) end
 	if not this.Users then return {} end
-	
+
 	local sanitised_array, i = {}, 0
 	for k, _ in pairs(this.Users) do
 		i = i + 1

--- a/lua/entities/gmod_wire_expression2/core/extpp.lua
+++ b/lua/entities/gmod_wire_expression2/core/extpp.lua
@@ -422,7 +422,7 @@ function E2Lib.ExtPP.Pass2(contents)
 							mangled_name, regfn, name, arg_typeids .. "...", ret_typeid, mangled_name, mangled_name, makestringtable(argtable.argnames, (thistype ~= "") and 2 or 1), attributes
 						)
 					)
-					
+
 
 					-- Using __varargs_priv to avoid shadowing variables like `args` and breaking this implementation.
 					table.insert(output, compact([[

--- a/lua/entities/gmod_wire_expression2/core/hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/hologram.lua
@@ -904,7 +904,7 @@ e2function vector holoBonePos(index, boneindex)
 	local Holo = CheckIndex(self, index)
 	if not Holo then return Vector(0, 0, 0) end
 	if not CheckBone(self, index, boneindex, Holo) then return Vector(0, 0, 0) end
-	
+
 	return Holo.ent:GetBoneMatrix(boneindex):GetTranslation()
 end
 
@@ -922,7 +922,7 @@ e2function angle holoBoneAng(index, boneindex)
 	local Holo = CheckIndex(self, index)
 	if not Holo then return Angle(0, 0, 0) end
 	if not CheckBone(self, index, boneindex, Holo) then return Angle(0, 0, 0) end
-	
+
 	return Holo.ent:GetBoneMatrix(boneindex):GetAngles()
 end
 
@@ -1060,7 +1060,7 @@ end
 e2function void holoInvertModel( index, enable )
 	local Holo = CheckIndex(self, index)
 	if not Holo then return end
-	
+
 	Holo.ent:SetNWInt("invert_model", enable ~= 0 and 1 or 0)
 end
 

--- a/lua/entities/gmod_wire_expression2/core/wirelink.lua
+++ b/lua/entities/gmod_wire_expression2/core/wirelink.lua
@@ -408,7 +408,7 @@ end
 e2function array wirelink:readArray(start, size)
 	if size < 0 then return {} end
 	if !validWirelink(self, this) or !this.ReadCell then return {} end
-	
+
 	self.prf = self.prf + size
 
 	local ret = {}

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -131,7 +131,7 @@ end
 function ENT:UpdatePerf()
 	if not self.context then return end
 	if self.error then return end
-	
+
 	self.context.prfbench = self.context.prfbench * 0.95 + self.context.prf * 0.05
 	self.context.prfcount = self.context.prfcount + self.context.prf - e2_softquota
 	self.context.timebench = self.context.timebench * 0.95 + self.context.time * 0.05 -- Average it over the last 20 ticks
@@ -434,9 +434,9 @@ end
 function ENT:ResetContext()
 	local resetPrfMult = 1
 	if self.lastResetOrError then
-		-- reduces all the opcounters based on the time passed since 
+		-- reduces all the opcounters based on the time passed since
 		-- the last time the chip was reset or errored
-		-- waiting up to 30s before resetting results in a 0.1 multiplier 
+		-- waiting up to 30s before resetting results in a 0.1 multiplier
 		local passed = CurTime() - self.lastResetOrError
 		resetPrfMult = math.max(0.1, (30 - passed) / 30)
 	end

--- a/lua/entities/gmod_wire_forcer.lua
+++ b/lua/entities/gmod_wire_forcer.lua
@@ -71,9 +71,9 @@ function ENT:Think()
 	local ent = trace.Entity
 
 	if not IsValid(ent) then return end
-	
+
 	if ent:GetMoveType() == MOVETYPE_PUSH then return end
-	
+
 	local convar_value = wire_forcer_permissions:GetInt()
 	if convar_value==1 then
 		if not IsValid(self:GetPlayer()) or gamemode.Call( "GravGunPunt", self:GetPlayer(), ent )==false then return end
@@ -82,7 +82,7 @@ function ENT:Think()
 	end
 
 	if hook.Run( "Wire_ForcerCanUse", self:GetPlayer(), ent, self ) == false then return end
-	
+
 	if ent:GetMoveType() == MOVETYPE_VPHYSICS then
 		local phys = ent:GetPhysicsObject()
 		if not IsValid(phys) then return end

--- a/lua/entities/gmod_wire_friendslist.lua
+++ b/lua/entities/gmod_wire_friendslist.lua
@@ -11,16 +11,16 @@ function ENT:Initialize()
 	BaseClass.Initialize( self )
 
 	WireLib.CreateInputs( self, {
-		"CheckEntity (Check if this player is in this friends list.\nIf they are, the 'Checked' output becomes 1 for a short time.) [ENTITY]", 
-		"CheckSteamID (Check if this SteamID is in this friends list.) [STRING]", 
+		"CheckEntity (Check if this player is in this friends list.\nIf they are, the 'Checked' output becomes 1 for a short time.) [ENTITY]",
+		"CheckSteamID (Check if this SteamID is in this friends list.) [STRING]",
 		"CheckEntityID (Check if this player is in this friends list.)",
 		"Any (Check if any of the players in this array are in this friends list.) [ARRAY]",
 		"All (Check if all of the players in this array are in this friends list.) [ARRAY]"
 	} )
 	WireLib.CreateOutputs( self, {
-		"Checked (Outputs 1 for a short time if a check was passed.)", 
-		"Friends (Outputs all currently connected players who would pass checks in this friends list.) [ARRAY]", 
-		"AmountConnected (Outputs the size of the 'Friends' array)", 
+		"Checked (Outputs 1 for a short time if a check was passed.)",
+		"Friends (Outputs all currently connected players who would pass checks in this friends list.) [ARRAY]",
+		"AmountConnected (Outputs the size of the 'Friends' array)",
 		"AmountTotal (Outputs the size of the list as provided by the friendslist user interface. Does not take Steam or CPPI sync into account.)"
 	} )
 
@@ -106,8 +106,8 @@ local function isInArray(r, ply)
 end
 
 local function checkSingle(self, ply)
-	if self.friends_lookup[ply] then 
-		return true 
+	if self.friends_lookup[ply] then
+		return true
 	end
 
 	if self.sync_with_steam then
@@ -173,7 +173,7 @@ end
 
 function ENT:TriggerInput( name, value )
 	-- the check function should return true if matched, false if not matched, and nil if no check was performed (not a valid player, etc)
-	local check = checkActions[name]( self, value ) 
+	local check = checkActions[name]( self, value )
 
 	if check == true then
 		WireLib.TriggerOutput( self, "Checked", 1 )

--- a/lua/entities/gmod_wire_hologram.lua
+++ b/lua/entities/gmod_wire_hologram.lua
@@ -120,10 +120,10 @@ if CLIENT then
 		end
 
 		self:SetupClipping()
-		
+
 		local invert_model = self:GetNWInt("invert_model")
 		render.CullMode(invert_model)
-		
+
 		if self:GetNWBool("disable_shading") then
 			render.SuppressEngineLighting(true)
 			self:DrawModel()
@@ -131,7 +131,7 @@ if CLIENT then
 		else
 			self:DrawModel()
 		end
-		
+
 		if invert_model ~= 0 then
 			render.CullMode(0)
 		end

--- a/lua/entities/gmod_wire_hoverball.lua
+++ b/lua/entities/gmod_wire_hoverball.lua
@@ -94,8 +94,8 @@ function ENT:Initialize()
 	self:SetAirResistance( 1 )
 	self:SetZTarget( self:GetPos().z ) -- reset target position
 
-	self.Inputs = WireLib.CreateInputs( self, { "On", 
-		"ZVelocity (If non-zero, causes the hoverball to attempt to fly up, or down if the value is negative.\nThe speed is based on the magnitude of the number multiplied by the speed configured in the context menu.)", 
+	self.Inputs = WireLib.CreateInputs( self, { "On",
+		"ZVelocity (If non-zero, causes the hoverball to attempt to fly up, or down if the value is negative.\nThe speed is based on the magnitude of the number multiplied by the speed configured in the context menu.)",
 		"ZTarget (Causes the hoverball to attempt to fly to the specified Z coordinate and stay there.)"
 	} )
 	self.Outputs = WireLib.CreateOutputs( self, { "Position [VECTOR]", "X", "Y", "Z", "Distance (How far away the hoverball's Z coordinate is from its target)" } )

--- a/lua/entities/gmod_wire_hydraulic.lua
+++ b/lua/entities/gmod_wire_hydraulic.lua
@@ -7,18 +7,18 @@ if CLIENT then return end -- No more client
 
 function ENT:Initialize()
 	BaseClass.Initialize(self)
-	WireLib.CreateInputs( self, { 
-		"Length (Sets the length of the hydraulic)", 
-		"In (Decreases the length of the hydraulic each tick.)", 
-		"Out (Increases the length of the hydraulic each tick.)", 
-		"Constant (Affects the strength of the hydraulic. Higher values means it's able to lift more weight, and more easily overcome the inertia of attached entities.\nSet to zero to reset this value to the default.)", 
+	WireLib.CreateInputs( self, {
+		"Length (Sets the length of the hydraulic)",
+		"In (Decreases the length of the hydraulic each tick.)",
+		"Out (Increases the length of the hydraulic each tick.)",
+		"Constant (Affects the strength of the hydraulic. Higher values means it's able to lift more weight, and more easily overcome the inertia of attached entities.\nSet to zero to reset this value to the default.)",
 		"Damping (Affects the springyness of the hydraulic.\nLower values means more bouncyness, higher values means more resistant to change.\nIf set too high, may cause severe shaking.\nSet to zero to reset this value to the default.)"
 	})
-	WireLib.CreateOutputs( self, { 
-		"Length", 
-		"Target Length", 
-		"Constant", 
-		"Damping" 
+	WireLib.CreateOutputs( self, {
+		"Length",
+		"Target Length",
+		"Constant",
+		"Damping"
 	})
 	self.TargetLength = 0
 	self.current_constant = 0

--- a/lua/entities/gmod_wire_keyboard/init.lua
+++ b/lua/entities/gmod_wire_keyboard/init.lua
@@ -64,13 +64,13 @@ function ENT:Initialize()
 	self:SetUseType(ONOFF_USE)
 
 	self.Inputs = WireLib.CreateInputs(self, { "Kick (Kicks the player currently using the keyboard out)", "Reset Output String" })
-	self.Outputs = WireLib.CreateOutputs(self, { 
-		"Memory (Outputs the last pressed key's ascii value.\nNote that this may skip keypresses due to being unable to update fast enough.\nEither use the 'Output' string or 'ActiveKeys' array outputs, or use\nE2/zCPU with hi-speed/wirelink to be able to catch all keypresses.)", 
-		"Output [STRING]", 
-		"OutputChar (Outputs the last pressed key.\nNote that this may skip keypresses due to being unable to update fast enough.) [STRING]", 
-		"ActiveKeys (Outputs an array of currently held key ascii values.) [ARRAY]", 
-		"User [ENTITY]", 
-		"InUse" 
+	self.Outputs = WireLib.CreateOutputs(self, {
+		"Memory (Outputs the last pressed key's ascii value.\nNote that this may skip keypresses due to being unable to update fast enough.\nEither use the 'Output' string or 'ActiveKeys' array outputs, or use\nE2/zCPU with hi-speed/wirelink to be able to catch all keypresses.)",
+		"Output [STRING]",
+		"OutputChar (Outputs the last pressed key.\nNote that this may skip keypresses due to being unable to update fast enough.) [STRING]",
+		"ActiveKeys (Outputs an array of currently held key ascii values.) [ARRAY]",
+		"User [ENTITY]",
+		"InUse"
 	})
 
 	self.ActiveKeys = {} -- table containing all currently active keys, used to see when keys are pressed/released

--- a/lua/entities/gmod_wire_pod.lua
+++ b/lua/entities/gmod_wire_pod.lua
@@ -121,11 +121,11 @@ function ENT:Initialize()
 		-- Keys
 		"W", "A", "S", "D", "Mouse1", "Mouse2",
 		"R", "Space", "Shift", "Zoom", "Alt", "Duck", "Noclip",
-		"TurnLeftKey (Not bound to a key by default. Bind a key to '+left' to use.\nOutside of a vehicle, makes the player's camera rotate left.)", 
+		"TurnLeftKey (Not bound to a key by default. Bind a key to '+left' to use.\nOutside of a vehicle, makes the player's camera rotate left.)",
 		"TurnRightKey (Not bound to a key by default. Bind a key to '+right' to use.\nOutside of a vehicle, makes the player's camera rotate right.)",
 
 		-- Clientside keys
-		"PrevWeapon (Usually bound to the mouse scroller, so will only be active for a single tick.)", 
+		"PrevWeapon (Usually bound to the mouse scroller, so will only be active for a single tick.)",
 		"NextWeapon (Usually bound to the mouse scroller, so will only be active for a single tick.)",
 		"Light",
 
@@ -149,7 +149,7 @@ function ENT:Initialize()
 	local inputs = {
 		"Lock", "Terminate", "Strip weapons", "Eject",
 		"Disable", "Crosshairs", "Brake", "Allow Buttons",
-		"Relative (If this is non-zero, the 'Bearing' and 'Elevation' outputs will be relative to the vehicle.)", 
+		"Relative (If this is non-zero, the 'Bearing' and 'Elevation' outputs will be relative to the vehicle.)",
 		"Damage Health (Damages the driver's health.)", "Damage Armor (Damages the driver's armor.)", "Hide Player", "Hide HUD", "Show Cursor",
 		"Vehicle [ENTITY]"
 	}

--- a/lua/entities/gmod_wire_ranger.lua
+++ b/lua/entities/gmod_wire_ranger.lua
@@ -20,9 +20,9 @@ function ENT:Initialize()
 	self:SetSolid( SOLID_VPHYSICS )
 	self:StartMotionController()
 
-	self.Inputs = WireLib.CreateInputs(self, { 
-		"X", "Y", "SelectValue", "Length", 
-		"Target [VECTOR]", 
+	self.Inputs = WireLib.CreateInputs(self, {
+		"X", "Y", "SelectValue", "Length",
+		"Target [VECTOR]",
 		"Ignore (Adds all specified entities to the ranger's filter.\nKeep in mind that this filtering is not synced to the client and is therefore not visible in the ranger's beam.) [ARRAY]"
 	})
 	self.Outputs = WireLib.CreateOutputs(self, { "Dist" })

--- a/lua/entities/gmod_wire_rt_screen.lua
+++ b/lua/entities/gmod_wire_rt_screen.lua
@@ -217,7 +217,7 @@ if CLIENT then
 
             return
         end
-        
+
         self.ShouldRenderCamera = self:IsScreenInRange(LocalPlayer())
 
         if IsValid(camera) then
@@ -311,7 +311,7 @@ if CLIENT then
             return
         end
 
-        if self:GetActive() and self.ShouldRenderCamera and self.Material ~= nil 
+        if self:GetActive() and self.ShouldRenderCamera and self.Material ~= nil
             and IsValid(self:GetCamera()) and self:GetCamera():GetActive()
         then
             self:DrawScreen()

--- a/lua/entities/gmod_wire_screen.lua
+++ b/lua/entities/gmod_wire_screen.lua
@@ -100,7 +100,7 @@ if CLIENT then
 
 	function ENT:Draw()
 		self:DrawModel()
-		
+
 		self.GPU:RenderToWorld(nil, 188, function(x, y, w, h)
 			surface.SetDrawColor(background_color)
 			surface.DrawRect(x, y, w, h)

--- a/lua/entities/gmod_wire_spawner.lua
+++ b/lua/entities/gmod_wire_spawner.lua
@@ -88,18 +88,18 @@ end
 function ENT:DoSpawn( pl, down )
 
 	if self.DisabledByTimeUntil > CurTime() then return end
-	
+
 	if self.DisabledByTouch then --If we'll teleport spawned prop fast prop spawner will remain disabled forever (Fix by Supertos)
-		-- self.TouchDisabledProp is entity, not table here 'cause we can't spawn any more props while this one is stuck 
+		-- self.TouchDisabledProp is entity, not table here 'cause we can't spawn any more props while this one is stuck
 		if IsValid( self.TouchDisabledProp ) then	--If there's no prop why should we even care?
 			local mins, maxs = self:GetPhysicsObject():GetAABB()
 			local size = maxs-mins
 			local test_radius = math.max( size.X, size.Y, size.Z )
-			
+
 			if self.TouchDisabledProp:GetPos():Distance( self:GetPos() ) < test_radius*2 then return end --This prop is still inside prop spawner (Multiple by two because spawned prop has some volume too )
 		end
 	end
-	
+
 	local ent	= self
 	if (not ent:IsValid()) then return end
 
@@ -110,7 +110,7 @@ function ENT:DoSpawn( pl, down )
 	local Ang	= ent:GetAngles()
 	local model	= ent:GetModel()
 	local prop  = nil
-	
+
 	if self.spawn_effect ~= 0 then
 		prop = MakeProp( pl, Pos, Ang, model, {}, {} )
 	else

--- a/lua/entities/info_wiremapinterface/init.lua
+++ b/lua/entities/info_wiremapinterface/init.lua
@@ -56,7 +56,7 @@ local MIN_TRIGGER_TIME = 0.01 -- Minimum triggering Time for in- and outputs.
 -- This checks if you can give an entity wiremod abilities
 function ENT:IsWireableEntity(Entity)
 	if (not IsValid(Entity)) then return false end -- No interface for invalid entities!
-	if (IsValid(Entity._WireMapInterfaceEnt) and (Entity._WireMapInterfaceEnt ~= self)) then return false end -- Only one interface per entity! 
+	if (IsValid(Entity._WireMapInterfaceEnt) and (Entity._WireMapInterfaceEnt ~= self)) then return false end -- Only one interface per entity!
 	if (not IsValid(Entity._WireMapInterfaceEnt) and (WireLib.HasPorts(Entity) or Entity.IsWire or Entity.Inputs or Entity.Outputs)) then return false end -- Don't destroy wiremod entites!
 
 	if (Entity:IsWorld()) then return false end -- No interface for the worldspawn!

--- a/lua/weapons/gmod_tool/stools/wire_adv.lua
+++ b/lua/weapons/gmod_tool/stools/wire_adv.lua
@@ -414,14 +414,14 @@ elseif CLIENT then
 	function TOOL:AutoWiringTypeLookup_Check( inputtype )
 		return self.AutoWiringTypeLookup_t[inputtype]
 	end
-	
+
 	-- Updates the trace hit position and normal to the surface of the parent, perpendicular to the originally hit entity.
 	-- As not all models have the same forward, up, etc. it checks all directions perpendicular to the hit entity, until it finds the parent.
 	-- If the parent is not found in any perpendicular direction, it traces the parent in the direction of the tool gun.
 	function TOOL:UpdateTraceForSurface(trace, parent)
 		if self:GetClientNumber("stick") == 0 then return end
 		if not WireLib.HasPorts(trace.Entity) then return end
-		
+
 		local hitParentPos
 		local hitParentNormal
 		local foundParent
@@ -1045,7 +1045,7 @@ elseif CLIENT then
 			-- special case for constant value to force render all descriptions at all times
 			-- and doesn't draw \n on separate lines,
 			-- and also doesn't automatically wrap too long lines
-			local isconstvalue = ent:GetClass() == "gmod_wire_value" 
+			local isconstvalue = ent:GetClass() == "gmod_wire_value"
 
 			-- draw description
 			if desc ~= "" and (self:GetStage() == 0 or self:GetStage() == 2 or isconstvalue) then

--- a/lua/wire/client/cl_wirelib.lua
+++ b/lua/wire/client/cl_wirelib.lua
@@ -26,7 +26,7 @@ WIRE_CLIENT_INSTALLED = 1
 mats_cache = {
 	["tripmine_laser"] = Material("tripmine_laser"),
 	["Models/effects/comball_tape"] = Material("Models/effects/comball_tape")
-}	 
+}
 
 BeamMat = Material("tripmine_laser")
 BeamMatHR = Material("Models/effects/comball_tape")
@@ -42,7 +42,7 @@ end
 
 function Wire_Render(ent)
 	if Wire_DisableWireRender ~= 0 then return end	--We shouldn't render anything
-	
+
 	local wires = ent.WirePaths
 	if not wires then
 		ent.WirePaths = {}
@@ -51,9 +51,9 @@ function Wire_Render(ent)
 		net.SendToServer()
 		return
 	end
-	
+
 	if not next(wires) then return end
-	
+
 	local t = CurTime()
 	if lastrender ~= t then
 		local w, f = math.modf(t*WIRE_BLINKS_PER_SECOND)
@@ -66,12 +66,12 @@ function Wire_Render(ent)
 	--CREATING (Not assigning a value) local variables OUTSIDE of cycle a bit faster
 	local start, color, nodes, len, h, s, v, tmpColor, endpos, node, node_ent
 	for net_name, wiretbl in pairs(wires) do
-	
+
 		width = wiretbl.Width
 		if width > 0 and blink ~= net_name then
 			start = IsValid(ent) and ent:LocalToWorld(wiretbl.StartPos) or wiretbl.StartPos
 			color = wiretbl.Color
-			
+
 			if WireLib.Wire_GrayOutWires then
 				h, s, v = ColorToHSV(color)
 				v = 0.175
@@ -85,7 +85,7 @@ function Wire_Render(ent)
 				render.SetMaterial( getmat(wiretbl.Material) )	--Maybe every wire addon should precache it's materials on setup?
 				render.StartBeam(len * 2 + 1)
 				render.AddBeam(start, width, scroll, color)
-				
+
 				for j=1, len do
 					node = nodes[j]
 					node_ent = node.Entity
@@ -97,7 +97,7 @@ function Wire_Render(ent)
 						start = endpos
 					end
 				end
-				
+
 				render.EndBeam()
 			end
 		end
@@ -167,7 +167,7 @@ function Wire_DrawTracerBeam( ent, beam_num, hilight, beam_length )
 	if beam_length == 0 then return end
 	local pos = ent:GetPos()
 	local trace = {}
-	
+
 	if ent.GetTarget and ( ent:GetTarget().X ~= 0 or ent:GetTarget().Y ~= 0 or ent:GetTarget().Z ~= 0 ) then
 		trace.endpos = pos + ( ent:GetTarget() - pos ):GetNormalized()*beam_length
 		if trace.endpos[1] ~= trace.endpos[1] then trace.endpos = pos+Vector(ent:GetBeamLength(), 0, 0) end
@@ -186,7 +186,7 @@ function Wire_DrawTracerBeam( ent, beam_num, hilight, beam_length )
 	else
 		trace.endpos = pos + ent:GetUp()*beam_length
 	end
-	
+
 	trace.start = pos
 	trace.filter = { ent }
 	if ent:GetNWBool("TraceWater") then trace.mask = MASK_ALL end
@@ -194,7 +194,7 @@ function Wire_DrawTracerBeam( ent, beam_num, hilight, beam_length )
 	--Update render bounds
 	ent.ExtraRBoxPoints = ent.ExtraRBoxPoints or {}
 	ent.ExtraRBoxPoints[beam_num] = ent:WorldToLocal(trace.HitPos)
-	
+
 	render.SetMaterial(BeamMat)
 	render.DrawBeam(pos, trace.HitPos, 6, 0, 10, ent:GetColor())
 	if hilight then	--This is intended behaivour
@@ -243,7 +243,7 @@ WireLib.__old_renderhalos = old_renderhalos
 if old_renderhalos ~= nil then
 	hook.Add("PostDrawEffects","RenderHalos", function()
 		if hook.Run("ShouldDrawHalos") == false then return end
-	
+
 		old_renderhalos()
 	end)
 else

--- a/lua/wire/client/text_editor/issue_viewer.lua
+++ b/lua/wire/client/text_editor/issue_viewer.lua
@@ -11,7 +11,7 @@ local gui_MouseY = gui.MouseY
 
 function PANEL:Init()
     local base = self
-    
+
     self.Files = {}
 
     self:Dock(BOTTOM)
@@ -42,7 +42,7 @@ function PANEL:Init()
     end
 
     function self.Dragger:Think()
-        if not self.Held then 
+        if not self.Held then
             if self.UnheldDueToCollapse then
                 self.UnheldDueToCollapse = false
                 self.Hovered = false
@@ -76,7 +76,7 @@ function PANEL:Init()
 
     function self.Dragger:OnMouseReleased(btn)
         if btn ~= MOUSE_LEFT then return end
-        
+
         self:MouseCapture(false)
         self.Held = false
     end
@@ -90,7 +90,7 @@ function PANEL:Init()
     self.IssuesView = self:Add("DTree")
     self.IssuesView:Dock(FILL)
     self.IssuesView:DockMargin(2, 0, 2, 3)
-    
+
     self.IssuesView:Hide()
     self.IssuesView.OldAddNode = self.IssuesView.AddNode
     function self.IssuesView:AddNode(text)
@@ -111,18 +111,18 @@ function PANEL:Init()
         n.Label.Paint = function(_, _, _) end
         return n
     end
-    
+
     local IssuesView_BackgroundColor = Color(32, 32, 32)
     function self.IssuesView:Paint(w, h)
         surface_SetDrawColor(IssuesView_BackgroundColor)
         surface_DrawRect(0, 0, w, h)
     end
-    
+
     self.ValidationText = "Code Validator"
     self:SetValidationColors(Color(180, 180, 180))
-    
+
     self.OnMousePressed = nil
-    
+
     self.ShowWhatPopupDoes = 0
 
     function self.ValidationButton:Paint(w, h)
@@ -139,13 +139,13 @@ function PANEL:Init()
 
         surface_SetDrawColor(base.ValidationColorOutline)
         surface_DrawOutlinedRect(0, 0, w, h, 2)
-        
+
         draw_SimpleText(base.ValidationText, "DermaDefault", w / 2, h / 2, color_white, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
         if base.ShowWhatPopupDoes > 0 then
             draw_SimpleText((base.IsCollapsed and "Show" or "Hide") .. " Code Problems", "DermaDefault", 36, h / 2, Color(255, 255, 255, base.ShowWhatPopupDoes * 255), TEXT_ALIGN_LEFT, TEXT_ALIGN_CENTER )
         end
     end
-    
+
     function self.ValidationButton:OnMousePressed(btn)
         if base.OnMousePressed ~= nil then
             base:OnMousePressed(btn)
@@ -162,31 +162,31 @@ function PANEL:Init()
         local menu = DermaMenu()
 
         local copy = menu:AddOption(
-            "Copy to clipboard", 
-            function() 
-                SetClipboardText(node.Label:GetText()) 
+            "Copy to clipboard",
+            function()
+                SetClipboardText(node.Label:GetText())
             end
         )
 
         menu:Open()
     end
-    
+
     self.TogglePopupButton = self.ValidationButton:Add("DButton")
     self.TogglePopupButton:Dock(LEFT)
     self.TogglePopupButton:SetSize(36, 0)
     self.TogglePopupButton:SetText("")
     self.IsCollapsed = true
-    
+
     function self.TogglePopupButton:Paint(w, h)
 
         surface_SetDrawColor(color_white)
         local centerX, centerY = w / 2, h / 2
         local arrowWidth, arrowHeight = 6, 3 * (base.IsCollapsed and -1 or 1)
-        
+
         surface_DrawLine(centerX - arrowWidth, centerY - arrowHeight, centerX, centerY + arrowHeight)
         surface_DrawLine(centerX + arrowWidth, centerY - arrowHeight, centerX, centerY + arrowHeight)
     end
-    
+
     function self.TogglePopupButton:DoClick()
         base:Toggle()
     end
@@ -196,7 +196,7 @@ function PANEL:Init()
     end
 end
 
-function PANEL:Paint(w, h) 
+function PANEL:Paint(w, h)
 
 end
 function PANEL:GetValue()
@@ -206,7 +206,7 @@ end
 function PANEL:Collapse(triggered_by_drag)
     if self.IsCollapsed then return end
 
-    if triggered_by_drag then 
+    if triggered_by_drag then
         self.Dragger.Held = false
         self.Dragger:MouseCapture(false)
         self.Dragger.UnheldDueToCollapse = true
@@ -236,7 +236,7 @@ end
 function PANEL:SetValidationColors(color)
     self.ValidationColorBackground = color
     local h, s, v = ColorToHSV(color)
-    
+
     self.ValidationColorOutline = HSVToColor(h, s, v / 1.2)
     self.ValidationColorHovered = HSVToColor(h, s, v + 0.073)
     self.ValidationColorDepressed = HSVToColor(h, s, v - 0.073)
@@ -254,10 +254,10 @@ end
 function PANEL:Update(errors, warnings, header_text, header_color)
     self.ValidationText = header_text or self.ValidationText
     if header_color ~= nil then self:SetValidationColors(header_color) end
-    
+
     self.Errors = errors
     self.Warnings = warnings
-    
+
     local tree = self.IssuesView
     tree:Clear()
 

--- a/lua/wire/client/text_editor/texteditor.lua
+++ b/lua/wire/client/text_editor/texteditor.lua
@@ -625,7 +625,7 @@ function EDITOR:Paint()
 	if self.MouseDown then
 		self.Caret = self:CursorToCaret()
 	end
-	
+
 	local backgroundColor = self:GetSyntaxColor("background")
 
 	surface_SetDrawColor(backgroundColor.r - 28,backgroundColor.g - 28,backgroundColor.b - 28)

--- a/lua/wire/client/text_editor/wire_expression2_editor.lua
+++ b/lua/wire/client/text_editor/wire_expression2_editor.lua
@@ -796,7 +796,7 @@ function Editor:InitComponents()
 	self.C.Control = self:addComponent(vgui.Create("Panel", self), -350, 52, 342, -32) -- Control Panel
 	self.C.Credit = self:addComponent(vgui.Create("DTextEntry", self), -160, 52, 150, 150) -- Credit box
 	self.C.Credit:SetEditable(false)
-	
+
 	self:CreateTab("generic")
 
 	-- extra component options
@@ -1652,10 +1652,10 @@ end
 function Editor:Validate(gotoerror)
 	local header_color, header_text = nil, nil
 	local problems_errors, problems_warnings = {}, {}
-	
+
 	if self.EditorType == "E2" then
 		local errors, _, warnings = wire_expression2_validate(self:GetCode())
-		
+
 		if not errors then
 			if warnings then
 				header_color = Color(163, 130, 64, 255)
@@ -1681,14 +1681,14 @@ function Editor:Validate(gotoerror)
 			if not row then
 				row, col = errors:match("at line ([0-9]+)$"), 1
 			end
-			
+
 			problems_errors = {{message = string.Explode(" at line", errors)[1], line = row, char = col}}
 
 			if gotoerror then
 				if row then self:GetCurrentEditor():SetCaret({ tonumber(row), tonumber(col) }) end
 			end
 		end
-		
+
 	elseif self.EditorType == "CPU" or self.EditorType == "GPU" or self.EditorType == "SPU" then
 		header_color = Color(64, 64, 64, 180)
 		header_text = "Recompiling..."
@@ -1833,7 +1833,7 @@ function Editor:SaveFile(Line, close, SaveAs)
 		self:Close()
 		return
 	end
-	
+
 	if not Line or SaveAs or Line == self.Location .. "/" .. ".txt" then
 		local str
 		if self.C.Browser.File then
@@ -1863,7 +1863,7 @@ function Editor:SaveFile(Line, close, SaveAs)
 				strTextOut = string.gsub(strTextOut, ".", invalid_filename_chars)
 				local save_location = self.Location .. "/" .. strTextOut .. ".txt"
 				if file.Exists(save_location, "DATA") then
-					Derma_QueryNoBlur("The file '" .. strTextOut .. "' already exists. Do you want to overwrite it?", "File already exists", 
+					Derma_QueryNoBlur("The file '" .. strTextOut .. "' already exists. Do you want to overwrite it?", "File already exists",
 					"Yes", function() self:SaveFile(save_location, close) end,
 					"No", function() end)
 				else

--- a/lua/wire/flir.lua
+++ b/lua/wire/flir.lua
@@ -14,7 +14,7 @@
 	* Add entities to the list as they are parented. If something is parented while FLIR is enabled, it doesn't
 		add itself until it's switched off and back on.
 	* Sun pops in and out of full brightness when looking around it
-	
+
 --]]
 
 if not FLIR then FLIR = { enabled = false } end

--- a/lua/wire/stools/characterlcd.lua
+++ b/lua/wire/stools/characterlcd.lua
@@ -13,10 +13,10 @@ WireToolSetup.SetupMax( 20 )
 
 if SERVER then
 	function TOOL:GetConVars()
-		return self:GetClientInfo("width"), self:GetClientInfo("height"), 
+		return self:GetClientInfo("width"), self:GetClientInfo("height"),
         math.Clamp(self:GetClientNumber("bgred"), 0, 255),
 				math.Clamp(self:GetClientNumber("bggreen"), 0, 255),
-				math.Clamp(self:GetClientNumber("bgblue"), 0, 255), 
+				math.Clamp(self:GetClientNumber("bgblue"), 0, 255),
         math.Clamp(self:GetClientNumber("fgred"), 0, 255),
 				math.Clamp(self:GetClientNumber("fggreen"), 0, 255),
 				math.Clamp(self:GetClientNumber("fgblue"), 0, 255)
@@ -34,7 +34,7 @@ TOOL.ClientConVar = {
   fgred      = 45,
   fggreen    = 91,
   fgblue     = 45,
-  
+
 }
 
 function TOOL.BuildCPanel(panel)
@@ -63,5 +63,5 @@ function TOOL.BuildCPanel(panel)
 	panel:NumSlider("Width", "wire_characterlcd_width", 1, 56, 0)
 	panel:NumSlider("Height", "wire_characterlcd_height", 1, 16, 0)
 	panel:CheckBox("#Create Flat to Surface", "wire_characterlcd_createflat")
-  
+
 end

--- a/lua/wire/stools/expression2.lua
+++ b/lua/wire/stools/expression2.lua
@@ -130,7 +130,7 @@ if SERVER then
 			name = truncName,
 			expiry = CurTime() + 60 -- 1 minute for the request before it's invalidated (could make this a convar)
 		}
-		
+
 		-- Invalidate expired requests
 		hook.Add("Tick", "WireExpression2_InvalidateRequests", InvalidateRequests)
 
@@ -304,7 +304,7 @@ if SERVER then
 				if not targetEnt.DownloadAllowedPlayers[ply] then return end
 				targetEnt.DownloadAllowedPlayers[ply] = nil
 				if table.IsEmpty(targetEnt.DownloadAllowedPlayers) then
-					targetEnt.DownloadAllowedPlayers = nil 
+					targetEnt.DownloadAllowedPlayers = nil
 				end
 			end)
 

--- a/lua/wire/stools/friendslist.lua
+++ b/lua/wire/stools/friendslist.lua
@@ -15,7 +15,7 @@ if CLIENT then
 	language.Add( "wire_friendslist_invalid_steamid", "Invalid SteamID" )
 	language.Add( "wire_friendslist_connected_players", "Currently connected players" )
 	language.Add( "wire_friendslist_not_connected", "Not Connected" )
-	
+
 	language.Add( "wire_friendslist_sync_with_steam", "Sync With Steam Friends" )
 	language.Add( "wire_friendslist_sync_with_cppi", "Sync With CPPI (Prop Protection)" )
 	language.Add( "wire_friendslist_sync_with_help", "Sync with Steam/CPPI. These synced settings ignore the 'save on entity' setting - friends on your steam/cppi lists will always be synced regardless." )
@@ -67,8 +67,8 @@ if SERVER then
 	end)
 
 	function TOOL:GetConVars()
-		return 
-			self:GetClientNumber( "save_on_entity" ) ~= 0, 
+		return
+			self:GetClientNumber( "save_on_entity" ) ~= 0,
 			friends[self:GetOwner()] or {},
 			self:GetClientNumber( "sync_with_steam" ) ~= 0,
 			self:GetClientNumber( "sync_with_cppi" ) ~= 0

--- a/lua/wire/stools/value.lua
+++ b/lua/wire/stools/value.lua
@@ -329,7 +329,7 @@ if CLIENT then
 
 		loadValues()
 	end)
-	
+
 	local function loadPreset(data)
 		local values = {}
 		-- Did you know Garry's Mod has a cool feature where this table's keys can be strings OR numbers?
@@ -359,13 +359,13 @@ if CLIENT then
 				table.insert(tbl, v.DataType)
 				table.insert(tbl, v.Value)
 			end
-			
+
 			presets.Add("wire_value", text, tbl)
 			ctrl:Update()
 		end
 		ctrl:SetPreset("wire_value")
 		panel:AddPanel(ctrl)
-		
+
 		WireToolHelpers.MakeModelSizer(panel, "wire_value_modelsize")
 		ModelPlug_AddToCPanel(panel, "Value", "wire_value", true)
 

--- a/lua/wire/tool_loader.lua
+++ b/lua/wire/tool_loader.lua
@@ -708,7 +708,7 @@ if SERVER then
 		if not controller.WireLinkedEnts then return end
 		if not controller.WireLinkedEnts.Marks then return end
 		if controller.WireLinkedEnts.LastUpdated < lastUpdated then return end
-			
+
 		net.Start("WireLinkedEnts")
 			net.WriteEntity(controller)
 			net.WriteFloat(controller.WireLinkedEnts.LastUpdated)


### PR DESCRIPTION
Trims all trailing whitespaces from lua files. Mainly improves style but it will also slightly increase joining speeds on servers i think, which is always welcome.

The linter will likely try to kill me because i only changed whitespaces so any files that haven't been properly styled yet will be flagged as bad.