### PR TITLE
Add `let` keyword as an alternative to `local`

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -359,7 +359,7 @@ function Parser:Stmt()
 		return Node.new(NodeVariant.Const, { name, value }, trace:stitch(self:Prev().trace))
 	end
 
-	local is_local, var = self:Consume(TokenVariant.Keyword, Keyword.Local), self:Consume(TokenVariant.Ident)
+	local is_local, var = self:Consume(TokenVariant.Keyword, Keyword.Local) or self:Consume(TokenVariant.Keyword, Keyword.Let), self:Consume(TokenVariant.Ident)
 	if not var then
 		self:Assert(not is_local, "Invalid operator (local) must be used for variable declaration.")
 	else

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -374,38 +374,40 @@ local Keyword = {
 	Else = 3,
 	-- ``local``
 	Local = 4,
+	-- ``let``
+	Let = 5,
 	-- ``const``
-	Const = 5,
+	Const = 6,
 	-- ``while``
-	While = 6,
+	While = 7,
 	-- ``for``
-	For = 7,
+	For = 8,
 	-- ``break``
-	Break = 8,
+	Break = 9,
 	-- ``continue``
-	Continue = 9,
+	Continue = 10,
 	-- ``switch``
-	Switch = 10,
+	Switch = 11,
 	-- ``case``
-	Case = 11,
+	Case = 12,
 	-- ``default``
-	Default = 12,
+	Default = 13,
 	-- ``foreach``
-	Foreach = 13,
+	Foreach = 14,
 	-- ``function``
-	Function = 14,
+	Function = 15,
 	-- ``return``
-	Return = 15,
+	Return = 16,
 	-- ``#include``
-	["#Include"] = 16,
+	["#Include"] = 17,
 	-- ``try``
-	Try = 17,
+	Try = 18,
 	-- ``catch``
-	Catch = 18,
+	Catch = 19,
 	-- ``do``
-	Do = 19,
+	Do = 20,
 	-- ``event``
-	Event = 20
+	Event = 21
 }
 
 E2Lib.Keyword = Keyword

--- a/lua/wire/client/text_editor/modes/e2.lua
+++ b/lua/wire/client/text_editor/modes/e2.lua
@@ -29,6 +29,7 @@ local keywords = {
 	["function"] = { [true] = true },
 	["return"] = { [true] = true },
 	["local"]  = { [true] = true },
+	["let"] = { [true] = true },
 	["const"] = { [true] = true },
 	["try"]    = { [true] = true },
 	["do"] = { [true] = true },


### PR DESCRIPTION
Addresses https://github.com/wiremod/wire/discussions/2831

Doesn't deprecate `local` or anything. Maybe in the future