### PR TITLE
Remove `wire_expression2_debug`, registerType `[5]`, GLON

### DIFF
--- a/data/expression2/tests/runtime/libraries/serialization.txt
+++ b/data/expression2/tests/runtime/libraries/serialization.txt
@@ -1,0 +1,30 @@
+## SHOULD_PASS:EXECUTE
+
+assert( jsonEncode( table(1 = 1, 2 = 2) ) == "[1.0,2.0]" )
+
+assert( jsonEncode( table("foo", "bar", 1, "baz", array(1, 2, 3)) ) == "[\"foo\",\"bar\",1.0,\"baz\",[1.0,2.0,3.0]]" )
+
+const T0 = jsonDecode("[\"foo\",\"bar\",1.0,\"baz\",[1.0,2.0,3.0]]")
+assert(T0[1, string] == "foo")
+assert(T0[2, string] == "bar")
+assert(T0[3, number] == 1)
+assert(T0[4, string] == "baz")
+assert(T0[5, table][1, number] == 1) # Deserializes any table as table
+assert(T0[5, table][2, number] == 2)
+assert(T0[5, table][3, number] == 3)
+
+assert( vonEncode(array(1, 2, noentity())) == "n1;2;e0;" )
+
+assert( vonEncode(array("foo", 2, "qux")) == "'foo\"n2;'qux\"" )
+
+const T1 = vonDecode("'foo\"n2;'qux\"")
+assert(T1[1, string] == "foo")
+assert(T1[2, number] == 2)
+assert(T1[3, string] == "qux")
+
+assert( vonEncode(table(1, 2, array(noentity(), 2, 3))) == "~'ntypes\":{'n\"'n\"'r\"}'s\":{}'n\":{n1;2;{e0;n2;3}}'size\":n3;'stypes\":{}" )
+
+const T2 = vonDecodeTable("~'ntypes\":{'n\"'n\"'r\"}'s\":{}'n\":{n1;2;{e0;n2;3}}'size\":n3;'stypes\":{}")
+
+assert(T2[2, number] == 2)
+assert(T2[3, array][3, number] == 3)

--- a/lua/entities/gmod_wire_expression2/core/angle.lua
+++ b/lua/entities/gmod_wire_expression2/core/angle.lua
@@ -5,10 +5,7 @@ Angle support
 registerType("angle", "a", Angle(0, 0, 0),
 	nil,
 	function(self, output) return Angle(output) end,
-	function(retval)
-		if isangle(retval) then return end
-		error("Return value is not an Angle, but a "..type(retval).."!", 0)
-	end,
+	nil,
 	function(v)
 		return not isangle(v)
 	end

--- a/lua/entities/gmod_wire_expression2/core/array.lua
+++ b/lua/entities/gmod_wire_expression2/core/array.lua
@@ -34,9 +34,7 @@ registerType("array", "r", {},
 		return ret
 	end,
 	nil,
-	function(retval)
-		if !istable(retval) then error("Return value is not a table, but a "..type(retval).."!",0) end
-	end,
+	nil,
 	function(v)
 		return !istable(v)
 	end

--- a/lua/entities/gmod_wire_expression2/core/bone.lua
+++ b/lua/entities/gmod_wire_expression2/core/bone.lua
@@ -79,11 +79,7 @@ E2Lib.isValidBone = isValidBone
 registerType("bone", "b", nil,
 	nil,
 	nil,
-	function(retval)
-		if retval == nil then return end
-		if type(retval) ~= "PhysObj" then error("Return value is neither nil nor a PhysObj, but a "..type(retval).."!",0) end
-		if not bone2entity[retval] then error("Return value is not a registered bone!",0) end
-	end,
+	nil,
 	function(b)
 		return not isValidBone(b)
 	end

--- a/lua/entities/gmod_wire_expression2/core/complex.lua
+++ b/lua/entities/gmod_wire_expression2/core/complex.lua
@@ -44,10 +44,7 @@ __e2setcost(2)
 registerType("complex", "c", { 0, 0 },
 	function(self, input) return { input[1], input[2] } end,
 	nil,
-	function(retval)
-		if !istable(retval) then error("Return value is not a table, but a "..type(retval).."!",0) end
-		if #retval ~= 2 then error("Return value does not have exactly 2 entries!",0) end
-	end,
+	nil,
 	function(v)
 		return !istable(v) or #v ~= 2
 	end

--- a/lua/entities/gmod_wire_expression2/core/custom/effects.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/effects.lua
@@ -38,11 +38,7 @@ end
 registerType("effect", "xef", nil,
 	nil,
 	nil,
-	function(retval)
-		if retval == nil then return end
-		local _type = type(retval)
-		if _type~="CEffectData" then error("Return value is neither nil nor a CEffectData, but a "..type(retval).."!",0) end
-	end,
+	nil,
 	function(v)
 		return type(v)~="CEffectData"
 	end

--- a/lua/entities/gmod_wire_expression2/core/damage.lua
+++ b/lua/entities/gmod_wire_expression2/core/damage.lua
@@ -4,11 +4,7 @@ local M_CTakeDamageInfo = FindMetaTable("CTakeDamageInfo")
 
 registerType("damage", "xdm", nil,
 	nil, nil,
-	function(retval)
-		if retval == nil then return end
-		if not istable(retval) then error("Return value is neither nil nor a table, but a " .. type(retval) .. "!",0) end
-		if getmetatable(retval) ~= M_CTakeDamageInfo then error("Return value is not a CTakeDamageInfo!", 0) end
-	end,
+	nil,
 	function(v)
 		return not istable(v) or getmetatable(v) ~= M_CTakeDamageInfo
 	end

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -252,52 +252,6 @@ function E2Lib.canModifyPlayer(self, ply)
 	return isOwner(self, vehicle)
 end
 
--- ------------------------ type guessing ------------------------------------------
-
-local type_lookup = {
-	number = "n",
-	string = "s",
-	Vector = "v",
-	PhysObj = "b",
-}
-local table_length_lookup = {
-	[2] = "xv2",
-	[3] = "v",
-	[4] = "xv4",
-	[9] = "m",
-	[16] = "xm4",
-}
-
-function E2Lib.guess_type(value)
-	local vtype = type(value)
-	if type_lookup[vtype] then return type_lookup[vtype] end
-	if IsValid(value) then return "e" end
-	if value.EntIndex then return "e" end
-	if vtype == "table" then
-		if table_length_lookup[#value] then return table_length_lookup[#value] end
-		if value.HitPos then return "xrd" end
-	end
-
-	for typeid, v in pairs(wire_expression_types2) do
-		if v[5] then
-			local ok = pcall(v[5], value)
-			if ok then return typeid end
-		end
-	end
-
-	-- TODO: more type guessing here
-
-	return "" -- empty string = unknown type, for now.
-end
-
--- Types that cannot possibly be guessed correctly:
--- angle (will be reported as vector)
--- matrix2 (will be reported as vector4)
--- wirelink (will be reported as entity)
--- complex (will be reported as vector2)
--- quaternion (will be reported as vector4)
--- all kinds of nil stuff
-
 -- ------------------------ list filtering -------------------------------------------------
 
 function E2Lib.filterList(list, criterion)

--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -1,11 +1,7 @@
 registerType("entity", "e", nil,
 	nil,
 	function(self,output) return output or NULL end,
-	function(retval)
-		if IsValid(retval) then return end
-		if retval == nil then return end
-		if not retval.EntIndex then error("Return value is neither nil nor an Entity, but a "..type(retval).."!",0) end
-	end,
+	nil,
 	function(v)
 		return not isentity(v)
 	end

--- a/lua/entities/gmod_wire_expression2/core/globalvars.lua
+++ b/lua/entities/gmod_wire_expression2/core/globalvars.lua
@@ -22,9 +22,7 @@ end)
 registerType( "gtable", "xgt", {},
 	function(self) self.entity:Error("You may not input a gtable.") end,
 	function(self) self.entity:Error("You may not output a gtable.") end,
-	function(retval)
-		if !istable(retval) then error("Return value is not a gtable, but a "..type(retval).."!",0) end
-	end,
+	nil,
 	function(v)
 		return !istable(v)
 	end

--- a/lua/entities/gmod_wire_expression2/core/matrix.lua
+++ b/lua/entities/gmod_wire_expression2/core/matrix.lua
@@ -23,10 +23,7 @@ registerType("matrix2", "xm2", { 0, 0,
 		return ret
 	end,
 	nil,
-	function(retval)
-		if !istable(retval) then error("Return value is not a table, but a "..type(retval).."!",0) end
-		if #retval ~= 4 then error("Return value does not have exactly 4 entries!",0) end
-	end,
+	nil,
 	function(v)
 		return !istable(v) or #v ~= 4
 	end
@@ -353,10 +350,7 @@ registerType("matrix", "m", { 0, 0, 0,
 		return ret
 	end,
 	nil,
-	function(retval)
-		if !istable(retval) then error("Return value is not a table, but a "..type(retval).."!",0) end
-		if #retval ~= 9 then error("Return value does not have exactly 9 entries!",0) end
-	end,
+	nil,
 	function(v)
 		return !istable(v) or #v ~= 9
 	end
@@ -878,10 +872,7 @@ registerType("matrix4", "xm4", { 0, 0, 0, 0,
 		return ret
 	end,
 	nil,
-	function(retval)
-		if !istable(retval) then error("Return value is not a table, but a "..type(retval).."!",0) end
-		if #retval ~= 16 then error("Return value does not have exactly 16 entries!",0) end
-	end,
+	nil,
 	function(v)
 		return !istable(v) or #v ~= 16
 	end

--- a/lua/entities/gmod_wire_expression2/core/number.lua
+++ b/lua/entities/gmod_wire_expression2/core/number.lua
@@ -34,11 +34,9 @@ local tanh   = math.tanh
 registerType("normal", "n", 0,
 	nil,
 	nil,
-	function(retval)
-		if !isnumber(retval) then error("Return value is not a number, but a "..type(retval).."!",0) end
-	end,
+	nil,
 	function(v)
-		return !isnumber(v)
+		return not isnumber(v)
 	end
 )
 

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -22,23 +22,16 @@ local M_CMoveData = FindMetaTable("CMoveData")
 
 registerType("usercmd", "xuc", nil,
 	nil, nil,
-	function(retval)
-		if retval == nil then return end
-		if not istable(retval) then error("Return value is neither nil nor a table, but a " .. type(retval) .. "!",0) end
-		if getmetatable(retval) ~= M_CUserCmd then error("Return value is not a CUserCmd!", 0) end
-	end,
+	nil,
 	function(v)
 		return not istable(v) or getmetatable(v) ~= M_CUserCmd
 	end
 )
 
 registerType("movedata", "xmv", nil,
-	nil, nil,
-	function(retval)
-		if retval == nil then return end
-		if not istable(retval) then error("Return value is neither nil nor a table, but a " .. type(retval) .. "!",0) end
-		if getmetatable(retval) ~= M_CMoveData then error("Return value is not a CMoveData!", 0) end
-	end,
+	nil,
+	nil,
+	nil,
 	function(v)
 		return not istable(v) or getmetatable(v) ~= M_CMoveData
 	end

--- a/lua/entities/gmod_wire_expression2/core/quaternion.lua
+++ b/lua/entities/gmod_wire_expression2/core/quaternion.lua
@@ -22,10 +22,7 @@ local rad2deg = 180/math.pi
 registerType("quaternion", "q", { 0, 0, 0, 0 },
 	nil,
 	nil,
-	function(retval)
-		if !istable(retval) then error("Return value is not a table, but a "..type(retval).."!",0) end
-		if #retval ~= 4 then error("Return value does not have exactly 4 entries!",0) end
-	end,
+	nil,
 	function(v)
 		return !istable(v) or #v ~= 4
 	end

--- a/lua/entities/gmod_wire_expression2/core/ranger.lua
+++ b/lua/entities/gmod_wire_expression2/core/ranger.lua
@@ -6,10 +6,7 @@
 registerType("ranger", "xrd", nil,
 	nil,
 	nil,
-	function(retval)
-		if retval == nil then return end
-		if !istable(retval) then error("Return value is neither nil nor a table, but a "..type(retval).."!",0) end
-	end,
+	nil,
 	function(v)
 		return !istable(v) or not v.HitPos
 	end

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -13,9 +13,7 @@ local string_Replace, string_Explode = string.Replace, string.Explode
 registerType("string", "s", "",
 	nil,
 	nil,
-	function(retval)
-		if not isstring(retval) then error("Return value is not a string, but a "..type(retval).."!",0) end
-	end,
+	nil,
 	function(v)
 		return not isstring(v)
 	end

--- a/lua/entities/gmod_wire_expression2/core/table.lua
+++ b/lua/entities/gmod_wire_expression2/core/table.lua
@@ -43,9 +43,7 @@ registerType("table", "t", newE2Table(),
 		return input
 	end,
 	nil,
-	function(retval)
-		if not istable(retval) then error("Return value is not a table, but a "..type(retval).."!", 0) end
-	end,
+	nil,
 	function(v)
 		return not istable(v)
 	end

--- a/lua/entities/gmod_wire_expression2/core/vector.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector.lua
@@ -45,10 +45,7 @@ local cubicBezier = math.CubicBezier
 registerType("vector", "v", Vector(0, 0, 0),
 	nil,
 	function(self, output) return Vector(output) end,
-	function(retval)
-		if isvector(retval) then return end
-		error("Return value is not a Vector, but a " .. type(retval) .. "!", 0)
-	end,
+	nil,
 	function(v)
 		return not isvector(v)
 	end

--- a/lua/entities/gmod_wire_expression2/core/vector2.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector2.lua
@@ -12,10 +12,7 @@ local pi = math.pi
 registerType("vector2", "xv2", { 0, 0 },
 	function(self, input) return { input[1], input[2] } end,
 	nil,
-	function(retval)
-		if !istable(retval) then error("Return value is not a table, but a "..type(retval).."!",0) end
-		if #retval ~= 2 then error("Return value does not have exactly 2 entries!",0) end
-	end,
+	nil,
 	function(v)
 		return !istable(v) or #v ~= 2
 	end
@@ -512,10 +509,7 @@ end
 registerType("vector4", "xv4", { 0, 0, 0, 0 },
 	function(self, input) return { input[1], input[2], input[3], input[4] } end,
 	nil,
-	function(retval)
-		if !istable(retval) then error("Return value is not a table, but a "..type(retval).."!",0) end
-		if #retval ~= 4 then error("Return value does not have exactly 4 entries!",0) end
-	end,
+	nil,
 	function(v)
 		return !istable(v) or #v ~= 4
 	end

--- a/lua/entities/gmod_wire_expression2/core/wirelink.lua
+++ b/lua/entities/gmod_wire_expression2/core/wirelink.lua
@@ -123,11 +123,7 @@ end
 registerType("wirelink", "xwl", nil,
 	nil,
 	nil,
-	function(retval)
-		if IsValid(retval) then return end
-		if retval == nil then return end
-		if not retval.EntIndex then error("Return value is neither nil nor an Entity (and thus not a wirelink), but a "..type(retval).."!",0) end
-	end,
+	nil,
 	function(v)
 		return not IsValid(v)
 	end

--- a/lua/wire/client/e2helper.lua
+++ b/lua/wire/client/e2helper.lua
@@ -314,8 +314,7 @@ function E2Helper.Update()
 	E2Helper.constants = {}
 	if E2Helper.CurrentMode == true then
 		for k, v in pairs(wire_expression2_constants) do
-			-- set the type according to the functions
-			local strType = E2Lib.guess_type(v)
+			local strType = isstring(v) and "s" or "n"
 
 			-- constants have no arguments and no cost
 			local name, args, rets, cost = k, nil, strType, 0


### PR DESCRIPTION
This removes
* `wire_expression2_debug` [reasoning here](https://github.com/wiremod/wire/discussions/2798)
* The pointless type_check / 5th field in `registerType`, since 6th field does the same but without throwing an error, and was only used by glon.
* GLON functions since the library hasn't existed in gmod for over a decade.

General decluttering.