### PR TITLE
Add selfaware functions for E2 extensions

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/selfaware.lua
+++ b/lua/entities/gmod_wire_expression2/core/selfaware.lua
@@ -211,20 +211,31 @@ local e2Extensions
 local e2ExtensionsTable
 -- See postinit for these getting initialized
 
+__e2setcost(30)
+
 [nodiscard]
 e2function array getExtensions()
 	local ret = {}
-	for k, v in ipairs(e2Extensions) do -- Optimized shallow copy
+	for k, v in ipairs(e2Extensions) do -- Optimized copy
 		ret[k] = v
 	end
 	return ret
 end
 
-__e2setcost(10)
+__e2setcost(60)
 
 [nodiscard]
 e2function table getExtensionStatus()
-	return table.Copy(e2ExtensionsTable)
+	local ret = E2Lib.newE2Table()
+	local s, stypes = ret.s, ret.stypes
+	ret.size = e2ExtensionsTable.size
+
+	for k, v in pairs(e2ExtensionsTable.s) do
+		s[k] = v
+		stypes[k] = "n"
+	end
+
+	return ret
 end
 
 __e2setcost(5)

--- a/lua/entities/gmod_wire_expression2/core/selfaware.lua
+++ b/lua/entities/gmod_wire_expression2/core/selfaware.lua
@@ -203,6 +203,34 @@ e2function number entity:canSetName(string name)
 	return IsValid(this) and isOwner(self, this) and canSetName(self, this, name) and 1 or 0
 end
 
+--[[******************************************************************************]]--
+-- Extensions
+
+[nodiscard]
+e2function array getExtensions()
+	return table.Copy(E2Lib.GetExtensions())
+end
+
+local getExtensionStatus = E2Lib.GetExtensionStatus
+[nodiscard]
+e2function table getExtensionStatus()
+	local ret = E2Lib.newE2Table()
+	local s, stypes, size = ret.s, ret.stypes, ret.size
+	for _, ext in ipairs(E2Lib.GetExtensions()) do
+		s[ext] = getExtensionStatus(ext) and 1 or 0
+		stypes[ext] = "n"
+		size = size + 1
+	end
+	ret.s, ret.stypes, ret.size = s, stypes, size -- Do this just because I'm paranoid
+
+	return ret
+end
+
+[nodiscard]
+e2function number getExtensionStatus(string extension)
+	return getExtensionStatus(extension) and 1 or 0
+end
+
 
 --[[******************************************************************************]]--
 

--- a/lua/entities/gmod_wire_expression2/core/selfaware.lua
+++ b/lua/entities/gmod_wire_expression2/core/selfaware.lua
@@ -206,25 +206,28 @@ end
 --[[******************************************************************************]]--
 -- Extensions
 
+local getExtensionStatus = E2Lib.GetExtensionStatus
+local e2Extensions
+local e2ExtensionsTable
+-- See postinit for these getting initialized
+
 [nodiscard]
 e2function array getExtensions()
-	return table.Copy(E2Lib.GetExtensions())
-end
-
-local getExtensionStatus = E2Lib.GetExtensionStatus
-[nodiscard]
-e2function table getExtensionStatus()
-	local ret = E2Lib.newE2Table()
-	local s, stypes, size = ret.s, ret.stypes, ret.size
-	for _, ext in ipairs(E2Lib.GetExtensions()) do
-		s[ext] = getExtensionStatus(ext) and 1 or 0
-		stypes[ext] = "n"
-		size = size + 1
+	local ret = {}
+	for k, v in ipairs(e2Extensions) do -- Optimized shallow copy
+		ret[k] = v
 	end
-	ret.s, ret.stypes, ret.size = s, stypes, size -- Do this just because I'm paranoid
-
 	return ret
 end
+
+__e2setcost(10)
+
+[nodiscard]
+e2function table getExtensionStatus()
+	return table.Copy(e2ExtensionsTable)
+end
+
+__e2setcost(5)
 
 [nodiscard]
 e2function number getExtensionStatus(string extension)
@@ -314,6 +317,18 @@ registerCallback("postinit", function()
 				registerFunction("changed", typeid, "n", registeredfunctions.e2_changed_xv4, 5, nil, { legacy = false })
 			end
 		end
+	end
+
+	e2Extensions = E2Lib.GetExtensions()
+	e2ExtensionsTable = E2Lib.newE2Table()
+	do
+		local s, stypes, size = e2ExtensionsTable.s, e2ExtensionsTable.stypes, 0
+		for _, ext in ipairs(e2Extensions) do
+			s[ext] = getExtensionStatus(ext) and 1 or 0
+			stypes[ext] = "n"
+			size = size + 1
+		end
+		e2ExtensionsTable.size = size
 	end
 end)
 

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -898,6 +898,9 @@ E2Helper.Descriptions["ioOutputEntities(s)"] = "Returns an array of all entities
 E2Helper.Descriptions["runOnLast(n)"] = "If set to 1, the chip will run once when it is removed, setting the last() flag when it does"
 E2Helper.Descriptions["selfDestruct()"] = "Removes the expression"
 E2Helper.Descriptions["selfDestructAll()"] = "Removes the expression and all constrained props"
+E2Helper.Descriptions["getExtensions()"] = "Returns an array of all the extensions that the server has. This includes disabled extensions!"
+E2Helper.Descriptions["getExtensionStatus()"] = "Returns a table of extension names with their statuses"
+E2Helper.Descriptions["getExtensionStatus(s)"] = "Returns 1 if the extension is enabled, otherwise 0"
 
 -- Debug
 E2Helper.Descriptions["playerCanPrint()"] = "Returns whether or not the next print-message will be printed or omitted by antispam"


### PR DESCRIPTION
Allows users to see the status of extensions on the server. This is like a dynamic form of `#ifdef`.

This idea came to me because I am trying to write a dependency checker that communicates to the player whether a chip with multiple dependencies will function properly or not.