### PR TITLE
Fix foreach ending on tables with type mismatch

### DIFF
--- a/data/expression2/tests/regressions/2803.txt
+++ b/data/expression2/tests/regressions/2803.txt
@@ -1,9 +1,24 @@
 ## SHOULD_PASS:EXECUTE
 
-local Ran = 0
+local TabMixedNonSeq = table(1 = 1, 2 = 2, 3 = 3, 10 = 10, 100 = 100, 2359 = 2359, # 6
+                             4 = "4", 5 = "5", 6 = "6", 11 = "11", 123 = "123", # 5
+                             "s" = "s", "foo" = "bar") # 2
 
-foreach(_:number, _:string = table( 123 = "foo" )) {
-	Ran = 1
+local TabMixedSeq = table(1 = 1, 2 = 2, 3 = 3, 7 = 7, 9 = 9, 11 = 11, # 6
+                          4 = "4", 5 = "5", 6 = "6", 8 = "8", 10 = "10", # 5
+                          "s" = "s", "foo" = "bar") # 2
+
+
+local I = 0
+foreach(_:number, _:number = TabMixedNonSeq) {
+    I = I + 1
 }
 
-assert(Ran)
+assert(I == 6)
+
+I = 0
+foreach(_:number, _:string = TabMixedSeq) {
+    I = I + 1
+}
+
+assert(I == 5)

--- a/lua/entities/gmod_wire_expression2/core/table.lua
+++ b/lua/entities/gmod_wire_expression2/core/table.lua
@@ -1162,17 +1162,19 @@ registerCallback( "postinit", function()
 
 		local next = next
 		local function itern(tbl, i)
-			local key, value = next(tbl.n, i)
-			if tbl.ntypes[key] == id then
-				return key, value
-			end
+			local value
+			repeat
+				i, value = next(tbl.n, i)
+			until tbl.ntypes[i] == id or value == nil
+			return i, value
 		end
 
 		local function iters(tbl, i)
-			local key, value = next(tbl.s, i)
-			if tbl.stypes[key] == id then
-				return key, value
-			end
+			local value
+			repeat
+				i, value = next(tbl.s, i)
+			until tbl.stypes[i] == id or value == nil
+			return i, value
 		end
 
 		registerOperator("iter", "s" .. id .. "=t", "", function(state, table)


### PR DESCRIPTION
Fixes #2803

This repeats the iter in a loop until a type match or nil.

This might be better as a fix in the rcompiler to run typecheck in the loop, so as to preserve the intent of `iter`. Unfortunately, despite my attempts, I can't find a way to safely put the responsibility on the compiler instead.

If I had the approval to change the signature of operator `iter` to include `type` at the end, it would be terribly easy to move into the compiler instead, however passing type is also a bit heavyhanded of an approach.