### PR TITLE
Ratelimit balloon creation

### DIFF
--- a/lua/entities/sent_deployableballoons.lua
+++ b/lua/entities/sent_deployableballoons.lua
@@ -105,7 +105,8 @@ end
 function ENT:TriggerInput(key,value)
 	if (key == "Deploy") then
 		if value ~= 0 then
-			if self.Deployed == 0 then
+			if self.Deployed == 0 and ( self.nextDeploy or 0 ) < CurTime() then
+                self.nextDeploy = CurTime() + 0.5
 				self:DeployBalloons()
 				self.Deployed = 1
 			end
@@ -156,8 +157,7 @@ function ENT:UpdatePopable()
 end
 
 function ENT:DeployBalloons()
-	local balloon
-	balloon = ents.Create("gmod_balloon") --normal balloon
+	local balloon = ents.Create("gmod_balloon") --normal balloon
 
 	local model = BalloonTypes[self.balloonType]
 	if(model==nil) then


### PR DESCRIPTION
Currently players can rapidly spam balloons creating the pop effect incredibly fast, this allows them to lag everyone in the server to sub 3 fps.
This is actively being abused so i decided I'd make a pr to fix it.