### PR TITLE
Make setname play nicely with E2 timers

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/selfaware.lua
+++ b/lua/entities/gmod_wire_expression2/core/selfaware.lua
@@ -93,7 +93,7 @@ end)
 --[[******************************************************************************]]--
 -- Name functions
 
-
+local SHORT_SECOND = 1 - engine.TickInterval()
 local function doSetName(self, this, name)
 	local data_SetName = self.data.SetName
 	if not data_SetName then
@@ -109,7 +109,7 @@ local function doSetName(self, this, name)
 	if totalChars >= 512 then return self:throw("You are sending too much data with setName!") end
 	data_SetName._chars = totalChars
 
-	timer.Create("wire_doSetName_Cleanup" .. self.entity:EntIndex(), 1, 1, function()
+	timer.Create("wire_doSetName_Cleanup" .. self.entity:EntIndex(), SHORT_SECOND, 1, function()
 		if self and self.data then self.data.SetName = nil end
 	end)
 

--- a/lua/entities/gmod_wire_expression2/core/selfaware.lua
+++ b/lua/entities/gmod_wire_expression2/core/selfaware.lua
@@ -93,7 +93,6 @@ end)
 --[[******************************************************************************]]--
 -- Name functions
 
-local SHORT_SECOND = 1 - engine.TickInterval()
 local function doSetName(self, this, name)
 	local data_SetName = self.data.SetName
 	if not data_SetName then
@@ -109,7 +108,7 @@ local function doSetName(self, this, name)
 	if totalChars >= 512 then return self:throw("You are sending too much data with setName!") end
 	data_SetName._chars = totalChars
 
-	timer.Create("wire_doSetName_Cleanup" .. self.entity:EntIndex(), SHORT_SECOND, 1, function()
+	timer.Create("wire_doSetName_Cleanup" .. self.entity:EntIndex(), 1 - engine.TickInterval(), 1, function()
 		if self and self.data then self.data.SetName = nil end
 	end)
 


### PR DESCRIPTION
Makes GC timer execute a tick before a second, so now they're a tick faster but they should respect `timer(1000)`.