### PR TITLE
Embed commit hash in Workshop uploads

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -11,6 +11,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@master
+
+      - name: Embed version
+        run: |
+          echo ${GITHUB_SHA:0:7} > lua/wire/version.lua
+
       - uses: wiremod/gmod-upload@master
         with:
           id: 3066780663

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Embed version
         run: |
-          echo ${GITHUB_SHA:0:7} > lua/wire/version.lua
+          echo " cachedversion = \"Canary ${GITHUB_SHA:0:7}\"" >> lua/wire/server/wirelib.lua
 
       - uses: wiremod/gmod-upload@master
         with:

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Embed version
         run: |
-          echo -e "\ncachedversion = \"Workshop ${GITHUB_SHA:0:7}\"" >> lua/wire/server/wirelib.lua
+          echo -e "\ncachedversion = \"Canary ${GITHUB_SHA:0:7}\"" >> lua/wire/server/wirelib.lua
 
       - uses: wiremod/gmod-upload@master
         with:

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Embed version
         run: |
-          echo " cachedversion = \"Canary ${GITHUB_SHA:0:7}\"" >> lua/wire/server/wirelib.lua
+          echo -e "\ncachedversion = \"Workshop ${GITHUB_SHA:0:7}\"" >> lua/wire/server/wirelib.lua
 
       - uses: wiremod/gmod-upload@master
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
 
       - name: Embed version
         run: |
-          echo ${GITHUB_SHA:0:7} > lua/wire/version.lua
+          echo " cachedversion = \"Workshop ${GITHUB_SHA:0:7}\"" >> lua/wire/server/wirelib.lua
 
       - uses: wiremod/gmod-upload@master
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
 
       - name: Embed version
         run: |
-          echo " cachedversion = \"Workshop ${GITHUB_SHA:0:7}\"" >> lua/wire/server/wirelib.lua
+          echo -e "\ncachedversion = \"Workshop ${GITHUB_SHA:0:7}\"" >> lua/wire/server/wirelib.lua
 
       - uses: wiremod/gmod-upload@master
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: wiremod/gmod-upload@master
         with:
           id: 160250458
-          changelog: "Deployment via Github to commit ${GITUB_SHA:0:7}"
+          changelog: "Deployment via Github to commit ${GITHUB_SHA:0:7}"
         env:
           STEAM_USERNAME: ${{ secrets.WIRETEAM_WORKSHOP_USERNAME }}
           STEAM_PASSWORD: ${{ secrets.WIRETEAM_WORKSHOP_PASSWORD }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,10 +9,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@master
+
+      - name: Embed version
+        run: |
+          echo ${GITHUB_SHA:0:7} > lua/wire/version.lua
+
       - uses: wiremod/gmod-upload@master
         with:
           id: 160250458
-          changelog: "Deployment via Github to latest changes"
+          changelog: "Deployment via Github to commit ${GITUB_SHA:0:7}"
         env:
           STEAM_USERNAME: ${{ secrets.WIRETEAM_WORKSHOP_USERNAME }}
           STEAM_PASSWORD: ${{ secrets.WIRETEAM_WORKSHOP_PASSWORD }}

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1223,12 +1223,6 @@ function WireLib.GetVersion()
 		end
 	end
 
-	local ws_version = file.Read("wire/version.lua", "LUA")
-	if ws_version then
-		cachedversion = "Workshop " .. ws_version
-		return cachedversion
-	end
-
 	if not cachedversion then cachedversion = "Unknown" end
 
 	return cachedversion

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1223,12 +1223,10 @@ function WireLib.GetVersion()
 		end
 	end
 
-	-- Check if we're Workshop version first
-	for k, addon in pairs(engine.GetAddons()) do
-		if addon.wsid == "160250458" then
-			cachedversion = "Workshop"
-			return cachedversion
-		end
+	local ws_version = file.Read("wire/version.lua", "LUA")
+	if ws_version then
+		cachedversion = "Workshop " .. ws_version
+		return cachedversion
 	end
 
 	if not cachedversion then cachedversion = "Unknown" end


### PR DESCRIPTION
Workshop users (Canary and main) now should be capable of seeing the commit hash with wireversion.