### PR TITLE
Allow foreach on 0-indexed arrays

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/array.lua
+++ b/lua/entities/gmod_wire_expression2/core/array.lua
@@ -237,8 +237,14 @@ registerCallback( "postinit", function()
 			end
 
 			registerOperator("iter", "n" .. id .. "=r", "", function(state, array)
-				return function()
-					return iter, array, 0
+				if array[0] then
+					return function()
+						return iter, array, -1
+					end
+				else
+					return function()
+						return iter, array, 0
+					end
 				end
 			end)
 


### PR DESCRIPTION
A small minority of E2 functions return 0-indexed arrays. This allows one to `foreach` over those arrays, which is at least a convenience improvement over a for loop.

Modifies iter operator to return `-1` as its third argument if an array has an element at 0.

<details><summary>Test code</summary>
<p>

```ruby
Arr = array(1, 2, 3, 4, 5, 6)
Arr[0, number] = 0

Str = array()
foreach(K:number, V:number = Arr)
{
    Str:pushString(format("%d : %d", K, V))
}

print(Str:concat("\n"))
```

</p>
</details>