### PR TITLE
Fix EGP would create objects on remove

### DIFF
--- a/lua/entities/gmod_wire_egp/lib/egplib/queuesystem.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/queuesystem.lua
@@ -11,15 +11,12 @@ function EGP:AddQueueObject( Ent, ply, Function, Object )
 	if (n > 0) then
 		local LastItem = self.Queue[ply][n]
 		if (LastItem.Ent == Ent and LastItem.Action == "Object") then
-			local found = false
 			for k,v in ipairs( LastItem.Args[1] ) do
 				if (v.index == Object.index) then
-					--self:EditObject( v, Object )
 
 					if (Object.remove) then -- The object has been removed
 						table.remove( LastItem.Args[1], k )
 					elseif (v.ID ~= Object.ID) then -- Not the same kind of object, create new
-						found = true
 						if (v.OnRemove) then v:OnRemove() end
 						local Obj = self:GetObjectByID( Object.ID )
 						Obj:EditObject(Object:DataStreamInfo())
@@ -27,16 +24,14 @@ function EGP:AddQueueObject( Ent, ply, Function, Object )
 						if (Obj.OnCreate) then Obj:OnCreate() end
 						LastItem.Args[1][k] = Obj
 					else -- Edit
-						found = true
 						v:EditObject(Object:DataStreamInfo())
 					end
 
-					break
+					return
 				end
 			end
-			if not found then
-				LastItem.Args[1][#LastItem.Args[1]+1] = Object
-			end
+			-- Not found, add it to queue
+			LastItem.Args[1][#LastItem.Args[1]+1] = Object
 		else
 			self:AddQueue( Ent, ply, Function, "Object", { Object } )
 		end


### PR DESCRIPTION
EGP would erroneously add objects to the queue because a flag was not set when removing.
This removes that flag and uses a return instead.