### PR TITLE
Add WireLib.ParseEscapes

### DIFF
--- a/lua/entities/gmod_wire_value.lua
+++ b/lua/entities/gmod_wire_value.lua
@@ -65,9 +65,7 @@ function parsers.ANGLE( val )
 		return Angle(tonumber(p),tonumber(y),tonumber(r))
 	end
 end
-function parsers.STRING( val )
-	return string.gsub( tostring( val ), "\\[n0\\]", {["\\\\"] = "\\", ["\\n"] = "\n", ["\\0"] = "\0"} )
-end
+parsers.STRING = WireLib.ParseString
 
 function ENT:ParseValue( value, tp )
 	if parsers[tp] then

--- a/lua/entities/gmod_wire_value.lua
+++ b/lua/entities/gmod_wire_value.lua
@@ -65,7 +65,7 @@ function parsers.ANGLE( val )
 		return Angle(tonumber(p),tonumber(y),tonumber(r))
 	end
 end
-parsers.STRING = WireLib.ParseString
+parsers.STRING = WireLib.ParseEscapes
 
 function ENT:ParseValue( value, tp )
 	if parsers[tp] then

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1276,6 +1276,26 @@ function WireLib.IsValidMaterial(material)
 	return material
 end
 
+local escapes = { n = "\n", r = "\r", t = "\t", ["\\"] = "\\", ["'"] = "'", ["\""] = "\"" }
+--- Parses a user-generated string so escape characters become their intended targets. Note that this is not a complete implementation of escape characters.
+--- @param str string
+function WireLib.ParseString(str)
+	return (str:gsub("\\([%a\\]?)(%d?%d?%d?)", function(char, num)
+		if escapes[char] then
+			return escapes[char] .. (num or "")
+		elseif num then
+			num = tonumber(num)
+			if num and num < 256 then
+				return string.char(num)
+			else
+				return (char or "") .. num
+			end
+		else
+			return char .. (num or "")
+		end
+	end)) -- These parentheses force Lua to return only the string. Please ignore the linter.
+end
+
 local ENTITY = FindMetaTable("Entity")
 
 if CPPI and ENTITY.CPPICanTool then

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -9,7 +9,7 @@ local timer = timer
 local string = string
 local string_gsub = string.gsub
 local string_char = string.char
-local string_find = string.find
+local string_match = string.match
 local string_sub = string.sub
 local utf8_char = utf8.char
 local math_clamp = math.Clamp
@@ -1291,14 +1291,14 @@ function WireLib.ParseEscapes(str)
 		if escapeChars[i] then
 			return escapeChars[i] .. arg
 		elseif i == "x" then
-			local num = string_match(arg, "^(%x?%x?)")
+			local num = string_match(arg, "^(%x%x)")
 			if not num then return false end
-			return string_char(tonumber(num, 16))..string_sub(arg, #num + 1)
+			return string_char(tonumber(num, 16)) .. string_sub(arg, #num + 1)
 		elseif i >= "0" and i <= "9" then
 			local num = string_match(arg, "^(%d?%d?)")
 			if not num then return false end
-			local tonum = tonumber(i..num)
-			return tonum < 256 and (string_char(tonum)..string_sub(arg, #num + 1))
+			local tonum = tonumber(i .. num)
+			return tonum < 256 and (string_char(tonum) .. string_sub(arg, #num + 1))
 		elseif i == "u" then
 			local num = string_match(arg, "^{(%x%x?%x?%x?%x?%x?)}")
 			if not num then return false end

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1276,12 +1276,30 @@ function WireLib.IsValidMaterial(material)
 	return material
 end
 
+local hex2num = { ["0"] = 0, ["1"] = 1, ["2"] = 2, ["3"] = 3, ["4"] = 4, ["5"] = 5, ["6"] = 6, ["7"] = 7, ["8"] = 8,
+				  ["9"] = 9, a = 10, b = 11, c = 12, d = 13, e = 14, f = 15 }
+
+local function hexToNum(hex)
+	hex = hex:gsub("^0x", "", 1):lower() -- Remove 0x/x if it's there
+	local sum = 0
+	for i = 1, #hex do
+		sum = (sum * 16) + hex2num[hex:sub(i, i)]
+	end
+	return sum
+end
+--- Converts a hexadecimal number represented as a string to a number representation.
+--- @param hex string
+WireLib.HexToNum = hexToNum
+
 local escapes = { n = "\n", r = "\r", t = "\t", ["\\"] = "\\", ["'"] = "'", ["\""] = "\"", a = "\a",
 b = "\b", f = "\f", v = "\v" }
 --- Parses a user-generated string so escape characters become their intended targets. Note that this is not a complete implementation of escape characters.
 --- @param str string
 function WireLib.ParseString(str)
 	str = str:gsub("\\([%a\\'\"])", escapes)
+	str = str:gsub("\\x(%x%x)", function(hex)
+		return string.char(hexToNum(hex))
+	end)
 	str = str:gsub("\\(%d%d?%d?)", function(num)
 		local tonum = tonumber(num)
 		return tonum < 256 and string.char(tonum) or num

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1281,17 +1281,19 @@ local escapes = { n = "\n", r = "\r", t = "\t", ["\\"] = "\\", ["'"] = "'", ["\"
 --- @param str string
 function WireLib.ParseString(str)
 	return (str:gsub("\\([%a\\]?)(%d?%d?%d?)", function(char, num)
-		if escapes[char] then
-			return escapes[char] .. (num or "")
+		if char ~= "" then
+			if escapes[char] then
+				return escapes[char] .. (num or "")
+			else
+				return char .. (num or "")
+			end
 		elseif num then
 			num = tonumber(num)
 			if num and num < 256 then
 				return string.char(num)
 			else
-				return (char or "") .. num
+				return num
 			end
-		else
-			return char .. (num or "")
 		end
 	end)) -- These parentheses force Lua to return only the string. Please ignore the linter.
 end

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -7,11 +7,6 @@ WireAddon = 1
 local ents = ents
 local timer = timer
 local string = string
-local string_gsub = string.gsub
-local string_char = string.char
-local string_match = string.match
-local string_sub = string.sub
-local utf8_char = utf8.char
 local math_clamp = math.Clamp
 local table = table
 local hook = hook
@@ -1279,36 +1274,6 @@ function WireLib.IsValidMaterial(material)
 	local path = string.StripExtension(string.GetNormalizedFilepath(string.lower(material)))
 	if material_blacklist[path] then return "" end
 	return material
-end
-
-local escapeChars = { n = "\n", r = "\r", t = "\t", ["\\"] = "\\", ["'"] = "'", ["\""] = "\"", a = "\a",
-b = "\b", f = "\f", v = "\v" }
-
---- Replaces escape sequences with the appropriate character. Uses Lua escape sequences. Invalid sequences are skipped.
---- @param str string
-function WireLib.ParseEscapes(str)
-	str = string_gsub(str, "\\(.?)([^\\]?[^\\]?[^\\]?[^\\]?[^\\]?[^\\]?[^\\]?}?)", function(i, arg)
-		if escapeChars[i] then
-			return escapeChars[i] .. arg
-		elseif i == "x" then
-			local num = string_match(arg, "^(%x%x)")
-			if not num then return false end
-			return string_char(tonumber(num, 16)) .. string_sub(arg, #num + 1)
-		elseif i >= "0" and i <= "9" then
-			local num = string_match(arg, "^(%d?%d?)")
-			if not num then return false end
-			local tonum = tonumber(i .. num)
-			return tonum < 256 and (string_char(tonum) .. string_sub(arg, #num + 1))
-		elseif i == "u" then
-			local num = string_match(arg, "^{(%x%x?%x?%x?%x?%x?)}")
-			if not num then return false end
-			local tonum = tonumber(num, 16)
-			return tonum <= 0x10ffff and utf8_char(tonum)
-		else
-			return false
-		end
-	end)
-	return str
 end
 
 local ENTITY = FindMetaTable("Entity")

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1280,22 +1280,12 @@ local escapes = { n = "\n", r = "\r", t = "\t", ["\\"] = "\\", ["'"] = "'", ["\"
 --- Parses a user-generated string so escape characters become their intended targets. Note that this is not a complete implementation of escape characters.
 --- @param str string
 function WireLib.ParseString(str)
-	return (str:gsub("\\([%a\\]?)(%d?%d?%d?)", function(char, num)
-		if char ~= "" then
-			if escapes[char] then
-				return escapes[char] .. (num or "")
-			else
-				return char .. (num or "")
-			end
-		elseif num then
-			num = tonumber(num)
-			if num and num < 256 then
-				return string.char(num)
-			else
-				return num
-			end
-		end
-	end)) -- These parentheses force Lua to return only the string. Please ignore the linter.
+	str = str:gsub("\\([%a\\'\"])", escapes)
+	str = str:gsub("\\(%d%d?%d?)", function(num)
+		local tonum = tonumber(num)
+		return tonum < 256 and string.char(tonum) or num
+	end)
+	return str
 end
 
 local ENTITY = FindMetaTable("Entity")

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1283,9 +1283,9 @@ end
 
 local escapeChars = { n = "\n", r = "\r", t = "\t", ["\\"] = "\\", ["'"] = "'", ["\""] = "\"", a = "\a",
 b = "\b", f = "\f", v = "\v" }
---- Parses a user-generated string so escape characters become their intended targets. Note that this is not a complete implementation of escape characters.
+--- Replaces escape sequences with the appropriate character. Uses Lua escape sequences. Invalid sequences are skipped.
 --- @param str string
-function WireLib.ParseString(str)
+function WireLib.ParseEscapes(str)
 	str = string_gsub(str, "\\(.)([^\\]?[^\\]?)", function(i, arg)
 		if escapeChars[i] then
 			return escapeChars[i]

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1283,29 +1283,36 @@ end
 
 local escapeChars = { n = "\n", r = "\r", t = "\t", ["\\"] = "\\", ["'"] = "'", ["\""] = "\"", a = "\a",
 b = "\b", f = "\f", v = "\v" }
+
+local function _escapeFuncNumber(arg, i)
+	local _, finish, num = string_find(arg, "^(%d?%d?)")
+	local tonum = tonumber(i .. (num or ""))
+	return tonum and tonum < 256 and string_char(tonum) .. string_sub(arg, finish + 1) or false
+end
+
+local escapeFuncs = {
+	x = function(arg)
+		if #arg < 2 then return false end
+		local tonum = tonumber(arg, 16)
+		return tonum and string_char(tonum) or false
+	end,
+	u = function(arg)
+		local _, _, num = string_find(arg, "{(%x%x?%x?%x?%x?%x?)}")
+		local tonum = tonumber(num or "", 16)
+		return tonum and tonum <= 0x10ffff and utf8_char(tonum) or false
+	end
+}
+
+for i = string.byte("0"), string.byte("9") do
+	escapeFuncs[string_char(i)] = _escapeFuncNumber
+end
+
 --- Replaces escape sequences with the appropriate character. Uses Lua escape sequences. Invalid sequences are skipped.
 --- @param str string
 function WireLib.ParseEscapes(str)
-	str = string_gsub(str, "\\(.)([^\\]?[^\\]?)", function(i, arg)
-		if escapeChars[i] then
-			return escapeChars[i]
-		elseif i == "x" then
-			if #arg < 2 then return false end
-			local tonum = tonumber(arg, 16)
-			return tonum and string_char(tonum) or false
-		elseif i >= "0" and i <= "9" then
-			local _, finish, num = string_find(arg, "^(%d?%d?)")
-			local tonum = tonumber(i .. (num or ""))
-			return tonum and tonum < 256 and string_char(tonum) .. string_sub(arg, finish + 1) or false
-		else
-			return false
-		end
+	return string_gsub(str, "(\\(.?)([^\\]?[^\\]?[^\\]?[^\\]?[^\\]?[^\\]?[^\\]?}?))", function(str, i, arg)
+		return escapeChars[i] and escapeChars[i] .. arg or (escapeFuncs[i] and escapeFuncs[i](arg, i)) or false
 	end)
-
-	return select(-2, string_gsub(str, "\\u{(%x%x?%x?%x?%x?%x?)}", function(uni)
-		local tonum = tonumber(uni, 16)
-		return tonum and tonum <= 0x10ffff and utf8_char(tonum) or false
-	end))
 end
 
 local ENTITY = FindMetaTable("Entity")

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1295,7 +1295,7 @@ function WireLib.ParseEscapes(str)
 			if not num then return false end
 			return string_char(tonumber(num, 16))..string_sub(arg, #num + 1)
 		elseif i >= "0" and i <= "9" then
-			local num = string.match(arg, "^(%d?%d?)")
+			local num = string_match(arg, "^(%d?%d?)")
 			if not num then return false end
 			local tonum = tonumber(i..num)
 			return tonum < 256 and (string_char(tonum)..string_sub(arg, #num + 1))

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1276,7 +1276,8 @@ function WireLib.IsValidMaterial(material)
 	return material
 end
 
-local escapes = { n = "\n", r = "\r", t = "\t", ["\\"] = "\\", ["'"] = "'", ["\""] = "\"" }
+local escapes = { n = "\n", r = "\r", t = "\t", ["\\"] = "\\", ["'"] = "'", ["\""] = "\"", a = "\a",
+b = "\b", f = "\f", v = "\v" }
 --- Parses a user-generated string so escape characters become their intended targets. Note that this is not a complete implementation of escape characters.
 --- @param str string
 function WireLib.ParseString(str)

--- a/lua/wire/wireshared.lua
+++ b/lua/wire/wireshared.lua
@@ -973,7 +973,7 @@ function WireLib.ParseEscapes(str)
 			local num = string_match(arg, "^{(%x%x?%x?%x?%x?%x?)}")
 			if not num then return false end
 			local tonum = tonumber(num, 16)
-			return tonum <= 0x10ffff and utf8_char(tonum)
+			return tonum <= 0x10ffff and utf8_char(tonum) .. string_sub(arg, #num + 3)
 		else
 			return false
 		end

--- a/lua/wire/wireshared.lua
+++ b/lua/wire/wireshared.lua
@@ -9,6 +9,11 @@ local LocalPlayer = LocalPlayer
 local Entity = Entity
 
 local string = string
+local string_gsub = string.gsub
+local string_char = string.char
+local string_match = string.match
+local string_sub = string.sub
+local utf8_char = utf8.char
 local hook = hook
 
 -- extra table functions
@@ -944,6 +949,36 @@ end
 function WireLib.setLocalAng(ent, ang)
 	if isnan(ang.pitch) or isnan(ang.yaw) or isnan(ang.roll) then return end
 	return ent:SetLocalAngles(ang)
+end
+
+local escapeChars = { n = "\n", r = "\r", t = "\t", ["\\"] = "\\", ["'"] = "'", ["\""] = "\"", a = "\a",
+b = "\b", f = "\f", v = "\v" }
+
+--- Replaces escape sequences with the appropriate character. Uses Lua escape sequences. Invalid sequences are skipped.
+--- @param str string
+function WireLib.ParseEscapes(str)
+	str = string_gsub(str, "\\(.?)([^\\]?[^\\]?[^\\]?[^\\]?[^\\]?[^\\]?[^\\]?}?)", function(i, arg)
+		if escapeChars[i] then
+			return escapeChars[i] .. arg
+		elseif i == "x" then
+			local num = string_match(arg, "^(%x%x)")
+			if not num then return false end
+			return string_char(tonumber(num, 16)) .. string_sub(arg, #num + 1)
+		elseif i >= "0" and i <= "9" then
+			local num = string_match(arg, "^(%d?%d?)")
+			if not num then return false end
+			local tonum = tonumber(i .. num)
+			return tonum < 256 and (string_char(tonum) .. string_sub(arg, #num + 1))
+		elseif i == "u" then
+			local num = string_match(arg, "^{(%x%x?%x?%x?%x?%x?)}")
+			if not num then return false end
+			local tonum = tonumber(num, 16)
+			return tonum <= 0x10ffff and utf8_char(tonum)
+		else
+			return false
+		end
+	end)
+	return str
 end
 
 -- Used by any applyForce function available to the user


### PR DESCRIPTION
New WireLib function `ParseEscapes`. Takes a string input generated by the user (such as from a TextEntry panel) and parses escape characters out. The output is the escaped string. This is a complete implementation of [*Luajit's* escape sequences](https://www.lua.org/manual/5.4/manual.html#3.1).

Purpose:
Some user inputs have their own implementation of escaping characters. This is meant to be a unified and thorough alternative and supports the entire Lua escape sequence library.

Notes:
This differs from Lua's escaping only in that invalid escape sequences are skipped instead of erroring.

I've only implemented this in constant value more as a demonstration than anything. Any user input should be changed to use this if desired. [E2's tokenizer, for example, is a noteworthy target.](https://github.com/Denneisk/wire/commit/4d909fdfc7e9eea4099fdedac4c44a44c44be996)