### PR TITLE
Make functions a compile time construct on `@strict`

### DIFF
--- a/data/expression2/tests/compiler/compiler/restrictions/fn_override_strict.txt
+++ b/data/expression2/tests/compiler/compiler/restrictions/fn_override_strict.txt
@@ -1,0 +1,7 @@
+## SHOULD_FAIL:COMPILE
+
+@strict
+
+function test() {}
+
+function test() {} # ERROR!

--- a/data/expression2/tests/runtime/base/userfunctions/functions_const.txt
+++ b/data/expression2/tests/runtime/base/userfunctions/functions_const.txt
@@ -1,0 +1,117 @@
+## SHOULD_PASS:EXECUTE
+
+@strict
+
+# Ensure functions get called in the first place
+
+Called = 0
+function myfunction() {
+	Called = 1
+}
+
+myfunction()
+
+assert(Called)
+
+
+local X = 500
+local Y = 1000
+local Z = 5000
+
+# Ensure function scoping doesn't affect outer scope
+
+function test(X, Y, Z) {
+	assert(X == 1)
+	assert(Y == 2)
+	assert(Z == 3)
+}
+
+test(1, 2, 3)
+
+assert(X == 500)
+assert(Y == 1000)
+assert(Z == 5000)
+
+# Ensure functions return properly
+
+function number returning() {
+	return 5
+}
+
+assert(returning() == 5)
+
+function number returning2(X:array) {
+	return X[1, number] + 5
+}
+
+assert(returning2(array(5)) == 10)
+assert(returning2(array()) == 5)
+
+function array returningref(X:array) {
+	return X
+}
+
+local A = array()
+assert(returningref(A):id() == A:id())
+
+function returnvoid() {
+	if (1) { return }
+	error("unreachable")
+}
+
+returnvoid()
+
+function void returnvoid2() {
+	return
+}
+
+returnvoid2()
+
+function returnvoid3() {
+	return void
+}
+
+returnvoid3()
+
+# Test recursion
+
+function number recurse(N:number) {
+	if (N == 1) {
+		return 5
+	} else {
+		return recurse(N - 1) + 1
+	}
+}
+
+assert(recurse(10) == 14, recurse(10):toString())
+
+Sentinel = -1
+function recursevoid() {
+	Sentinel++
+	if (Sentinel == 0) {
+		recursevoid()
+	}
+}
+
+recursevoid()
+
+assert(Sentinel == 1)
+
+function number nilInput(X, Y:ranger, Z:vector) {
+	assert(Z == vec(1, 2, 3))
+	return 5
+}
+
+assert( nilInput(1, noranger(), vec(1, 2, 3)) == 5 )
+
+Ran = 0
+
+if (0) {
+	function constant() {
+		Ran = 1
+	}
+}
+
+constant()
+
+assert(Ran)

--- a/data/expression2/tests/runtime/base/userfunctions/methods_const.txt
+++ b/data/expression2/tests/runtime/base/userfunctions/methods_const.txt
@@ -1,0 +1,120 @@
+## SHOULD_PASS:EXECUTE
+
+@strict
+
+# Ensure methods get called in the first place
+
+Called = 0
+function number:mymethod() {
+	Called = 1
+}
+
+1:mymethod()
+
+assert(Called)
+
+local This = 10
+local X = 500
+local Y = 1000
+local Z = 5000
+
+# Ensure function scoping doesn't affect outer scope
+
+function number number:method(X, Y, Z) {
+	assert(This == 500)
+	assert(X == 1)
+	assert(Y == 2)
+	assert(Z == 4)
+
+	return 5
+}
+
+assert( 500:method(1, 2, 4) == 5 )
+
+assert(This == 10)
+assert(X == 500)
+assert(Y == 1000)
+assert(Z == 5000)
+
+# Ensure functions return properly
+
+function number number:returning() {
+	return 5
+}
+
+assert(1:returning() == 5)
+
+function number number:returning2(X:array) {
+	return X[1, number] + 5
+}
+
+assert(1:returning2(array(5)) == 10)
+assert(1:returning2(array()) == 5)
+
+function array number:returningref(X:array) {
+	return X
+}
+
+local A = array()
+assert(1:returningref(A):id() == A:id())
+
+function number:returnvoid() {
+	if (1) { return }
+}
+
+1:returnvoid()
+
+function void number:returnvoid2() {
+	return
+}
+
+1:returnvoid2()
+
+function number:returnvoid3() {
+	return void
+}
+
+1:returnvoid3()
+
+# Test recursion
+
+function number number:recurse(N:number) {
+	if (N == 1) {
+		return 5
+	} else {
+		return This:recurse(N - 1) + 1
+	}
+}
+
+assert(1:recurse(10) == 14, 1:recurse(10):toString())
+
+Sentinel = -1
+function number:recursevoid() {
+	Sentinel++
+	if (Sentinel == 0) {
+		This:recursevoid()
+	}
+}
+
+1:recursevoid()
+
+assert(Sentinel == 1)
+
+function number number:nilInput(X, Y:ranger, Z:vector) {
+	assert(Z == vec(1, 2, 3))
+	return 5
+}
+
+assert( 1:nilInput(1, noranger(), vec(1, 2, 3)) == 5 )
+
+Ran = 0
+
+if (0) {
+	function number:constant() {
+		Ran = 1
+	}
+}
+
+1:constant()
+
+assert(Ran)

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -697,7 +697,7 @@ local CompileVisitors = {
 			end
 		end
 
-		local fn = { args = param_types, returns = return_type and { return_type }, meta = meta_type, cost = variadic_ty and 25 or 10, attrs = {} }
+		local fn = { args = param_types, returns = return_type and { return_type }, meta = meta_type, cost = variadic_ty and 10 or 5 + (self.strict and 0 or 3), attrs = {} }
 		local sig = table.concat(param_types, "", 1, #param_types - 1) .. ((variadic_ty and ".." or "") .. (param_types[#param_types] or ""))
 
 		if meta_type then

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -672,6 +672,10 @@ local CompileVisitors = {
 			end
 		end
 
+		if self.strict and not self.scope:IsGlobalScope() then
+			self:Warning("Functions should be in the top scope, nesting them does nothing", trace)
+		end
+
 		local fn_data, lookup_variadic, userfunction = self:GetFunction(name.value, param_types, meta_type)
 		if fn_data then
 			if not userfunction then

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -1538,8 +1538,7 @@ local CompileVisitors = {
 		local nargs = #args
 		local user_method = self.user_methods[meta_type] and self.user_methods[meta_type][name.value] and self.user_methods[meta_type][name.value][arg_sig]
 		if user_method then
-			-- Calling a user function - chance of being overridden. Also not legacy.
-			if user_method.const then
+			if self.strict then -- If @strict, functions are compile time constructs (like events).
 				local fn = user_method.op
 				return function(state)
 					local rargs = { meta(state) }
@@ -1547,7 +1546,7 @@ local CompileVisitors = {
 						rargs[k + 1] = args[k](state)
 					end
 					return fn(state, rargs, types)
-				end
+				end, fn_data.returns and (fn_data.returns[1] ~= "" and fn_data.returns[1] or nil)
 			else
 				local full_sig = name.value .. "(" .. meta_type .. ":" .. arg_sig .. ")"
 				return function(state) ---@param state RuntimeContext

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -1478,7 +1478,7 @@ local CompileVisitors = {
 					return fn(state, rargs, types)
 				end, fn_data.returns and (fn_data.returns[1] ~= "" and fn_data.returns[1] or nil)
 			else
-				self.scope.data.ops = self.scope.data.ops + 4 + ((fn_data.cost or 15) + (fn_data.attrs["legacy"] and 10 or 0))
+				self.scope.data.ops = self.scope.data.ops + (fn_data.cost or 15) + (fn_data.attrs["legacy"] and 10 or 0)
 
 				local full_sig = name.value .. "(" .. arg_sig .. ")"
 				return function(state) ---@param state RuntimeContext


### PR DESCRIPTION
## No overriding

Overriding functions at runtime is no longer a thing on `@strict`. It's rare, odd dynamic behavior that shouldn't really be a thing. Function objects will fulfill their purpose in the future.

```golo
@strict

function test() {}

function test() {} # ERROR!
```

It gives a warning without `@strict` for backwards compatibility.

## Compile time

Like events, functions on `@strict` will now be compile time constructs, so it doesn't matter if they're inside an `event tick() {}` loop or something. The function will just be created once when the chip is compiled.

Basically: they will be cheaper to call and create. I raised the cost of calling functions on non-`@strict`, but the base cost is still 10 ops (will likely be lowered in the future).

## Breaking Change to String Calls

Since they will be compile time constructs, string calls to userfunctions won't work on `@strict` (will get a "no such function" error). This could be reverted while keeping the perf boost from calling, but the cost of creating the function will still exist.

I think it is a worthwhile break since stringcalls should hopefully be made obsolete soon with function objects.