### PR TITLE
Fix gmod_wire_interactiveprop net errors

### DIFF
--- a/lua/entities/gmod_wire_interactiveprop.lua
+++ b/lua/entities/gmod_wire_interactiveprop.lua
@@ -415,7 +415,7 @@ end
 util.AddNetworkString("wire_interactiveprop_action")
 net.Receive("wire_interactiveprop_action",function(len,ply)
 	local ent = net.ReadEntity()
-	if not IsValid( ent ) or ent:GetClass() ~= "gmod_wire_interactiveprop" or ply ~= ent.User then return end
+	if not ent:IsValid() or ent:GetClass() ~= "gmod_wire_interactiveprop" or ply ~= ent.User then return end
 
 	ent:ReceiveData()
 	ent:UpdateOverlay()
@@ -451,7 +451,7 @@ end
 util.AddNetworkString("wire_interactiveprop_close")
 net.Receive("wire_interactiveprop_close",function(len,ply)
     local ent = net.ReadEntity()
-    if not IsValid( ent ) or ent:GetClass() ~= "gmod_wire_interactiveprop" then return end
+    if not ent:IsValid() or ent:GetClass() ~= "gmod_wire_interactiveprop" then return end
     ent:Unprompt()
 end)
 

--- a/lua/entities/gmod_wire_interactiveprop.lua
+++ b/lua/entities/gmod_wire_interactiveprop.lua
@@ -345,7 +345,6 @@ if CLIENT then
 	end)
 
 	return
-
 end
 
 function ENT:InitData()
@@ -451,13 +450,12 @@ end
 util.AddNetworkString("wire_interactiveprop_close")
 net.Receive("wire_interactiveprop_close",function(len,ply)
     local ent = net.ReadEntity()
-    if not ent:IsValid() or ent:GetClass() ~= "gmod_wire_interactiveprop" then return end
+    if not ent:IsValid() or ent:GetClass() ~= "gmod_wire_interactiveprop" or ply ~= ent.User then return end
     ent:Unprompt()
 end)
 
 util.AddNetworkString("wire_interactiveprop_kick")
 function ENT:Unprompt()
-
 	self.User = nil
 	self:UpdateOverlay()
 end

--- a/lua/entities/gmod_wire_interactiveprop.lua
+++ b/lua/entities/gmod_wire_interactiveprop.lua
@@ -414,13 +414,11 @@ end
 ----------------------------------------------------
 util.AddNetworkString("wire_interactiveprop_action")
 net.Receive("wire_interactiveprop_action",function(len,ply)
-	self = net.ReadEntity()
-	if not IsValid( self ) or not IsValid( ply ) or ply ~= self.User then return end
+	local ent = net.ReadEntity()
+	if not IsValid( ent ) or ent:GetClass() ~= "gmod_wire_interactiveprop" or ply ~= ent.User then return end
 
-	self:ReceiveData()
-
-
-	self:UpdateOverlay()
+	ent:ReceiveData()
+	ent:UpdateOverlay()
 end)
 
 ----------------------------------------------------

--- a/lua/entities/gmod_wire_interactiveprop.lua
+++ b/lua/entities/gmod_wire_interactiveprop.lua
@@ -452,8 +452,9 @@ end
 
 util.AddNetworkString("wire_interactiveprop_close")
 net.Receive("wire_interactiveprop_close",function(len,ply)
-local self = net.ReadEntity()
-self:Unprompt()
+    local ent = net.ReadEntity()
+    if not IsValid( ent ) or ent:GetClass() ~= "gmod_wire_interactiveprop" then return end
+    ent:Unprompt()
 end)
 
 util.AddNetworkString("wire_interactiveprop_kick")


### PR DESCRIPTION
Fixes cases where gmod_wire_interactiveprop can receive NULL or wrong entities and cause errors.