### PR TITLE
Remove IsValid Check on DHDD Data Input

### DIFF
--- a/lua/entities/gmod_wire_dhdd.lua
+++ b/lua/entities/gmod_wire_dhdd.lua
@@ -77,7 +77,6 @@ end
 function ENT:TriggerInput( name, value )
 	if (name == "Data") then
 		if not value then return end -- if the value is invalid, abort
-		if not IsValid(self.Inputs.Data.Src) then return end -- if the input is not wired to anything, abort
 		if not self.AllowWrite then return end -- if we don't allow writing, abort
 
 		self.Memory = value


### PR DESCRIPTION
**Description**:
When setting the DHDD *Data* input to an array using wires, the *Memory* output is changed accordingly. However, when using wirelinks to set *Data*, there appears to be no effect.

This PR allows wirelinks to properly set the *Data* input of DHDDs. The default behavior of DHDDs can still be expected as an input trigger with *nil* is already accounted for.

<details><summary>Issue</summary>
<p>

**To Reproduce:**
1. Create two DHDDs.
2. Create an E2 that outputs an array such as `Out = array(...)` and wire it to one DHDD.
3. Observe the memory of the DHDD with the debugger. It will contain all the data you pass to it.
![image](https://github.com/wiremod/wire/assets/20892685/d86e5837-4ef0-45ab-9d15-d62871174335)

6. Create another E2 that uses wirelinks such as `DHDD["Data", array] = ...` to set *Data* on the DHDD.
7. Observe the memory of the DHDD. It will contain nothing.
![image](https://github.com/wiremod/wire/assets/20892685/9ae83911-2f51-4a50-84e3-7c9d5e90f279)


**Expected behavior:**
Setting *Data* through wirelink should update the DHDD appropriately.
</p>
</details> 