### PR TITLE
Move effect burst count out of isAllowed

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/effects.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/effects.lua
@@ -8,29 +8,31 @@ local effect_blacklist = {
 	dof_node = true
 }
 
-local function isAllowed( self )
-	local data = self.data
+local function isAllowed(self)
+	return self.data.effect_burst >= 0
+end
 
-	if data.effect_burst == 0 then return false end
+local function fire(self, this, name)
+	local data = self.data
 
 	data.effect_burst = data.effect_burst - 1
 
 	local timerid = "E2_effect_burst_count_" .. self.entity:EntIndex()
-	if not timer.Exists( timerid ) then
-		timer.Create( timerid, wire_expression2_effect_burst_rate:GetFloat(), 0, function()
-			if not IsValid( self.entity ) then
-				timer.Remove( timerid )
+	if not timer.Exists(timerid) then
+		timer.Create(timerid, wire_expression2_effect_burst_rate:GetFloat(), 0, function()
+			if not IsValid(self.entity) then
+				timer.Remove(timerid)
 				return
 			end
 
 			data.effect_burst = data.effect_burst + 1
 			if data.effect_burst == wire_expression2_effect_burst_max:GetInt() then
-				timer.Remove( timerid )
+				timer.Remove(timerid)
 			end
 		end)
 	end
 
-	return true
+	util.Effect(name, this, true, true)
 end
 
 registerType("effect", "xef", nil,
@@ -180,7 +182,7 @@ e2function void effect:play(string name)
 	if effect_blacklist[name] then return self:throw("This effect is blacklisted!", nil) end
 	if hook.Run( "Expression2_CanEffect", name:lower(), self ) == false then return self:throw("A hook prevented this function from running", nil) end
 
-	util.Effect(name, this, true, true)
+	fire(self, this, name)
 end
 
 e2function number effectCanPlay()

--- a/lua/entities/gmod_wire_expression2/core/custom/effects.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/effects.lua
@@ -3,7 +3,7 @@ E2Lib.RegisterExtension("effects", false, "Allows E2s to play arbitrary effects.
 local wire_expression2_effect_burst_max = CreateConVar( "wire_expression2_effect_burst_max", 4, {FCVAR_ARCHIVE} )
 local wire_expression2_effect_burst_rate = CreateConVar( "wire_expression2_effect_burst_rate", 0.1, {FCVAR_ARCHIVE} )
 
--- Use hook E2CanEffect to blacklist/whitelist effects
+-- Use hook Expression2_CanEffect to blacklist/whitelist effects
 local effect_blacklist = {
 	dof_node = true
 }


### PR DESCRIPTION
Fixes erroneous burst count decrement when using `effectCanPlay` by moving burst count setter and effect playing to its own function.