### PR TITLE
Add `Wire_UserCanUse` user hook

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -285,6 +285,8 @@ e2function void entity:use()
 	if not IsValid(ply) then return end -- if the owner isn't connected to the server, do nothing
 
 	if not hook.Run( "PlayerUse", ply, this ) then return end
+    if not hook.Run( "WireUse", ply, this, self ) then return false end
+
 	if this.Use then
 		this:Use(ply,ply,USE_ON,0)
 	else

--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -285,7 +285,7 @@ e2function void entity:use()
 	if not IsValid(ply) then return end -- if the owner isn't connected to the server, do nothing
 
 	if not hook.Run( "PlayerUse", ply, this ) then return end
-    if not hook.Run( "WireUse", ply, this, self ) then return false end
+	if not hook.Run( "WireUse", ply, this, self ) then return false end
 
 	if this.Use then
 		this:Use(ply,ply,USE_ON,0)

--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -285,7 +285,7 @@ e2function void entity:use()
 	if not IsValid(ply) then return end -- if the owner isn't connected to the server, do nothing
 
 	if hook.Run( "PlayerUse", ply, this ) == false then return end
-	if hook.Run( "WireUse", ply, this, self ) == false then return false end
+	if hook.Run( "WireUse", ply, this, self ) == false then return end
 
 	if this.Use then
 		this:Use(ply,ply,USE_ON,0)

--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -284,8 +284,8 @@ e2function void entity:use()
 	local ply = self.player
 	if not IsValid(ply) then return end -- if the owner isn't connected to the server, do nothing
 
-	if not hook.Run( "PlayerUse", ply, this ) then return end
-	if not hook.Run( "WireUse", ply, this, self ) then return false end
+	if hook.Run( "PlayerUse", ply, this ) == false then return end
+	if hook.Run( "WireUse", ply, this, self ) == false then return false end
 
 	if this.Use then
 		this:Use(ply,ply,USE_ON,0)

--- a/lua/entities/gmod_wire_user.lua
+++ b/lua/entities/gmod_wire_user.lua
@@ -35,8 +35,8 @@ function ENT:TriggerInput(iname, value)
 		local ply = self:GetPlayer()
 		if not IsValid(ply) then ply = self end
 
-		if not hook.Run( "PlayerUse", ply, trace.Entity ) then return false end
-		if not hook.Run( "WireUse", ply, trace.Entity, self ) then return false end
+		if hook.Run( "PlayerUse", ply, trace.Entity ) == false then return false end
+		if hook.Run( "WireUse", ply, trace.Entity, self ) == false then return false end
 
 		if trace.Entity.Use then
 			trace.Entity:Use(ply,ply,USE_ON,0)

--- a/lua/entities/gmod_wire_user.lua
+++ b/lua/entities/gmod_wire_user.lua
@@ -36,6 +36,7 @@ function ENT:TriggerInput(iname, value)
 		if not IsValid(ply) then ply = self end
 
 		if not hook.Run( "PlayerUse", ply, trace.Entity ) then return false end
+        if not hook.Run( "Wire_UserCanUse", ply, trace.Entity, self ) then return false end
 
 		if trace.Entity.Use then
 			trace.Entity:Use(ply,ply,USE_ON,0)

--- a/lua/entities/gmod_wire_user.lua
+++ b/lua/entities/gmod_wire_user.lua
@@ -36,7 +36,7 @@ function ENT:TriggerInput(iname, value)
 		if not IsValid(ply) then ply = self end
 
 		if not hook.Run( "PlayerUse", ply, trace.Entity ) then return false end
-		if not hook.Run( "Wire_UserCanUse", ply, trace.Entity, self ) then return false end
+		if not hook.Run( "WireUse", ply, trace.Entity, self ) then return false end
 
 		if trace.Entity.Use then
 			trace.Entity:Use(ply,ply,USE_ON,0)

--- a/lua/entities/gmod_wire_user.lua
+++ b/lua/entities/gmod_wire_user.lua
@@ -36,7 +36,7 @@ function ENT:TriggerInput(iname, value)
 		if not IsValid(ply) then ply = self end
 
 		if not hook.Run( "PlayerUse", ply, trace.Entity ) then return false end
-        if not hook.Run( "Wire_UserCanUse", ply, trace.Entity, self ) then return false end
+		if not hook.Run( "Wire_UserCanUse", ply, trace.Entity, self ) then return false end
 
 		if trace.Entity.Use then
 			trace.Entity:Use(ply,ply,USE_ON,0)


### PR DESCRIPTION
Adds a simple hook that passes the owner, the hit ent and the user itself, it's a bit double considering it's already calling `PlayerUse` however that doesn't pass the user itself. I figured, considering other wire components have dedicated hooks like this that it'd be fine.