### PR TITLE
Naive fix for TextLayout TopLeft

### DIFF
--- a/lua/entities/gmod_wire_egp/lib/objects/textlayout.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/textlayout.lua
@@ -45,18 +45,21 @@ function Obj:Draw(ent, drawMat)
 
 		if (not self.layouter) then self.layouter = MakeTextScreenLayouter() end
 
+		local w, h = self.w, self.h
+		local x, y = self.x - w / 2, self.y - h / 2
+
 		if self.angle == 0 then
-			self.layouter:DrawText(self.text, self.x, self.y, self.w, self.h, self.halign, self.valign)
+			self.layouter:DrawText(self.text, x, y, w, h, self.halign, self.valign)
 		else
 			mat:Set(drawMat)
 
-			mat:Translate(Vector(self.x, self.y, 0))
+			mat:Translate(Vector(x, y, 0))
 
 			matAng.y = -self.angle
 			mat:Rotate(matAng)
 
 			cam_PushModelMatrix(mat, true)
-				self.layouter:DrawText(self.text, 0, 0, self.w, self.h, self.halign, self.valign)
+				self.layouter:DrawText(self.text, 0, 0, w, h, self.halign, self.valign)
 			cam_PopModelMatrix()
 		end
 


### PR DESCRIPTION
Makes TextLayout centered like boxes.
This should not bother people who are using `egpDrawTopLeft(1)` by default. I hope. This *will* bother people who expected old behavior.

Todo: This sucks because `MoveTopLeft` undoes what this does. Maybe make MoveTopLeft a method, too?

Change default rendering to topleft by default? Maybe save that for EGPv4 (it's really annoying, though).