### PR TITLE
Improve E2 Constants

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -100,7 +100,8 @@ local NodeVariant = {
 	ExprTable = 35, -- `table(1, 2, 3)` or `table(1 = 2, "test" = 3)`
 	ExprFunction = 36, -- `function() {}`
 	ExprLiteral = 37, -- `"test"` `5e2` `4.023` `4j`
-	ExprIdent = 38 -- `Variable`
+	ExprIdent = 38, -- `Variable`
+	ExprConstant = 39, -- `_FOO`
 }
 
 Parser.Variant = NodeVariant
@@ -1000,6 +1001,11 @@ function Parser:Expr15()
 	local ident =  self:Consume(TokenVariant.Ident)
 	if ident then
 		return Node.new(NodeVariant.ExprIdent, ident, ident.trace)
+	end
+
+	local constant = self:Consume(TokenVariant.Constant)
+	if constant then
+		return Node.new(NodeVariant.ExprConstant, constant, constant.trace)
 	end
 
 	-- Error Messages

--- a/lua/entities/gmod_wire_expression2/base/tokenizer.lua
+++ b/lua/entities/gmod_wire_expression2/base/tokenizer.lua
@@ -276,16 +276,7 @@ function Tokenizer:Next()
 
 	match = self:ConsumePattern("^_[A-Z0-9_]+")
 	if match then
-		-- Constant value
-		local value = wire_expression2_constants[match]
-
-		if type(value) == "number" then
-			return Token.new(TokenVariant.Decimal, value)
-		elseif type(value) == "string" then
-			return Token.new(TokenVariant.String, value)
-		else
-			return self:Error("Constant (" .. match .. ") has invalid data type (" .. type(value) .. ")")
-		end
+		return Token.new(TokenVariant.Constant, match)
 	end
 
 	if self:ConsumePattern("^_") then

--- a/lua/entities/gmod_wire_expression2/core/init.lua
+++ b/lua/entities/gmod_wire_expression2/core/init.lua
@@ -174,13 +174,46 @@ function registerFunction(name, pars, rets, func, cost, argnames, attributes)
 	wire_expression2_funclist[name] = true
 end
 
-function E2Lib.registerConstant(name, value)
+---@alias E2Constant string | number | E2Constant[]
+
+local TypeMap = {
+	["number"] = "n", ["string"] = "s",
+	["Vector"] = "v", ["Angle"] = "a",
+	["table"] = "r"
+}
+
+local ValidArrayTypes = {
+	["number"] = true, ["string"] = true,
+	["Vector"] = true, ["Angle"] = true
+}
+
+---@param value E2Constant
+---@param description string?
+function E2Lib.registerConstant(name, value, description)
 	if name:sub(1, 1) ~= "_" then name = "_" .. name end
 
 	local ty = type(value)
-	assert(ty == "number" or ty == "string", "Invalid value passed to registerConstant (must be number or string)")
+	local e2ty = TypeMap[ty]
 
-	wire_expression2_constants[name] = value
+	if e2ty then
+		if ty == "table" then -- ensure it's actually an array (sequential and valid types)
+			local i = 1
+			for _, val in pairs(value) do
+				assert(value[i] ~= nil, "Invalid array passed to registerConstant (must be sequential)")
+				assert(ValidArrayTypes[type(val)], "Invalid array passed to registerConstant (must only contain numbers, strings, vector or angles)")
+				i = i + 1
+			end
+		end
+
+		wire_expression2_constants[name] = {
+			value = value,
+			type = e2ty,
+			description = description,
+			extension = E2Lib.currentextension
+		}
+	else
+		error("Invalid value passed to registerConstant. Only numbers, strings, vectors, angles and arrays can be constant values.")
+	end
 end
 
 --- Example:

--- a/lua/entities/gmod_wire_expression2/core/vector.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector.lua
@@ -52,6 +52,7 @@ registerType("vector", "v", Vector(0, 0, 0),
 )
 
 E2Lib.registerConstant("VECTOR_ORIGIN", Vector(0, 0, 0), "Origin of the map. This is vec(0, 0, 0)")
+E2Lib.registerConstant("VECTOR_UP", Vector(0, 0, 1), "Upward direction. This is vec(0, 0, 1)")
 
 --------------------------------------------------------------------------------
 

--- a/lua/entities/gmod_wire_expression2/core/vector.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector.lua
@@ -51,6 +51,8 @@ registerType("vector", "v", Vector(0, 0, 0),
 	end
 )
 
+E2Lib.registerConstant("VECTOR_ORIGIN", Vector(0, 0, 0), "Origin of the map. This is vec(0, 0, 0)")
+
 --------------------------------------------------------------------------------
 
 __e2setcost(1) -- approximated

--- a/lua/wire/client/e2helper.lua
+++ b/lua/wire/client/e2helper.lua
@@ -152,12 +152,17 @@ function E2Helper.Create(reset)
 		self:ClearSelection()
 		self:SelectItem(line)
 
-		-- don't try describing the function when it is actually a constant
-		if E2Helper.constants[line] then
-			E2Helper.FuncEntry:SetText("Constant value")
+		local const = E2Helper.constants[line]
+		if const then
+			E2Helper.FuncEntry:SetText(line:GetValue(1) .. " (" .. const.type .. ")")
 
-			E2Helper.DescriptionEntry:SetText("Constants do not support descriptions (yet)")
-			E2Helper.DescriptionEntry:SetTextColor(Color(128, 128, 128))
+			if const.description then
+				E2Helper.DescriptionEntry:SetText(const.description)
+				E2Helper.DescriptionEntry:SetTextColor(Color(0, 0, 0))
+			else
+				E2Helper.DescriptionEntry:SetText("No description found :(")
+				E2Helper.DescriptionEntry:SetTextColor(Color(128, 128, 128))
+			end
 		else
 			E2Helper.FuncEntry:SetText(E2Helper.GetFunctionSyntax(line:GetValue(1), line:GetValue(3), line:GetValue(4)))
 			local desc = getdesc(line:GetValue(1), line:GetValue(3))
@@ -314,13 +319,11 @@ function E2Helper.Update()
 	E2Helper.constants = {}
 	if E2Helper.CurrentMode == true then
 		for k, v in pairs(wire_expression2_constants) do
-			local strType = isstring(v) and "s" or "n"
-
 			-- constants have no arguments and no cost
-			local name, args, rets, cost = k, nil, strType, 0
+			local name, args, rets, cost = k, nil, v.type, 0
 			if name:lower():find(search_name, 1, true) and search_args == "" and rets:lower():find(search_rets, 1, true) and string.find("constants",search_from, 1, true) then
-				local line = E2Helper.ResultFrame:AddLine(name, "constants", args, rets, cost)
-				E2Helper.constants[line] = true
+				local line = E2Helper.ResultFrame:AddLine(name, v.extension, args, rets, cost)
+				E2Helper.constants[line] = v
 				count = count + 1
 				if count >= maxcount then break end
 			end

--- a/lua/wire/client/text_editor/modes/e2.lua
+++ b/lua/wire/client/text_editor/modes/e2.lua
@@ -551,7 +551,7 @@ function EDITOR:SyntaxColorLine(row)
 		-- eat next token
 		if self:NextPattern("^_[A-Z][A-Z_0-9]*") then
 			local word = self.tokendata
-			for k,_ in pairs( wire_expression2_constants ) do
+			for k in pairs( wire_expression2_constants ) do
 				if k == word then
 					tokenname = "constant"
 				end

--- a/lua/wire/client/text_editor/texteditor.lua
+++ b/lua/wire/client/text_editor/texteditor.lua
@@ -2122,7 +2122,7 @@ local function FindConstants( self, word )
 
 	local suggestions = {}
 
-	for name, _ in pairs( wire_expression2_constants ) do
+	for name in pairs( wire_expression2_constants ) do
 		if name:sub(1,len) == wordu then
 			count = count + 1
 			suggestions[count] = GetTableForConstant( name )


### PR DESCRIPTION
* Moved constant handling from tokenizer to compiler
* Constants can now be these types: `array` `vector` `angle` `string` `number` (rather than just number and string)
* Constants have descriptions in the E2Helper
* Constants have `extension` filled in the E2Helper
* Added `_VECTOR_ORIGIN`

`E2Lib.registerConstant` now takes a third optional parameter for the description of the constant for the E2Helper.

Note that arrays can only accept other `vector`/`angle`/`string`/`number`.

## How it works

Basically

```ts
print(_VECTOR_ORIGIN)
```

Is the same as
```ts
print(vec(0, 0, 0))
```

This is also how it worked previously except it only accepted numbers and strings.

## RFC

Any other constants to be added?