### PR TITLE
Fix effect_blacklist circumvention in Effect core

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/effects.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/effects.lua
@@ -170,8 +170,10 @@ end
 e2function void effect:play(string name)
 	if not this then return self:throw("Invalid effect!", nil) end
 	if not isAllowed(self) then return self:throw("Effect play() burst limit reached!", nil) end
+
+	name = name:lower()
 	if effect_blacklist[name] then return self:throw("This effect is blacklisted!", nil) end
-	if hook.Run( "Expression2_CanEffect", name:lower(), self ) == false then return self:throw("A hook prevented this function from running", nil) end
+	if hook.Run( "Expression2_CanEffect", name, self ) == false then return self:throw("A hook prevented this function from running", nil) end
 
 	fire(self, this, name)
 end


### PR DESCRIPTION
Effects are case-insensitive, so we should lowercase them before we check the blacklist.

DoF isn't as big a deal now as it used to be, but we noticed this over in the Starfall repo while working in the same area and I figured I'd extend the fix over here too.

