### PR TITLE
EGP Patches

### DIFF
--- a/lua/entities/gmod_wire_egp/lib/egplib/parenting.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/parenting.lua
@@ -112,7 +112,7 @@ local function GetGlobalPos(self, Ent, index)
 				return obj.verticesindex ~= nil, { x = vec.x, y = vec.y, angle = -ang.y }
 			else
 				local _, data = GetGlobalPos(Ent, select(3, EGP:HasObject(Ent, obj.parent)))
-				local vec, ang = LocalToWorld(Vector(obj._x, obj._y, 0), Angle(0, -obj._angle or 0, 0), Vector(data.x, data.y, 0), Angle(0, -data.angle or 0, 0))
+				local vec, ang = LocalToWorld(Vector(obj._x, obj._y, 0), Angle(0, -(obj._angle or 0), 0), Vector(data.x, data.y, 0), Angle(0, -(data.angle or 0), 0))
 				return obj.verticesindex ~= nil, { x = vec.x, y = vec.y, angle = -ang.y }
 			end
 		end

--- a/lua/entities/gmod_wire_egp/lib/objects/poly.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/poly.lua
@@ -119,13 +119,12 @@ function Obj:SetPos(x, y, angle)
 	if not angle then angle = sa else angle = angle % 360 end
 	if sx == x and sy == y and sa == angle then return false end
 
-	for i, v in ipairs(self.vertices) do
+	for _, v in ipairs(self.vertices) do
 		local vec = LocalToWorld(Vector(v.x - sx, v.y - sy, 0), angle_zero, Vector(x, y, 0), Angle(0, sa - angle, 0))
 		v.x = vec.x
 		v.y = vec.y
 	end
 	self.x, self.y, self.angle = x, y, angle
-	if self._x then self._x, self._y, self._angle = x, y, angle end
 	return true
 end
 

--- a/lua/entities/gmod_wire_egp_hud/huddraw.lua
+++ b/lua/entities/gmod_wire_egp_hud/huddraw.lua
@@ -177,7 +177,9 @@ else -- SERVER
 		end
 	end
 
-	net.Receive("EGP_HUD_Unlink", function(len, ply)
+	util.AddNetworkString("EGP_HUD_Unlink")
+
+	net.Receive("EGP_HUD_Unlink", function(_, ply)
 		unlinkUser(ply)
 	end)
 


### PR DESCRIPTION
Fixes bad global position with parented polys.
Fixes error on `GetGlobalPos` with objects that don't have angles.
Fixes error on `wire_egp_hud_unlink`.