### PR TITLE
Fix EGP:GetGlobalPos making unparented EGP polys parented

### DIFF
--- a/lua/entities/gmod_wire_egp/lib/egplib/parenting.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/parenting.lua
@@ -153,7 +153,7 @@ function EGP:GetGlobalPos( Ent, index )
 				return true, ret
 			end
 			local ret = {}
-			if isstring(v.verticesindex) then ret = { [v.verticesindex] = makeTable( v, makeArray( v ) ) }	else ret = makeTable( v, makeArray( v ) ) end
+			if isstring(v.verticesindex) then ret = { [v.verticesindex] = makeTable( v, makeArray(v, true) ) }	else ret = makeTable( v, makeArray(v, true) ) end
 			return true, ret
 		else -- Object does not have vertices, parent does not
 			if (v.parent and v.parent ~= 0) then -- Object is parented


### PR DESCRIPTION
When calling `EGP:GetGlobalPos` or any E2 function that calls it internally (such as `egpGlobalPos` or `egpObjectContainsPoint`), unparented polys would be erroneously modified to have parented features. This would make it so that when drawn, their position would be centered at `0, 0`.