### PR TITLE
Add constant variables to E2

### DIFF
--- a/data/expression2/tests/compiler/compiler/restrictions/const_assign.txt
+++ b/data/expression2/tests/compiler/compiler/restrictions/const_assign.txt
@@ -1,0 +1,5 @@
+## SHOULD_FAIL:COMPILE
+
+const X = 5
+
+X = 2

--- a/data/expression2/tests/compiler/compiler/restrictions/const_redeclare.txt
+++ b/data/expression2/tests/compiler/compiler/restrictions/const_redeclare.txt
@@ -1,0 +1,4 @@
+## SHOULD_FAIL:COMPILE
+
+const Y = 2
+const Y = 1

--- a/data/expression2/tests/compiler/compiler/restrictions/const_redeclare_local.txt
+++ b/data/expression2/tests/compiler/compiler/restrictions/const_redeclare_local.txt
@@ -1,0 +1,4 @@
+## SHOULD_FAIL:COMPILE
+
+const X = 5
+local X = 2

--- a/data/expression2/tests/compiler/compiler/restrictions/const_redeclare_multi.txt
+++ b/data/expression2/tests/compiler/compiler/restrictions/const_redeclare_multi.txt
@@ -1,0 +1,4 @@
+## SHOULD_FAIL:COMPILE
+
+const Z = "Foo"
+A=Z="Y"

--- a/data/expression2/tests/compiler/parser/const.txt
+++ b/data/expression2/tests/compiler/parser/const.txt
@@ -1,0 +1,4 @@
+## SHOULD_PASS:COMPILE
+
+const Var = 5
+const Xyz = "test"

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -420,36 +420,38 @@ local Keyword = {
 	Else = 3,
 	-- ``local``
 	Local = 4,
+	-- ``const``
+	Const = 5,
 	-- ``while``
-	While = 5,
+	While = 6,
 	-- ``for``
-	For = 6,
+	For = 7,
 	-- ``break``
-	Break = 7,
+	Break = 8,
 	-- ``continue``
-	Continue = 8,
+	Continue = 9,
 	-- ``switch``
-	Switch = 9,
+	Switch = 10,
 	-- ``case``
-	Case = 10,
+	Case = 11,
 	-- ``default``
-	Default = 11,
+	Default = 12,
 	-- ``foreach``
-	Foreach = 12,
+	Foreach = 13,
 	-- ``function``
-	Function = 13,
+	Function = 14,
 	-- ``return``
-	Return = 14,
+	Return = 15,
 	-- ``#include``
-	["#Include"] = 15,
+	["#Include"] = 16,
 	-- ``try``
-	Try = 16,
+	Try = 17,
 	-- ``catch``
-	Catch = 17,
+	Catch = 18,
 	-- ``do``
-	Do = 18,
+	Do = 19,
 	-- ``event``
-	Event = 19
+	Event = 20
 }
 
 E2Lib.Keyword = Keyword

--- a/lua/wire/client/text_editor/modes/e2.lua
+++ b/lua/wire/client/text_editor/modes/e2.lua
@@ -29,6 +29,7 @@ local keywords = {
 	["function"] = { [true] = true },
 	["return"] = { [true] = true },
 	["local"]  = { [true] = true },
+	["const"] = { [true] = true },
 	["try"]    = { [true] = true },
 	["do"] = { [true] = true },
 	["event"] = { [true] = true },


### PR DESCRIPTION
Allows creating immutable variables with `const` keyword.

Brings the language a little closer to typescript and a lot of people may just prefer this over lua's odd `local` keyword.

```ts
const X = 5

const X = 2 # Compile error
local X = 2 # Compile error
X = 2 # Compile error

print(X)
```

Potentially inputs could be marked as `const` with this too (since mutating them does nothing)