### PR TITLE
Change preprocessor duplicate error to warning

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/preprocessor.lua
+++ b/lua/entities/gmod_wire_expression2/base/preprocessor.lua
@@ -200,7 +200,11 @@ local function handleIO(name)
 
 		for i, key in ipairs(retval[1]) do
 			if ports[3][key] then
-				self:Warning("Directive (@" .. name .. ") contains multiple definitions of the same variable", columns[i])
+				if ports[3][key] ~= retval[2][i] then
+					self:Error("Directive (@" .. name .. ") contains multiple definitions of the same variable with differing types", columns[i])
+				else
+					self:Warning("Directive (@" .. name .. ") contains multiple definitions of the same variable", columns[i])
+				end
 			else
 				local index = #ports[1] + 1
 				ports[1][index] = key -- Index: Name

--- a/lua/entities/gmod_wire_expression2/base/preprocessor.lua
+++ b/lua/entities/gmod_wire_expression2/base/preprocessor.lua
@@ -200,7 +200,7 @@ local function handleIO(name)
 
 		for i, key in ipairs(retval[1]) do
 			if ports[3][key] then
-				self:Error("Directive (@" .. name .. ") contains multiple definitions of the same variable", columns[i])
+				self:Warning("Directive (@" .. name .. ") contains multiple definitions of the same variable", columns[i])
 			else
 				local index = #ports[1] + 1
 				ports[1][index] = key -- Index: Name


### PR DESCRIPTION
Fixes #2839

Since `@persist` is being phased out, this is not really that important.
But I see nothing wrong with this being implemented

Either way, a proper module system with exports won't exist for a long while

@shadowscion 