### PR TITLE
Add Descriptions to Gates

### DIFF
--- a/lua/wire/gates/angle.lua
+++ b/lua/wire/gates/angle.lua
@@ -78,6 +78,7 @@ GateActions["angle_mul"] = {
 -- Component Derivative
 GateActions["angle_derive"] = {
 	name = "Delta",
+	description = "Outputs the rate of change of the angle.",
 	inputs = { "A" },
 	inputtypes = { "ANGLE" },
 	outputtypes = { "ANGLE" },
@@ -118,6 +119,7 @@ GateActions["angle_divide"] = {
 -- Conversion To/From
 GateActions["angle_convto"] = {
 	name = "Compose",
+	description = "Combines three numbers into an angle.",
 	inputs = { "Pitch", "Yaw", "Roll" },
 	inputtypes = { "NORMAL", "NORMAL", "NORMAL" },
 	outputtypes = { "ANGLE" },
@@ -131,6 +133,7 @@ GateActions["angle_convto"] = {
 
 GateActions["angle_convfrom"] = {
 	name = "Decompose",
+	description = "Splits an angle into three numbers.",
 	inputs = { "A" },
 	inputtypes = { "ANGLE" },
 	outputs = { "Pitch", "Yaw", "Roll" },
@@ -207,6 +210,7 @@ GateActions["angle_fruvecs"] = {
 
 GateActions["angle_norm"] = {
 	name = "Normalize",
+	description = "Makes the angle fit within +/-180 degrees.",
 	inputs = { "A" },
 	inputtypes = { "ANGLE" },
 	outputtypes = { "ANGLE" },

--- a/lua/wire/gates/arithmetic.lua
+++ b/lua/wire/gates/arithmetic.lua
@@ -6,6 +6,7 @@ GateActions("Arithmetic")
 
 GateActions["increment"] = {
 	name = "Increment",
+	dsecription = "Increases its value by a number on every clk.",
 	inputs = { "A", "Clk", "Reset" },
 	output = function(gate, A, Clk, Reset)
 		local clk = ( Clk > 0 )
@@ -265,6 +266,7 @@ GateActions["PI"] = {
 
 GateActions["exp"] = {
 	name = "Exp",
+	description = "Outputs e to the power of A.",
 	inputs = { "A" },
 	output = function(gate, A)
 		return math.exp(A)
@@ -312,6 +314,7 @@ GateActions["Percent"] = {
 
 GateActions["Delta"] = {
 	name = "Delta",
+	description = "Gets the rate of change of the number.",
 	inputs = { "A" },
 	output = function(gate, A)
 		gate.PrevValue = gate.PrevValue or 0
@@ -373,6 +376,7 @@ GateActions["Average"] = {
 
 GateActions["increment/decrement"] = {
 	name = "Increment/Decrement",
+	description = "Increases and decreases its value by a number.",
 	inputs = { "A", "Increment", "Decrement", "Reset" },
 	output = function(gate, A, Increment, Decrement, Reset)
 		local increment = ( Increment > 0 )

--- a/lua/wire/gates/array.lua
+++ b/lua/wire/gates/array.lua
@@ -38,6 +38,7 @@ for type_name, default in pairs( types_defaults ) do
 
 	GateActions["array_read_" .. type_name] = {
 		name = "Array Read (" .. type_name .. ")",
+		description = "Attempts to get a " .. type_name:lower() .. " from the array at the index.",
 		inputs = { "R", "Index" },
 		inputtypes = { "ARRAY", "NORMAL" },
 		outputtypes = { type_name2 },
@@ -60,6 +61,7 @@ for type_name, default in pairs( types_defaults ) do
 
 	GateActions["array_find_" .. type_name] = {
 		name = "Array Find (" .. type_name .. ")",
+		description = "Outputs the index of the specified " .. type_name:lower() .. " if it exists in the array.",
 		inputs = { "R", "Value" },
 		inputtypes = { "ARRAY", type_name2 },
 		outputtypes = { "NORMAL" },
@@ -118,6 +120,7 @@ GateActions["array_create"] = {
 
 GateActions["array_gettype"] = {
 	name = "Array Get Type",
+	description = "Gets the type of the element at the index as a string.",
 	inputs = { "R", "Index" },
 	inputtypes = { "ARRAY", "NORMAL" },
 	outputtypes = { "STRING" },

--- a/lua/wire/gates/entity.lua
+++ b/lua/wire/gates/entity.lua
@@ -408,6 +408,7 @@ GateActions["entity_health"] = {
 
 GateActions["entity_radius"] = {
 	name = "Radius",
+	description = "Gets the widest radius of the entity's bounding box.",
 	inputs = { "Ent" },
 	inputtypes = { "ENTITY" },
 	outputtypes = { "NORMAL" },
@@ -436,6 +437,7 @@ GateActions["entity_mass"] = {
 
 GateActions["entity_masscenter"] = {
 	name = "Mass Center",
+	description = "Gets the entity's center of mass.",
 	inputs = { "Ent" },
 	inputtypes = { "ENTITY" },
 	outputtypes = { "VECTOR" },
@@ -450,6 +452,7 @@ GateActions["entity_masscenter"] = {
 
 GateActions["entity_masscenterlocal"] = {
 	name = "Mass Center (local)",
+	description = "Gets the entity's center of mass relative to itself.",
 	inputs = { "Ent" },
 	inputtypes = { "ENTITY" },
 	outputtypes = { "VECTOR" },
@@ -597,6 +600,7 @@ GateActions["entity_owner"] = {
 
 GateActions["entity_isheld"] = {
 	name = "Is Player Holding",
+	description = "Outputs 1 if a player is holding the object with the physgun, gravgun, or use key.",
 	inputs = { "Ent" },
 	inputtypes = { "ENTITY" },
 	outputtypes = { "NORMAL" },
@@ -657,6 +661,7 @@ GateActions["player_invehicle"] = {
 
 GateActions["player_connected"] = {
 	name = "Time Connected",
+	description = "Outputs the duration the player has been in the server in seconds.",
 	inputs = { "Ent" },
 	inputtypes = { "ENTITY" },
 	outputtypes = { "NORMAL" },
@@ -671,6 +676,7 @@ GateActions["player_connected"] = {
 }
 GateActions["entity_aimentity"] = {
 	name = "AimEntity",
+	description = "Gets the entity that the player is looking at.",
 	inputs = { "Ent" },
 	inputtypes = { "ENTITY" },
 	outputtypes = { "ENTITY" },
@@ -686,6 +692,7 @@ GateActions["entity_aimentity"] = {
 
 GateActions["entity_aimenormal"] = {
 	name = "AimNormal",
+	description = "Gets the aim direction of an entity.",
 	inputs = { "Ent" },
 	inputtypes = { "ENTITY" },
 	outputtypes = { "VECTOR" },
@@ -705,6 +712,7 @@ GateActions["entity_aimenormal"] = {
 
 GateActions["entity_aimedirection"] = {
 	name = "AimDirection",
+	description = "Gets the aim direction of a player.",
 	inputs = { "Ent" },
 	inputtypes = { "ENTITY" },
 	outputtypes = { "VECTOR" },
@@ -828,6 +836,7 @@ GateActions["entity_clr"] = {
 
 GateActions["entity_name"] = {
 	name = "Name",
+	description = "Gets the name of a player.",
 	inputs = { "Ent" },
 	inputtypes = { "ENTITY" },
 	outputtypes = { "STRING" },
@@ -842,6 +851,7 @@ GateActions["entity_name"] = {
 
 GateActions["entity_aimpos"] = {
 	name = "AimPosition",
+	description = "Gets the position that the player is looking at.",
 	inputs = { "Ent" },
 	inputtypes = { "ENTITY" },
 	outputtypes = { "VECTOR" },
@@ -873,8 +883,9 @@ GateActions["entity_select"] = {
 
 GateActions["entity_bearing"] = {
 	name = "Bearing",
+	description = "Gets the angle along the X, Y plane from the entity to the position.",
 	inputs = { "Entity", "Position" },
-	inputtypes = { "ENTITY", "VECTOR", "NORMAL" },
+	inputtypes = { "ENTITY", "VECTOR" },
 	outputtypes = { "NORMAL" },
 	timed = true,
 	output = function( gate, Entity, Position )
@@ -889,8 +900,9 @@ GateActions["entity_bearing"] = {
 
 GateActions["entity_elevation"] = {
 	name = "Elevation",
+	description = "Gets the difference in elevation from the entity to the position.",
 	inputs = { "Entity", "Position" },
-	inputtypes = { "ENTITY", "VECTOR", "NORMAL" },
+	inputtypes = { "ENTITY", "VECTOR" },
 	outputtypes = { "NORMAL" },
 	timed = true,
 	output = function( gate, Entity, Position )
@@ -906,8 +918,9 @@ GateActions["entity_elevation"] = {
 
 GateActions["entity_heading"] = {
 	name = "Heading",
+	description = "Gets the elevation and bearing from the entity to the position.",
 	inputs = { "Entity", "Position" },
-	inputtypes = { "ENTITY", "VECTOR", "NORMAL" },
+	inputtypes = { "ENTITY", "VECTOR" },
 	outputs = { "Bearing", "Elevation", "Heading" },
 	outputtypes = { "NORMAL", "NORMAL", "ANGLE" },
 	timed = true,

--- a/lua/wire/gates/logic.lua
+++ b/lua/wire/gates/logic.lua
@@ -6,6 +6,7 @@ GateActions("Logic")
 
 GateActions["not"] = {
 	name = "Not (Invert)",
+	description = "Outputs 0 for inputs greater than 0, otherwise outputs 1.",
 	inputs = { "A" },
 	output = function(gate, A)
 		if (A > 0) then return 0 end
@@ -18,6 +19,7 @@ GateActions["not"] = {
 
 GateActions["and"] = {
 	name = "And (All)",
+	description = "Outputs 1 if all inputs are greater than 0.",
 	inputs = { "A", "B", "C", "D", "E", "F", "G", "H" },
 	compact_inputs = 2,
 	output = function(gate, ...)
@@ -56,6 +58,7 @@ GateActions["or"] = {
 
 GateActions["xor"] = {
 	name = "Exclusive Or (Odd)",
+	description = "Outputs 1 if there is an odd amount of nonzero inputs.",
 	inputs = { "A", "B", "C", "D", "E", "F", "G", "H" },
 	compact_inputs = 2,
 	output = function(gate, ...)
@@ -76,6 +79,7 @@ GateActions["xor"] = {
 
 GateActions["nand"] = {
 	name = "Not And (Not All)",
+	description = "Outputs 1 if there is 1 or 0 nonzero inputs.",
 	inputs = { "A", "B", "C", "D", "E", "F", "G", "H" },
 	compact_inputs = 2,
 	output = function(gate, ...)
@@ -95,6 +99,7 @@ GateActions["nand"] = {
 
 GateActions["nor"] = {
 	name = "Not Or (None)",
+	description = "Outputs 1 if there are no inputs greater than 0.",
 	inputs = { "A", "B", "C", "D", "E", "F", "G", "H" },
 	compact_inputs = 2,
 	output = function(gate, ...)
@@ -114,6 +119,7 @@ GateActions["nor"] = {
 
 GateActions["xnor"] = {
 	name = "Exclusive Not Or (Even)",
+	description = "Outputs 1 if there are an even amount of nonzero inputs.",
 	inputs = { "A", "B", "C", "D", "E", "F", "G", "H" },
 	compact_inputs = 2,
 	output = function(gate, ...)

--- a/lua/wire/gates/memory.lua
+++ b/lua/wire/gates/memory.lua
@@ -6,6 +6,7 @@ GateActions("Memory")
 
 GateActions["latch"] = {
 	name = "Latch (Edge triggered)",
+	description = "Updates its value to Data when Clk changes and is greater than 0.",
 	inputs = { "Data", "Clk" },
 	output = function(gate, Data, Clk)
 		local clk = (Clk > 0)
@@ -28,6 +29,7 @@ GateActions["latch"] = {
 
 GateActions["dlatch"] = {
 	name = "D-Latch",
+	description = "Updates its value to Data when Clk is greater than 0.",
 	inputs = { "Data", "Clk" },
 	output = function(gate, Data, Clk)
 		if (Clk > 0) then
@@ -45,6 +47,7 @@ GateActions["dlatch"] = {
 
 GateActions["srlatch"] = {
 	name = "SR-Latch",
+	description = "Outputs 1 when set (S) until it gets reset (R).",
 	inputs = { "S", "R" },
 	output = function(gate, S, R)
 		if (S > 0) and (R <= 0) then
@@ -64,6 +67,7 @@ GateActions["srlatch"] = {
 
 GateActions["rslatch"] = {
 	name = "RS-Latch",
+	description = "Outputs 1 when set (S) and not reset (R).",
 	inputs = { "S", "R" },
 	output = function(gate, S, R)
 		if (S > 0) and (R < 1) then
@@ -83,6 +87,7 @@ GateActions["rslatch"] = {
 
 GateActions["toggle"] = {
 	name = "Toggle (Edge triggered)",
+	description = "Toggles its output between two values when Clk changes.",
 	inputs = { "Clk", "OnValue", "OffValue" },
 	output = function(gate, Clk, OnValue, OffValue)
 		local clk = (Clk > 0)
@@ -387,6 +392,7 @@ GateActions["ram64x64"] = {
 
 GateActions["udcounter"] = {
 	name = "Up/Down Counter",
+	description = "Increases or decreases on Clk.",
 	inputs = { "Increment", "Decrement", "Clk", "Reset"},
 	output = function(gate, Inc, Dec, Clk, Reset)
 		local lInc = (Inc > 0)
@@ -415,6 +421,7 @@ GateActions["udcounter"] = {
 
 GateActions["togglewhile"] = {
 	name = "Toggle While(Edge triggered)",
+	description = "Toggles its output between two values when Clk changes and While is nonzero.",
 	inputs = { "Clk", "OnValue", "OffValue", "While" },
 	output = function(gate, Clk, OnValue, OffValue, While)
 		local clk = (Clk > 0)

--- a/lua/wire/gates/rangerdata.lua
+++ b/lua/wire/gates/rangerdata.lua
@@ -6,6 +6,7 @@ GateActions("Ranger")
 
 GateActions["rd_trace"] = {
 	name = "Trace",
+	description = "Traces a line between two positions and outputs a ranger data.",
 	inputs = { "Startpos", "Endpos" },
 	inputtypes = { "VECTOR", "VECTOR" },
 	outputtypes = { "RANGER" },
@@ -25,6 +26,7 @@ GateActions["rd_trace"] = {
 
 GateActions["rd_hitpos"] = {
 	name = "Hit Position",
+	description = "Outputs the hit position of the ranger.",
 	inputs = { "A" },
 	inputtypes = { "RANGER" },
 	outputtypes = { "VECTOR" },
@@ -41,6 +43,7 @@ GateActions["rd_hitpos"] = {
 
 GateActions["rd_hitnorm"] = {
 	name = "Hit Normal",
+	description = "Outputs the direction of the hit surface.",
 	inputs = { "A" },
 	inputtypes = { "RANGER" },
 	outputtypes = { "VECTOR" },
@@ -56,6 +59,7 @@ GateActions["rd_hitnorm"] = {
 
 GateActions["rd_entity"] = {
 	name = "Entity",
+	description = "Outputs the entity that the ranger hit, if it did.",
 	inputs = { "A" },
 	inputtypes = { "RANGER" },
 	outputtypes = { "ENTITY" },
@@ -71,6 +75,7 @@ GateActions["rd_entity"] = {
 
 GateActions["rd_hitworld"] = {
 	name = "Hit World",
+	description = "Outputs 1 if the ranger hit the world.",
 	inputs = { "A" },
 	inputtypes = { "RANGER" },
 	outputtypes = { "NORMAL" },
@@ -86,6 +91,7 @@ GateActions["rd_hitworld"] = {
 
 GateActions["rd_hit"] = {
 	name = "Hit",
+	description = "Outputs 1 if the ranger hit anything.",
 	inputs = { "A" },
 	inputtypes = { "RANGER" },
 	outputtypes = { "NORMAL" },
@@ -101,6 +107,7 @@ GateActions["rd_hit"] = {
 
 GateActions["rd_distance"] = {
 	name = "Distance",
+	description = "Outputs the distance of the ranger hit.",
 	inputs = { "A" },
 	inputtypes = { "RANGER" },
 	outputtypes = { "NORMAL" },

--- a/lua/wire/gates/selection.lua
+++ b/lua/wire/gates/selection.lua
@@ -6,6 +6,7 @@ GateActions("Selection")
 
 GateActions["min"] = {
 	name = "Minimum (Smallest)",
+	description = "Outputs the least of 8 values.",
 	inputs = { "A", "B", "C", "D", "E", "F", "G", "H" },
 	compact_inputs = 2,
 	output = function(gate, ...)
@@ -22,6 +23,7 @@ GateActions["min"] = {
 
 GateActions["max"] = {
 	name = "Maximum (Largest)",
+	description = "Outputs the greatest of 8 values.",
 	inputs = { "A", "B", "C", "D", "E", "F", "G", "H" },
 	compact_inputs = 2,
 	output = function(gate, ...)
@@ -38,6 +40,7 @@ GateActions["max"] = {
 
 GateActions["minmax"] = {
 	name = "Value Range",
+	description = "Clamps the value to between Min and Max.",
 	inputs = { "Min", "Max", "Value" },
 	output = function(gate, Min, Max, Value)
 		local temp = Min
@@ -89,6 +92,7 @@ GateActions["select"] = {
 
 GateActions["router"] = {
 	name = "Router",
+	description = "Outputs the Data to the desired index (Path).",
 	inputs = { "Path", "Data" },
 	outputs = { "A", "B", "C", "D", "E", "F", "G", "H" },
 	output = function(gate, Path, Data)
@@ -122,6 +126,7 @@ local SegmentInfo = {
 
 GateActions["7seg"] = {
 	name = "7 Segment Decoder",
+	description = "Converts a number to a 7-segment representation.",
 	inputs = { "A", "Clear" },
 	outputs = { "A", "B", "C", "D", "E", "F", "G" },
 	output = function(gate, A, Clear)
@@ -138,6 +143,7 @@ GateActions["7seg"] = {
 
 GateActions["timedec"] = {
 	name = "Time/Date decoder",
+	description = "Converts a Time in seconds and a Date in years a human-readable format.",
 	inputs = { "Time", "Date" },
 	outputs = { "Hours","Minutes","Seconds","Year","Day" },
 	output = function(gate, Time, Date)

--- a/lua/wire/gates/string.lua
+++ b/lua/wire/gates/string.lua
@@ -32,6 +32,7 @@ GateActions["string_cineq"] = {
 
 GateActions["string_index"] = {
 	name = "Index",
+	description = "Gets the character at the index.",
 	inputs = { "A" , "Index" },
 	inputtypes = { "STRING" , "NORMAL" },
 	outputtypes = { "STRING" },
@@ -88,6 +89,7 @@ GateActions["string_lower"] = {
 
 GateActions["string_sub"] = {
 	name = "Substring",
+	description = "Gets a part of the string between the start and end indices (inclusive).",
 	inputs = { "A" , "Start" , "End" },
 	inputtypes = { "STRING" , "NORMAL" , "NORMAL" },
 	outputtypes = { "STRING" },
@@ -104,6 +106,7 @@ GateActions["string_sub"] = {
 
 GateActions["string_explode"] = {
 	name = "Explode",
+	description = "Splits a string into an array by the separator pattern.",
 	inputs = { "A" , "Separator" },
 	inputtypes = { "STRING" , "STRING" },
 	outputtypes = { "ARRAY" },
@@ -119,6 +122,7 @@ GateActions["string_explode"] = {
 
 GateActions["string_find"] = {
 	name = "Find",
+	description = "Finds a substring within the string and outputs the position it begins.",
 	inputs = { "A", "B", "StartIndex" },
 	inputtypes = { "STRING", "STRING" },
 	outputtypes = { "NORMAL" },
@@ -135,6 +139,7 @@ GateActions["string_find"] = {
 
 GateActions["string_concat"] = {
 	name = "Concatenate",
+	description = "Combines multiple strings together into one string.",
 	inputs = { "A" , "B" , "C" , "D" , "E" , "F" , "G" , "H" },
 	inputtypes = { "STRING" , "STRING" , "STRING" , "STRING" , "STRING" , "STRING" , "STRING" , "STRING" },
 	outputtypes = { "STRING" },
@@ -160,6 +165,7 @@ GateActions["string_concat"] = {
 
 GateActions["string_trim"] = {
 	name = "Trim",
+	description = "Removes trailing and leading whitespace from the string.",
 	inputs = { "A" },
 	inputtypes = { "STRING" },
 	outputtypes = { "STRING" },
@@ -174,6 +180,7 @@ GateActions["string_trim"] = {
 
 GateActions["string_replace"] = {
 	name = "Replace",
+	description = "Replaces each occurance of the ToBeReplaced pattern with the Replacer pattern.",
 	inputs = { "String" , "ToBeReplaced" , "Replacer" },
 	inputtypes = { "STRING" , "STRING" , "STRING" },
 	outputtypes = { "STRING" },
@@ -205,6 +212,7 @@ GateActions["string_reverse"] = {
 
 GateActions["string_tonum"] = {
 	name = "To Number",
+	description = "Tries to convert the string to a number.",
 	inputs = { "A" },
 	inputtypes = { "STRING" },
 	outputtypes = { "NORMAL" },
@@ -219,6 +227,7 @@ GateActions["string_tonum"] = {
 
 GateActions["string_tostr"] = {
 	name = "Number to String",
+	description = "Converts the number to a string.",
 	inputs = { "A" },
 	inputtypes = { "NORMAL" },
 	outputtypes = { "STRING" },
@@ -233,6 +242,7 @@ GateActions["string_tostr"] = {
 
 GateActions["string_tobyte"] = {
 	name = "To Byte",
+	description = "Converts a character to a number representation.",
 	inputs = { "A" },
 	inputtypes = { "STRING" },
 	outputtypes = { "NORMAL" },
@@ -247,6 +257,7 @@ GateActions["string_tobyte"] = {
 
 GateActions["string_tochar"] = {
 	name = "To Character",
+	description = "Tries to convert a number to a character.",
 	inputs = { "A" },
 	inputtypes = { "NORMAL" },
 	outputtypes = { "STRING" },
@@ -261,6 +272,7 @@ GateActions["string_tochar"] = {
 
 GateActions["string_repeat"] = {
 	name = "Repeat",
+	description = "Repeats a string by Num times.",
 	inputs = { "A" , "Num"},
 	inputtypes = { "STRING" , "NORMAL" },
 	outputtypes = { "STRING" },

--- a/lua/wire/gates/time.lua
+++ b/lua/wire/gates/time.lua
@@ -6,6 +6,7 @@ GateActions("Time")
 
 GateActions["accumulator"] = {
 	name = "Accumulator",
+	description = "Counts time while A is set and Hold is not set.",
 	inputs = { "A", "Hold", "Reset" },
 	timed = true,
 	output = function(gate, A, Hold, Reset)
@@ -29,6 +30,7 @@ GateActions["accumulator"] = {
 
 GateActions["smoother"] = {
 	name = "Smoother",
+	description = "Smooths the change in a number.",
 	inputs = { "A", "Rate" },
 	timed = true,
 	output = function(gate, A, Rate)
@@ -53,6 +55,7 @@ GateActions["smoother"] = {
 
 GateActions["timer"] = {
 	name = "Timer",
+	description = "Counts time upward while Run is set.",
 	inputs = { "Run", "Reset" },
 	timed = true,
 	output = function(gate, Run, Reset)
@@ -76,6 +79,7 @@ GateActions["timer"] = {
 
 GateActions["ostime"] = {
 	name = "OS Time",
+	description = "Outputs the time of day on the server in seconds.",
 	inputs = { },
 	timed = true,
 	output = function(gate)
@@ -88,6 +92,7 @@ GateActions["ostime"] = {
 
 GateActions["osdate"] = {
 	name = "OS Date",
+	description = "Outputs the date on the server in days.",
 	inputs = { },
 	timed = true,
 	output = function(gate)
@@ -100,6 +105,7 @@ GateActions["osdate"] = {
 
 GateActions["pulser"] = {
 	name = "Pulser",
+	description = "Activates for one tick every TickTime while Run is set.",
 	inputs = { "Run", "Reset", "TickTime" },
 	timed = true,
 	output = function(gate, Run, Reset, TickTime)
@@ -127,6 +133,7 @@ GateActions["pulser"] = {
 
 GateActions["squarepulse"] = {
 	name = "Square Pulse",
+	description = "Outputs Max during the PulseTime, Min during the GapTime, while Run is set.",
 	inputs = { "Run", "Reset", "PulseTime", "GapTime", "Min", "Max" },
 	timed = true,
 	output = function(gate, Run, Reset, PulseTime, GapTime, Min, Max)
@@ -157,6 +164,7 @@ GateActions["squarepulse"] = {
 
 GateActions["sawpulse"] = {
 	name = "Saw Pulse",
+	description = "Outputs a value that linearly increases to Max and decreases to Min while Run is set.",
 	inputs = { "Run", "Reset", "SlopeRaiseTime", "PulseTime", "SlopeDescendTime", "GapTime", "Min", "Max" },
 	timed = true,
 	output = function(gate, Run, Reset, SlopeRaiseTime, PulseTime, SlopeDescendTime, GapTime, Min, Max)
@@ -199,6 +207,7 @@ GateActions["sawpulse"] = {
 
 GateActions["derive"] = {
 	name = "Derivative",
+	description = "Outputs the rate of change (derivative) of the number.",
 	inputs = {"A"},
 	timed = false,
 	output = function(gate, A)
@@ -224,6 +233,7 @@ GateActions["derive"] = {
 
 GateActions["delay"] = {
 	name = "Delay",
+	description = "Holds an output of 1 for Hold seconds after Delay seconds on Clk.",
 	inputs = { "Clk", "Delay", "Hold", "Reset" },
 	outputs = { "Out", "TimeElapsed", "Remaining" },
 	timed = true,
@@ -278,6 +288,7 @@ GateActions["delay"] = {
 
 GateActions["monostable"] = {
 	name = "Monostable Timer",
+	description = "Outputs 1 for Time duration and resets to 0 for a tick in between.",
 	inputs = { "Run", "Time", "Reset" },
 	timed = true,
 	output = function(gate, Run, Time, Reset)

--- a/lua/wire/gates/trig.lua
+++ b/lua/wire/gates/trig.lua
@@ -6,6 +6,7 @@ GateActions("Trig")
 
 GateActions["quadratic"] = {
 	name = "Quadratic Formula",
+	description = "Solves for X in the quadratic equation.",
 	inputs = { "A", "B", "C" },
 	outputs = { "Pos", "Neg" },
 	output = function(gate, A, B, C)

--- a/lua/wire/gates/vector.lua
+++ b/lua/wire/gates/vector.lua
@@ -177,6 +177,7 @@ GateActions["vector_mag"] = {
 -- Conversion To/From
 GateActions["vector_convto"] = {
 	name = "Compose",
+	description = "Combines three numbers into a vector.",
 	inputs = { "X", "Y", "Z" },
 	inputtypes = { "NORMAL", "NORMAL", "NORMAL" },
 	outputtypes = { "VECTOR" },
@@ -191,6 +192,7 @@ GateActions["vector_convto"] = {
 GateActions["vector_convfrom"] = {
 	name = "Decompose",
 	inputs = { "A" },
+	description = "Splits an vector into three numbers.",
 	inputtypes = { "VECTOR" },
 	outputs = { "X", "Y", "Z" },
 	outputtypes = { "NORMAL", "NORMAL", "NORMAL" },
@@ -208,6 +210,7 @@ GateActions["vector_convfrom"] = {
 -- Normalise
 GateActions["vector_norm"] = {
 	name = "Normalise",
+	description = "Outputs the vector adjusted to have a magnitude of 1.",
 	inputs = { "A" },
 	inputtypes = { "VECTOR" },
 	outputtypes = { "VECTOR" },
@@ -256,6 +259,7 @@ GateActions["vector_rand"] = {
 -- Component Derivative
 GateActions["vector_derive"] = {
 	name = "Delta",
+	description = "Outputs the rate of change of the vector.",
 	inputs = { "A" },
 	inputtypes = { "VECTOR" },
 	outputtypes = { "VECTOR" },
@@ -282,6 +286,7 @@ GateActions["vector_derive"] = {
 -- Component Integral
 GateActions["vector_cint"] = {
 	name = "Component Integral",
+	description = "Integrates the vector.",
 	inputs = { "A" },
 	inputtypes = { "VECTOR" },
 	outputtypes = { "VECTOR" },
@@ -312,6 +317,7 @@ GateActions["vector_cint"] = {
 -- Multiplexer
 GateActions["vector_mux"] = {
 	name = "Multiplexer",
+	description = "Selects between 8 different vectors based on a number.",
 	inputs = { "Sel", "A", "B", "C", "D", "E", "F", "G", "H" },
 	inputtypes = { "NORMAL", "VECTOR", "VECTOR", "VECTOR", "VECTOR", "VECTOR", "VECTOR", "VECTOR", "VECTOR" },
 	compact_inputs = 3,
@@ -334,6 +340,7 @@ GateActions["vector_mux"] = {
 -- Demultiplexer
 GateActions["vector_dmx"] = {
 	name = "Demultiplexer",
+	description = "Outputs a vector to one of 8 outputs based on a number.",
 	inputs = { "Sel", "In" },
 	inputtypes = { "NORMAL", "VECTOR" },
 	outputs = { "A", "B", "C", "D", "E", "F", "G", "H" },
@@ -358,6 +365,7 @@ GateActions["vector_dmx"] = {
 -- Latch
 GateActions["vector_latch"] = {
 	name = "Latch",
+	description = "Stores a vector when Clk is nonzero.",
 	inputs = { "In", "Clk" },
 	inputtypes = { "VECTOR", "NORMAL" },
 	outputtypes = { "VECTOR" },
@@ -385,6 +393,7 @@ GateActions["vector_latch"] = {
 -- D-latch
 GateActions["vector_dlatch"] = {
 	name = "D-Latch",
+	description = "Stores a vector when Clk changes and is nonzero.",
 	inputs = { "In", "Clk" },
 	inputtypes = { "VECTOR", "NORMAL" },
 	outputtypes = { "VECTOR" },
@@ -502,6 +511,7 @@ GateActions["vector_compgteq"] = {
 -- Returns a positive vector.
 GateActions["vector_positive"] = {
 	name = "Positive",
+	description = "Outputs a vector with its components converted to positive numbers.",
 	inputs = { "A" },
 	inputtypes = { "VECTOR"},
 	outputtypes = { "VECTOR" },
@@ -597,6 +607,7 @@ GateActions["vector_shiftr"] = {
 -- Returns 1 if a vector is on world.
 GateActions["vector_isinworld"] = {
 	name = "Is In World",
+	description = "Outputs 1 if a vector is within the world bounds.",
 	inputs = { "A" },
 	inputtypes = { "VECTOR" },
 	output = function(gate, A)
@@ -638,6 +649,7 @@ GateActions["vector_select"] = {
 
 GateActions["vector_rotate"] = {
 	name = "Rotate",
+	description = "Rotates a vector by the given angle.",
 	inputs = { "A", "B" },
 	inputtypes = { "VECTOR", "ANGLE" },
 	outputtypes = { "VECTOR" },
@@ -655,6 +667,7 @@ GateActions["vector_rotate"] = {
 
 GateActions["vector_mulcomp"] = {
 	name = "Multiplication (component)",
+	description = "Multiplies a vector by a number.",
 	inputs = { "A", "B" },
 	inputtypes = { "VECTOR", "NORMAL" },
 	outputtypes = { "VECTOR" },
@@ -670,6 +683,7 @@ GateActions["vector_mulcomp"] = {
 
 GateActions["vector_clampn"] = {
 	name = "Clamp (numbers)",
+	description = "Clamps the vector's components between numbers Min and Max.",
 	inputs = { "A", "Min", "Max" },
 	inputtypes = { "VECTOR", "NORMAL", "NORMAL" },
 	outputtypes = { "VECTOR" },
@@ -684,6 +698,7 @@ GateActions["vector_clampn"] = {
 
 GateActions["vector_clampv"] = {
 	name = "Clamp (vectors)",
+	description = "Clamps the vector between vectors Min and Max.",
 	inputs = { "A", "Min", "Max" },
 	inputtypes = { "VECTOR", "VECTOR", "VECTOR" },
 	outputtypes = { "VECTOR" },

--- a/lua/wire/stools/gates.lua
+++ b/lua/wire/stools/gates.lua
@@ -84,7 +84,7 @@ if CLIENT then
 				local name = gate.name
 				local lowname = string_lower(name)
 				if string_find( lowname, text, 1, true ) then -- If it has ANY match at all
-					results[#results+1] = { name = gate.name, group = gate.group, action = action, dist = WireLib.levenshtein( text, lowname ) }
+					results[#results+1] = { name = gate.name, group = gate.group, action = action, dist = WireLib.levenshtein( text, lowname ), description = gate.description }
 				end
 			end
 
@@ -118,6 +118,10 @@ if CLIENT then
 						line:SetSelected( true )
 					end
 					line.action = result.action
+					if result.description then
+						line.description = result.description
+						line:SetTooltip(result.description)
+					end
 				end
 			else
 				if searching then
@@ -145,6 +149,7 @@ if CLIENT then
 			end
 
 			line:SetSelected(true) -- Select new
+			panel.GateDescription:SetText(line.description or "")
 			RunConsoleCommand( "wire_gates_action", line.action )
 		end
 
@@ -177,9 +182,14 @@ if CLIENT then
 				local action, gate = subtree[index].action, subtree[index].gate
 				local node2 = node:AddNode( gate.name or "No name found :(" )
 				node2.name = gate.name
+				if gate.description then
+					node2.description = gate.description
+					node2:SetTooltip(gate.description)
+				end
 				node2.action = action
 				function node2:DoClick()
 					RunConsoleCommand( "wire_gates_Action", self.action )
+					panel.GateDescription:SetText(self.description or "")
 				end
 				node2.Icon:SetImage( "icon16/newspaper.png" )
 			end
@@ -219,6 +229,7 @@ if CLIENT then
 		-- add it all to the main panel
 		panel:AddItem( holder )
 
+		panel.GateDescription = panel:Help("")
 
 		-- MISCELLANEOUS PLACEMENT OPTIONS, AND MODEL
 


### PR DESCRIPTION
Adds a simple system to include short descriptions to gates that appear as tooltips and below the gate list.

![Demo](https://github.com/wiremod/wire/assets/20892685/6574e3e6-fc46-432e-a890-117428ef67c4)


This PR doesn't contain a complete set of descriptions for every gate, but I tried to go for gates that may be confusing, excluding highspeed and memory gates.