### PR TITLE
Store Extension on E2 registerCallback

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/array.lua
+++ b/lua/entities/gmod_wire_expression2/core/array.lua
@@ -67,7 +67,6 @@ end
 -- Looped functions and operators
 --------------------------------------------------------------------------------
 registerCallback( "postinit", function()
-	E2Lib.currentextension = "array"
 	local getf, setf
 	for k,v in pairs( wire_expression_types ) do
 		local name = k:lower()

--- a/lua/entities/gmod_wire_expression2/core/core.lua
+++ b/lua/entities/gmod_wire_expression2/core/core.lua
@@ -258,7 +258,6 @@ end
 __e2setcost(nil)
 
 registerCallback("postinit", function()
-	E2Lib.currentextension = "core"
 	-- Returns the Nth value given after the index, the type's zero element otherwise. If you mix types, all non-matching arguments will be regarded as the 2nd argument's type's zero element.
 	for name,id,zero in pairs_map(wire_expression_types, unpack) do
 		registerFunction("select", "n"..id.."...", id, function(self, args)

--- a/lua/entities/gmod_wire_expression2/core/datasignal.lua
+++ b/lua/entities/gmod_wire_expression2/core/datasignal.lua
@@ -240,7 +240,6 @@ local non_allowed_types = { xgt = true } -- If anyone can think of any other typ
 local fixDefault = E2Lib.fixDefault
 
 registerCallback("postinit",function()
-	E2Lib.currentextension = "datasignal"
 	-- Add support for EVERY SINGLE type. Yeah!!
 	for k,v in pairs( wire_expression_types ) do
 		if not non_allowed_types[v[1]] then

--- a/lua/entities/gmod_wire_expression2/core/init.lua
+++ b/lua/entities/gmod_wire_expression2/core/init.lua
@@ -155,7 +155,7 @@ end
 function E2Lib.registerCallback(event, callback)
 	if not wire_expression_callbacks[event] then wire_expression_callbacks[event] = {} end
 	local currExt = E2Lib.currentextension
-	table.insert(wire_expression_callbacks[event], function(...) E2Lib.currentextension = currExt return callback(...) end)
+	table.insert(wire_expression_callbacks[event], function(a, b, c, d, e, f) E2Lib.currentextension = currExt return callback(a, b, c, d, e, f) end)
 end
 
 registerCallback = E2Lib.registerCallback

--- a/lua/entities/gmod_wire_expression2/core/init.lua
+++ b/lua/entities/gmod_wire_expression2/core/init.lua
@@ -154,7 +154,8 @@ end
 
 function E2Lib.registerCallback(event, callback)
 	if not wire_expression_callbacks[event] then wire_expression_callbacks[event] = {} end
-	table.insert(wire_expression_callbacks[event], callback)
+	local currExt = E2Lib.currentextension
+	table.insert(wire_expression_callbacks[event], function(...) E2Lib.currentextension = currExt return callback(...) end)
 end
 
 registerCallback = E2Lib.registerCallback

--- a/lua/entities/gmod_wire_expression2/core/selfaware.lua
+++ b/lua/entities/gmod_wire_expression2/core/selfaware.lua
@@ -212,7 +212,6 @@ local comparable_types = {
 }
 
 registerCallback("postinit", function()
-	E2Lib.currentextension = "selfaware"
 	-- Angle is the same as vector
 	registerFunction("changed", "a", "n", registeredfunctions.e2_changed_v)
 

--- a/lua/entities/gmod_wire_expression2/core/table.lua
+++ b/lua/entities/gmod_wire_expression2/core/table.lua
@@ -981,7 +981,6 @@ end
 --------------------------------------------------------------------------------
 
 registerCallback( "postinit", function()
-	E2Lib.currentextension = "table"
 	local getf, setf
 	for k,v in pairs( wire_expression_types ) do
 		local name = k


### PR DESCRIPTION
Removes the responsibility of manually setting the extension to callbacks. E2 descriptions will never be in the wrong extension ever again.