### PR TITLE
Enforce function returns at compile time

### DIFF
--- a/data/expression2/tests/compiler/compiler/restrictions/fn_return.txt
+++ b/data/expression2/tests/compiler/compiler/restrictions/fn_return.txt
@@ -1,0 +1,3 @@
+## SHOULD_FAIL:COMPILE
+
+function string nothing() {}

--- a/data/expression2/tests/compiler/compiler/restrictions/fn_return_pass.txt
+++ b/data/expression2/tests/compiler/compiler/restrictions/fn_return_pass.txt
@@ -1,0 +1,13 @@
+## SHOULD_PASS:COMPILE
+
+function string nothing() {
+	return "something"
+}
+
+function number deadcase() {
+	if (1) {
+		return 2158129
+	} else {
+		return 2321515
+	}
+}

--- a/data/expression2/tests/compiler/compiler/restrictions/fn_return_pass.txt
+++ b/data/expression2/tests/compiler/compiler/restrictions/fn_return_pass.txt
@@ -11,3 +11,12 @@ function number deadcase() {
 		return 2321515
 	}
 }
+
+function number switchcase() {
+	switch (5) {
+		case 5,
+			return 2
+		default,
+			return 5
+	}
+}

--- a/data/expression2/tests/compiler/compiler/restrictions/fn_return_switch.txt
+++ b/data/expression2/tests/compiler/compiler/restrictions/fn_return_switch.txt
@@ -1,0 +1,12 @@
+## SHOULD_FAIL:COMPILE
+
+function string failure() {
+	switch (5) {
+		case 2,
+			break
+		default,
+			break
+
+		# 'break' does not return a value or cause a runtime error, just early returns switch.
+	}
+}

--- a/data/expression2/tests/compiler/compiler/restrictions/fn_return_switch2.txt
+++ b/data/expression2/tests/compiler/compiler/restrictions/fn_return_switch2.txt
@@ -1,0 +1,9 @@
+## SHOULD_FAIL:COMPILE
+
+function string failure() {
+	switch (5) {
+		case 2,
+			return "boowomp"
+		# no default case, compiler can't guarantee that this always runs, fails to compile.
+	}
+}

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -1459,8 +1459,6 @@ local CompileVisitors = {
 					return fn(state, rargs, types)
 				end, fn_data.returns and (fn_data.returns[1] ~= "" and fn_data.returns[1] or nil)
 			else
-				self.scope.data.ops = self.scope.data.ops + 3
-
 				local full_sig = name.value .. "(" .. arg_sig .. ")"
 				return function(state) ---@param state RuntimeContext
 					local rargs = {}

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -1459,6 +1459,8 @@ local CompileVisitors = {
 					return fn(state, rargs, types)
 				end, fn_data.returns and (fn_data.returns[1] ~= "" and fn_data.returns[1] or nil)
 			else
+				self.scope.data.ops = self.scope.data.ops + 3
+
 				local full_sig = name.value .. "(" .. arg_sig .. ")"
 				return function(state) ---@param state RuntimeContext
 					local rargs = {}

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -17,7 +17,6 @@ cvars.AddChangeCallback("wire_expression2_quotatick", function(_, old, new)
 end, "compiler_quota_check")
 
 ---@class ScopeData
----@field returned boolean?
 ---@field dead boolean?
 ---@field loop boolean?
 ---@field switch_case boolean?
@@ -313,8 +312,7 @@ local CompileVisitors = {
 			end)
 		end
 
-		if els and dead then
-			-- if (0) { return } else { return } mark any code after as dead
+		if els and dead then -- if (0) { return } else { return } mark any code after as dead
 			self.scope.data.dead = true
 		end
 
@@ -802,8 +800,8 @@ local CompileVisitors = {
 
 			block = self:CompileStmt(data[5])
 
-			if return_type then
-				self:Assert(scope.data.returned or scope.data.dead, "This function marked to return '" .. data[1].value .. "' must return a value", data[1].trace)
+			if return_type then -- Ensure function either returns or errors
+				self:Assert(scope.data.dead, "This function marked to return '" .. data[1].value .. "' must return a value", data[1].trace)
 			end
 		end)
 
@@ -892,7 +890,7 @@ local CompileVisitors = {
 		local fn = self.scope:ResolveData("function")
 		self:Assert(fn, "Cannot use `return` outside of a function", trace)
 
-		self.scope.data.dead, self.scope.data.returned = true, true
+		self.scope.data.dead = true
 
 		local retval, ret_ty
 		if data then


### PR DESCRIPTION
Instead of doing a runtime check for functions returning values, (which would bring a minor amount of overhead to E2 functions), now they will be checked at compile time if they return.

This won't compile
```golo
function string test() {}
```
> This function marked to return 'string' must return a value

But these two cases will (Featuring some cheeky logic to make if and switch statements mark the above scope as dead if all cases return and there is an `else` / `default` case)

```golo
function number increment() {
    if (Ran) {
        error("Ran twice")
    } else {
        Ran = 1
        return 1
    }
}

function number good(N:string) {
    switch (N) {
        case "E2",
            return 1
        default,
            return 0
    }
}
```

## Changes to OPS
This also lowers base cost of userfunctions to 10 ops.