### PR TITLE
Add playerMove event with "usercmd" and "movedata" types and getter functions

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -989,52 +989,52 @@ E2Lib.registerEvent("playerChangedTeam", {
 
 __e2setcost(1)
 
---- Returns <this>'s mouse delta on the x-axis.
+
 e2function number usercmd:getMouseDeltaX()
 	return this:GetMouseX()
 end
 
---- Returns <this>'s mouse delta on the y-axis.
+
 e2function number usercmd:getMouseDeltaY()
 	return this:GetMouseY()
 end
 
---- Returns <this>'s forward movement.
+
 e2function number usercmd:getForwardMove()
 	return this:GetForwardMove()
 end
 
---- Returns <this>'s strafe movement.
+
 e2function number usercmd:getSideMove()
 	return this:GetSideMove()
 end
 
---- Returns <this>'s upward movement.
+
 e2function number usercmd:getUpMove()
 	return this:GetUpMove()
 end
 
---- Returns <this>'s forward speed.
+
 e2function number movedata:getForwardSpeed()
 	return this:GetForwardSpeed()
 end
 
---- Returns <this>'s strafe speed.
+
 e2function number movedata:getSideSpeed()
 	return this:GetSideSpeed()
 end
 
---- Returns <this>'s upward speed.
+
 e2function number movedata:getUpSpeed()
 	return this:GetUpSpeed()
 end
 
---- Returns <this>'s max speed.
+
 e2function number movedata:getMaxSpeed()
 	return this:GetMaxSpeed()
 end
 
---- Returns <this>'s move angles.
+
 e2function angle movedata:getMoveAngles()
 	return this:GetMoveAngles()
 end

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -985,6 +985,10 @@ E2Lib.registerEvent("playerChangedTeam", {
 	{ "NewTeam", "n" }
 })
 
+--[[--------------------------------------------------------------------------------------------]]--
+
+__e2setcost(1)
+
 e2function number usercmd:getMouseDeltaX()
 	return this:GetMouseX()
 end

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -948,6 +948,25 @@ E2Lib.registerEvent("playerUse", {
 	{ "Entity", "e" }
 })
 
+hook.Add("SetupMove", "Exp2MouseInput", function( ply, mv, cmd )
+	local deltaX = cmd:GetMouseX()
+	local deltaY = cmd:GetMouseY()
+	local scroll = cmd:GetMouseWheel()
+	E2Lib.triggerEvent("mouseWheeled", {ply, scroll})
+	E2Lib.triggerEvent("mouseMoved", {ply, deltaX, deltaY})
+end)
+
+E2Lib.registerEvent("mouseWheeled", {
+	{"Ply","e"},
+	{"Scroll", "n"}
+})
+
+E2Lib.registerEvent("mouseMoved", {
+	{"Ply","e"},
+	{"DeltaX", "n"},
+	{"DeltaY", "n"}
+})
+
 hook.Add("PlayerChangedTeam", "Exp2PlayerChangedTeam", function(ply, oldTeam, newTeam)
 	E2Lib.triggerEvent("playerChangedTeam", { ply, oldTeam, newTeam })
 end)

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -17,6 +17,33 @@ registerCallback("e2lib_replace_function", function(funcname, func, oldfunc)
 	end
 end)
 
+local M_CUserCmd = FindMetaTable("CUserCmd")
+local M_CMoveData = FindMetaTable("CMoveData")
+
+registerType("usercmd", "xuc", nil,
+	nil, nil,
+	function(retval)
+		if retval == nil then return end
+		if not istable(retval) then error("Return value is neither nil nor a table, but a " .. type(retval) .. "!",0) end
+		if getmetatable(retval) ~= M_CUserCmd then error("Return value is not a CUserCmd!", 0) end
+	end,
+	function(v)
+		return not istable(v) or getmetatable(v) ~= M_CUserCmd
+	end
+)
+
+registerType("movedata", "xmv", nil,
+	nil, nil,
+	function(retval)
+		if retval == nil then return end
+		if not istable(retval) then error("Return value is neither nil nor a table, but a " .. type(retval) .. "!",0) end
+		if getmetatable(retval) ~= M_CMoveData then error("Return value is not a CMoveData!", 0) end
+	end,
+	function(v)
+		return not istable(v) or getmetatable(v) ~= M_CMoveData
+	end
+)
+
 --------------------------------------------------------------------------------
 
 __e2setcost(5) -- temporary
@@ -948,25 +975,6 @@ E2Lib.registerEvent("playerUse", {
 	{ "Entity", "e" }
 })
 
-hook.Add("SetupMove", "Exp2MouseInput", function(ply, mv, cmd)
-	local deltaX = cmd:GetMouseX()
-	local deltaY = cmd:GetMouseY()
-	local scroll = cmd:GetMouseWheel()
-	E2Lib.triggerEvent("mouseWheeled", { ply, scroll })
-	E2Lib.triggerEvent("mouseMoved", { ply, deltaX, deltaY })
-end)
-
-E2Lib.registerEvent("mouseWheeled", {
-	{ "Player","e" },
-	{ "Scroll", "n" }
-})
-
-E2Lib.registerEvent("mouseMoved", {
-	{ "Player","e" },
-	{ "DeltaX", "n" },
-	{ "DeltaY", "n" }
-})
-
 hook.Add("PlayerChangedTeam", "Exp2PlayerChangedTeam", function(ply, oldTeam, newTeam)
 	E2Lib.triggerEvent("playerChangedTeam", { ply, oldTeam, newTeam })
 end)
@@ -975,6 +983,56 @@ E2Lib.registerEvent("playerChangedTeam", {
 	{ "Player", "e" },
 	{ "OldTeam", "n" },
 	{ "NewTeam", "n" }
+})
+
+e2function number usercmd:getMouseDeltaX()
+	return this:GetMouseX()
+end
+
+e2function number usercmd:getMouseDeltaY()
+	return this:GetMouseY()
+end
+
+e2function number usercmd:getForwardMove()
+	return this:GetForwardMove()
+end
+
+e2function number usercmd:getSideMove()
+	return this:GetSideMove()
+end
+
+e2function number usercmd:getUpMove()
+	return this:GetUpMove()
+end
+
+e2function number movedata:getForwardSpeed()
+	return this:GetForwardSpeed()
+end
+
+e2function number movedata:getSideSpeed()
+	return this:GetSideSpeed()
+end
+
+e2function number movedata:getUpSpeed()
+	return this:GetUpSpeed()
+end
+
+e2function number movedata:getMaxSpeed()
+	return this:GetMaxSpeed()
+end
+
+e2function angle movedata:getMoveAngles()
+	return this:GetMoveAngles()
+end
+
+hook.Add("SetupMove", "E2_PlayerMove", function(ply, mv, cmd)
+	E2Lib.triggerEvent("playerMove", { ply, mv, cmd })
+end)
+
+E2Lib.registerEvent("playerMove", {
+	{ "Player", "e" },
+	{ "MoveData", "xmv" },
+	{ "Command", "xuc" }
 })
 
 --******************************************--

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -989,42 +989,52 @@ E2Lib.registerEvent("playerChangedTeam", {
 
 __e2setcost(1)
 
+--- Returns <this>'s mouse delta on the x-axis.
 e2function number usercmd:getMouseDeltaX()
 	return this:GetMouseX()
 end
 
+--- Returns <this>'s mouse delta on the y-axis.
 e2function number usercmd:getMouseDeltaY()
 	return this:GetMouseY()
 end
 
+--- Returns <this>'s forward movement.
 e2function number usercmd:getForwardMove()
 	return this:GetForwardMove()
 end
 
+--- Returns <this>'s strafe movement.
 e2function number usercmd:getSideMove()
 	return this:GetSideMove()
 end
 
+--- Returns <this>'s upward movement.
 e2function number usercmd:getUpMove()
 	return this:GetUpMove()
 end
 
+--- Returns <this>'s forward speed.
 e2function number movedata:getForwardSpeed()
 	return this:GetForwardSpeed()
 end
 
+--- Returns <this>'s strafe speed.
 e2function number movedata:getSideSpeed()
 	return this:GetSideSpeed()
 end
 
+--- Returns <this>'s upward speed.
 e2function number movedata:getUpSpeed()
 	return this:GetUpSpeed()
 end
 
+--- Returns <this>'s max speed.
 e2function number movedata:getMaxSpeed()
 	return this:GetMaxSpeed()
 end
 
+--- Returns <this>'s move angles.
 e2function angle movedata:getMoveAngles()
 	return this:GetMoveAngles()
 end

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -994,46 +994,37 @@ e2function number usercmd:getMouseDeltaX()
 	return this:GetMouseX()
 end
 
-
 e2function number usercmd:getMouseDeltaY()
 	return this:GetMouseY()
 end
-
 
 e2function number usercmd:getForwardMove()
 	return this:GetForwardMove()
 end
 
-
 e2function number usercmd:getSideMove()
 	return this:GetSideMove()
 end
-
 
 e2function number usercmd:getUpMove()
 	return this:GetUpMove()
 end
 
-
 e2function number movedata:getForwardSpeed()
 	return this:GetForwardSpeed()
 end
-
 
 e2function number movedata:getSideSpeed()
 	return this:GetSideSpeed()
 end
 
-
 e2function number movedata:getUpSpeed()
 	return this:GetUpSpeed()
 end
 
-
 e2function number movedata:getMaxSpeed()
 	return this:GetMaxSpeed()
 end
-
 
 e2function angle movedata:getMoveAngles()
 	return this:GetMoveAngles()

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -948,23 +948,23 @@ E2Lib.registerEvent("playerUse", {
 	{ "Entity", "e" }
 })
 
-hook.Add("SetupMove", "Exp2MouseInput", function( ply, mv, cmd )
+hook.Add("SetupMove", "Exp2MouseInput", function(ply, mv, cmd)
 	local deltaX = cmd:GetMouseX()
 	local deltaY = cmd:GetMouseY()
 	local scroll = cmd:GetMouseWheel()
-	E2Lib.triggerEvent("mouseWheeled", {ply, scroll})
-	E2Lib.triggerEvent("mouseMoved", {ply, deltaX, deltaY})
+	E2Lib.triggerEvent("mouseWheeled", { ply, scroll })
+	E2Lib.triggerEvent("mouseMoved", { ply, deltaX, deltaY })
 end)
 
 E2Lib.registerEvent("mouseWheeled", {
-	{"Ply","e"},
-	{"Scroll", "n"}
+	{ "Player","e" },
+	{ "Scroll", "n" }
 })
 
 E2Lib.registerEvent("mouseMoved", {
-	{"Ply","e"},
-	{"DeltaX", "n"},
-	{"DeltaY", "n"}
+	{ "Player","e" },
+	{ "DeltaX", "n" },
+	{ "DeltaY", "n" }
 })
 
 hook.Add("PlayerChangedTeam", "Exp2PlayerChangedTeam", function(ply, oldTeam, newTeam)

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -376,16 +376,16 @@ E2Helper.Descriptions["setCollisionGroup(e:n)"] = "Sets the collision group of t
 E2Helper.Descriptions["noCollideAll"] = "Nocollides an entity to all entities/players, just like the tool's right-click"
 
 -- Movedata/Usercmd
-E2Helper.Descriptions["getMouseDeltaX()"] = "Returns the mouse delta of this command on the x-axis"
-E2Helper.Descriptions["getMouseDeltaY()"] = "Returns the mouse delta of this command on the y-axis"
-E2Helper.Descriptions["getForwardMove()"] = "Returns the forward/back movement of this command"
-E2Helper.Descriptions["getSideMove()"] = "Returns the strafe movement of this command"
-E2Helper.Descriptions["getUpMove()"] = "Returns the up/down movement of this command"
-E2Helper.Descriptions["getForwardSpeed()"] = "Returns the forward/back speed of the movedata"
-E2Helper.Descriptions["getSideSpeed()"] = "Returns the strafe speed of the movedata"
-E2Helper.Descriptions["getUpSpeed()"] = "Returns the up/down speed of the movedata"
-E2Helper.Descriptions["getMaxSpeed()"] = "Returns the movedata's maximum movement speed"
-E2Helper.Descriptions["getMoveAngles()"] = "Returns movedata's angles"
+E2Helper.Descriptions["getMouseDeltaX(xuc:)"] = "Returns the mouse delta of this command on the x-axis"
+E2Helper.Descriptions["getMouseDeltaY(xuc:)"] = "Returns the mouse delta of this command on the y-axis"
+E2Helper.Descriptions["getForwardMove(xuc:)"] = "Returns the forward/back movement of this command"
+E2Helper.Descriptions["getSideMove(xuc:)"] = "Returns the strafe movement of this command"
+E2Helper.Descriptions["getUpMove(xuc:)"] = "Returns the up/down movement of this command"
+E2Helper.Descriptions["getForwardSpeed(xmv:)"] = "Returns the forward/back speed of the movedata"
+E2Helper.Descriptions["getSideSpeed(xmv:)"] = "Returns the strafe speed of the movedata"
+E2Helper.Descriptions["getUpSpeed(xmv:)"] = "Returns the up/down speed of the movedata"
+E2Helper.Descriptions["getMaxSpeed(xmv:)"] = "Returns the movedata's maximum movement speed"
+E2Helper.Descriptions["getMoveAngles(xmv:)"] = "Returns movedata's angles"
 
 -- Attachment
 E2Helper.Descriptions["lookupAttachment(e:s)"] = "Returns Es attachment ID associated with attachmentName"

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -375,6 +375,18 @@ E2Helper.Descriptions["getCollisionGroup(e:)"] = "Returns the collision group of
 E2Helper.Descriptions["setCollisionGroup(e:n)"] = "Sets the collision group of the entity. Does not work on players. Use one of the _COLLISION_GROUP constants"
 E2Helper.Descriptions["noCollideAll"] = "Nocollides an entity to all entities/players, just like the tool's right-click"
 
+-- Movedata/Usercmd
+E2Helper.Descriptions["getMouseDeltaX()"] = "Returns the mouse delta of this command on the x-axis"
+E2Helper.Descriptions["getMouseDeltaY()"] = "Returns the mouse delta of this command on the y-axis"
+E2Helper.Descriptions["getForwardMove()"] = "Returns the forward/back movement of this command"
+E2Helper.Descriptions["getSideMove()"] = "Returns the strafe movement of this command"
+E2Helper.Descriptions["getUpMove()"] = "Returns the up/down movement of this command"
+E2Helper.Descriptions["getForwardSpeed()"] = "Returns the forward/back speed of the movedata"
+E2Helper.Descriptions["getSideSpeed()"] = "Returns the strafe speed of the movedata"
+E2Helper.Descriptions["getUpSpeed()"] = "Returns the up/down speed of the movedata"
+E2Helper.Descriptions["getMaxSpeed()"] = "Returns the movedata's maximum movement speed"
+E2Helper.Descriptions["getMoveAngles()"] = "Returns movedata's angles"
+
 -- Attachment
 E2Helper.Descriptions["lookupAttachment(e:s)"] = "Returns Es attachment ID associated with attachmentName"
 E2Helper.Descriptions["attachmentPos(e:n)"] = "Returns Es attachment position associated with attachmentID"


### PR DESCRIPTION
### This adds a multitude of functions:
- xuc:getMouseDeltaX()
- xuc:getMouseDeltaY()
- xuc:getForwardMove()
- xuc:getSideMove()
- xuc:getUpMove()
- xmv:getForwardSpeed()
- xmv:getSideSpeed()
- xmv:getUpSpeed()
- xmv:getMaxSpeed()
- xmv:getMoveAngles()

### And with an event to go alongside:
- playerMove(Player:entity, MoveData:movedata, Command:usercmd)
### Example:
```lua
event playerMove(P:entity, M:movedata, C:usercmd) {
    if(P == owner()) {
        print(C:getMouseDeltaX(), C:getMouseDeltaY())
    }
}
``` 



