### PR TITLE
Update CanTopLeft for certain EGP Objects

### DIFF
--- a/lua/entities/gmod_wire_egp/lib/objects/circle.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/circle.lua
@@ -2,6 +2,7 @@
 local Obj = EGP.ObjectInherit("Circle", "Box")
 Obj.angle = 0
 Obj.fidelity = 180
+Obj.CanTopLeft = nil
 
 local base = Obj.BaseClass
 

--- a/lua/entities/gmod_wire_egp/lib/objects/textlayout.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/textlayout.lua
@@ -2,6 +2,7 @@
 local Obj = EGP.ObjectInherit("TextLayout", "Text")
 Obj.h = 512
 Obj.w = 512
+Obj.CanTopLeft = true
 
 local base = Obj.BaseClass
 


### PR DESCRIPTION
Disables it on Circle, enables it on TextLayout.

Circles were not meant to be TopLeft. TextLayouts are boxes so they're fine, though.