### PR TITLE
Blind fix of delta operator

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -846,6 +846,10 @@ local CompileVisitors = {
 		if not include[2] then
 			include[2] = true -- Prevent self-compiling infinite loop
 
+			for var in pairs(include[3]) do -- add dvars from include
+				self.delta_vars[var] = true
+			end
+
 			local last_file = self.include
 			self.include = data
 			self.warnings[data] = self.warnings[data] or {}
@@ -1544,7 +1548,6 @@ local CompileVisitors = {
 		if data[1] == Operator.Dlt then -- $
 			self:Warning("Delta operator ($) is deprecated. Recommended to handle variable differences yourself.", trace)
 			self:Assert(var.depth == 0, "Delta operator ($) can not be used on temporary variables", trace)
-			self.delta_vars[var_name] = true
 
 			local sub_op, sub_ty = self:GetOperator("sub", { var.type, var.type }, trace)
 			return function(state) ---@param state RuntimeContext

--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -974,7 +974,11 @@ function Parser:Expr15()
 				else
 					self:Error("Operator (" .. v[1] .. ") must be followed by variable")
 				end
-			end ---@cast ident Token # Know it isn't nil from above check
+			end ---@cast ident Token
+
+			if v[2] == Operator.Dlt then -- TODO: Delete this and move to analyzer step
+				self.delta_vars[ident.value] = true
+			end
 
 			return Node.new(NodeVariant.ExprUnaryWire, { v[2], ident }, op.trace:stitch(ident.trace))
 		end

--- a/lua/entities/gmod_wire_expression2/cl_init.lua
+++ b/lua/entities/gmod_wire_expression2/cl_init.lua
@@ -5,7 +5,7 @@ local Trace, Error = E2Lib.Debug.Trace, E2Lib.Debug.Error
 ---@param e2 string
 ---@param directives PPDirectives
 ---@param includes table<string, string>
----@param scripts table<string, Node>
+---@param scripts table<string, { [1]: Node, [2]: boolean?, [3]: table<string, boolean> }>
 ---@return Error[]?
 local function Include(e2, directives, includes, scripts)
 	if scripts[e2] then
@@ -37,7 +37,7 @@ local function Include(e2, directives, includes, scripts)
 
 	includes[e2] = code
 
-	scripts[e2] = { tree }
+	scripts[e2] = { tree, nil, dvars }
 
 	for i, file in ipairs(files) do
 		local ierrors = Include(file, directives, includes, scripts)

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -384,7 +384,7 @@ function ENT:PrepareIncludes(files)
 			return
 		end
 
-		self.includes[file] = { tree }
+		self.includes[file] = { tree, nil, dvars }
 	end
 
 	return true


### PR DESCRIPTION
* Fixed oversight with delta as I was trying to move the functionality from the parser to the compiler, which made using a delta variable before the compiler saw the `$` operator being used treat it as a normal variable.
* Fixed delta variables across includes which wouldn't be tagged as delta variables (I think this might've been an issue even before the compiler rewrite, I just happened to think of it.)

```golo
#include "Include_me"

Var = 0

printDelta()
```

```golo
@name Include me
@persist Var

Var = 5

function printDelta() {
    print($Var)    
}
```

So this code doesn't error now.

@CheezusChrust