### PR TITLE
Remove E2Lib encode/decode Functions

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/cl_files.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_files.lua
@@ -138,10 +138,12 @@ net.Receive( "wire_expression2_request_list", function( netlen )
 		net.WriteUInt(#files + #folders, 16)
 		for _,fop in pairs(files) do
 			if string.GetExtensionFromFilename( fop ) == "txt" then
+				net.WriteUInt(#fop, 16)
 				net.WriteData(fop)
 			end
 		end
 		for _,fop in pairs(folders) do
+			net.WriteUInt(#fop, 16)
 			net.WriteData(fop .. "/")
 		end
 	net.SendToServer()

--- a/lua/entities/gmod_wire_expression2/core/cl_files.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_files.lua
@@ -81,16 +81,16 @@ net.Receive("wire_expression2_request_file", function(netlen)
 	if file.Exists( fullpath,"DATA" ) and file.Size( fullpath, "DATA" ) <= (cv_max_transfer_size:GetInt() * 1024) then
 		local filedata = file.Read( fullpath,"DATA" ) or ""
 
-		local encoded = E2Lib.encode( filedata )
+		local len = #filedata
 
 		upload_buffer = {
 			chunk = 1,
-			chunks = math.ceil( string.len( encoded ) / upload_chunk_size ),
-			data = encoded
+			chunks = math.ceil(len / upload_chunk_size),
+			data = filedata
 		}
 
 		net.Start("wire_expression2_file_begin")
-			net.WriteUInt(string.len(filedata), 32)
+			net.WriteUInt(len, 32)
 		net.SendToServer()
 
 		timer.Create( "wire_expression2_file_upload", 1/60, upload_buffer.chunks, upload_callback )
@@ -138,11 +138,11 @@ net.Receive( "wire_expression2_request_list", function( netlen )
 		net.WriteUInt(#files + #folders, 16)
 		for _,fop in pairs(files) do
 			if string.GetExtensionFromFilename( fop ) == "txt" then
-				net.WriteString(E2Lib.encode( fop ))
+				net.WriteData(fop)
 			end
 		end
 		for _,fop in pairs(folders) do
-			net.WriteString(E2Lib.encode( fop.."/" ))
+			net.WriteData(fop .. "/")
 		end
 	net.SendToServer()
 end )

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -606,28 +606,6 @@ function E2Lib.limitString(text, length)
 	end
 end
 
-do
-	local enctbl = { ["'"] = true, ["\""] = true, ["\n"] = true, ["\\"] = true, ["%"] = true }
-	local dectbl = {}
-
-	-- generate encode/decode lookup tables
-	for k in pairs(enctbl) do
-		local hexed = bit.tohex(string.byte(k), 2)
-		dectbl[hexed] = k
-		enctbl[k] = "%" .. hexed
-	end
-
-	-- escapes special characters
-	function E2Lib.encode(str)
-		return str:gsub(".", enctbl)
-	end
-
-	-- decodes escaped characters
-	function E2Lib.decode(encoded)
-		return encoded:gsub("%%(..)", dectbl)
-	end
-end
-
 -- ------------------------------- extensions ----------------------------------
 
 do

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -607,33 +607,14 @@ function E2Lib.limitString(text, length)
 end
 
 do
-	local enctbl = {}
+	local enctbl = { ["'"] = true, ["\""] = true, ["\n"] = true, ["\\"] = true, ["%"] = true }
 	local dectbl = {}
 
-	do
-		-- generate encode/decode lookup tables
-		-- local valid_chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890 +-*/#^!?~=@&|.,:(){}[]<>" -- list of "normal" chars that can be transferred without problems
-		local invalid_chars = "'\"\n\\%"
-		local hex = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' }
-
-
-		for i = 1, #invalid_chars do
-			local char = invalid_chars:sub(i, i)
-			enctbl[char] = true
-		end
-		for byte = 1, 255 do
-			dectbl[hex[(byte - byte % 16) / 16 + 1] .. hex[byte % 16 + 1]] = string.char(byte)
-			if enctbl[string.char(byte)] then
-				enctbl[string.char(byte)] = "%" .. hex[(byte - byte % 16) / 16 + 1] .. hex[byte % 16 + 1]
-			else
-				enctbl[string.char(byte)] = string.char(byte)
-			end
-		end
-
-		--for i = 1, #valid_chars do
-		--	local char = valid_chars:sub(i, i)
-		--	enctbl[char] = char
-		--end
+	-- generate encode/decode lookup tables
+	for k in pairs(enctbl) do
+		local hexed = bit.tohex(string.byte(k), 2)
+		dectbl[hexed] = k
+		enctbl[k] = "%" .. hexed
 	end
 
 	-- escapes special characters

--- a/lua/entities/gmod_wire_expression2/core/files.lua
+++ b/lua/entities/gmod_wire_expression2/core/files.lua
@@ -459,7 +459,7 @@ net.Receive("wire_expression2_file_list", function(netlen, ply)
 	if timer.Exists( timername ) then timer.Remove( timername ) end
 
 	for i=1, net.ReadUInt(16) do
-		table.insert(plist.data, net.ReadData())
+		table.insert(plist.data, net.ReadData(net.ReadUInt(16)))
 	end
 
 	plist.uploaded = true

--- a/lua/entities/gmod_wire_expression2/core/files.lua
+++ b/lua/entities/gmod_wire_expression2/core/files.lua
@@ -410,7 +410,7 @@ net.Receive("wire_expression2_file_finish", function(netlen, ply)
 	if !pfile or !pfile.buffer then return end
 
 	pfile.uploading = false
-	pfile.data = E2Lib.decode( pfile.buffer )
+	pfile.data = pfile.buffer
 	pfile.buffer = ""
 
 	if string.len( pfile.data ) ~= pfile.len then -- transfer error
@@ -459,7 +459,7 @@ net.Receive("wire_expression2_file_list", function(netlen, ply)
 	if timer.Exists( timername ) then timer.Remove( timername ) end
 
 	for i=1, net.ReadUInt(16) do
-		table.insert( plist.data, ( E2Lib.decode( net.ReadString() ) ) )
+		table.insert(plist.data, net.ReadData())
 	end
 
 	plist.uploaded = true

--- a/lua/wire/stools/expression2.lua
+++ b/lua/wire/stools/expression2.lua
@@ -361,7 +361,7 @@ if SERVER then
 		if not wantedfiles[ply] then wantedfiles[ply] = {} end
 		table.insert(wantedfiles[ply], net.ReadData(net.ReadUInt(32)))
 		if numpackets <= #wantedfiles[ply] then
-			local ok, ret = pcall(WireLib.von.deserialize, E2Lib.decode(table.concat(wantedfiles[ply])))
+			local ok, ret = pcall(WireLib.von.deserialize, table.concat(wantedfiles[ply]))
 			wantedfiles[ply] = nil
 			if not ok then
 				WireLib.AddNotify(ply, "Expression 2 download failed! Error message:\n" .. ret, NOTIFY_ERROR, 7, NOTIFYSOUND_DRIP3)
@@ -405,7 +405,7 @@ if SERVER then
 		if not uploads[ply] then uploads[ply] = {} end
 		uploads[ply][#uploads[ply]+1] = net.ReadData(net.ReadUInt(32))
 		if numpackets <= #uploads[ply] then
-			local datastr = E2Lib.decode(table.concat(uploads[ply]))
+			local datastr = table.concat(uploads[ply])
 			uploads[ply] = nil
 			local ok, ret = pcall(WireLib.von.deserialize, datastr)
 
@@ -732,9 +732,9 @@ elseif CLIENT then
 				newincludes[k] = v
 			end
 
-			datastr = E2Lib.encode(WireLib.von.serialize({ code, newincludes, filepath }))
+			datastr = WireLib.von.serialize({ code, newincludes, filepath })
 		else
-			datastr = E2Lib.encode(WireLib.von.serialize({ code, {}, filepath }))
+			datastr = WireLib.von.serialize({ code, {}, filepath })
 		end
 
 		queue[#queue+1] = {
@@ -920,7 +920,7 @@ elseif CLIENT then
 			for k, v in pairs(selectedfiles) do haschoice = true break end
 			if not haschoice then pnl:Close() return end
 
-			local datastr = E2Lib.encode(WireLib.von.serialize(selectedfiles))
+			local datastr = WireLib.von.serialize(selectedfiles)
 			local numpackets = math.ceil(#datastr / 64000)
 			for i = 1, #datastr, 64000 do
 				net.Start("wire_expression2_download_wantedfiles")


### PR DESCRIPTION
~~Saw this and thought it was unnecessarily complex and a little hard to read. Hopefully a performance, or at least memory, improvement.~~

~~Only functional difference is that `bit.tohex` uses lowercase hex. There are no instances of the output of `E2Lib.encode` being used in a way that this would cause an issue. Namely, this is only used when sending/receiving E2 chip files and E2 file extension files.~~

Removes these functions that are apparently unnecessary.