### PR TITLE
Prevent entity gates from being used on players

### DIFF
--- a/lua/wire/gates/entity.lua
+++ b/lua/wire/gates/entity.lua
@@ -7,6 +7,8 @@ GateActions("Entity")
 local clamp = WireLib.clampForce
 
 local function isAllowed( gate, ent )
+	if not IsValid( ent ) then return false end
+	if ent:IsPlayer() then return false end
 	if not IsValid(gate:GetPlayer()) then return false end
 	return hook.Run( "PhysgunPickup", gate:GetPlayer(), ent ) ~= false
 end
@@ -17,11 +19,9 @@ GateActions["entity_applyf"] = {
 	inputtypes = { "ENTITY" , "VECTOR" },
 	timed = true,
 	output = function(gate, ent, vec )
-		if not IsValid( ent ) then return end
-		if ent:IsPlayer() then return end
+		if not isAllowed( gate, ent ) then return end
 		local phys = ent:GetPhysicsObject()
 		if not IsValid( phys ) then return end
-		if not isAllowed( gate, ent ) then return end
 		if not isvector(vec) then vec = Vector (0, 0, 0) end
 		vec = clamp(vec)
 		if vec.x == 0 and vec.y == 0 and vec.z == 0 then return end
@@ -39,11 +39,9 @@ GateActions["entity_applyof"] = {
 	inputtypes = { "ENTITY" , "VECTOR" , "VECTOR" },
 	timed = true,
 	output = function(gate, ent, vec, offset )
-		if not IsValid( ent ) then return end
-		if ent:IsPlayer() then return end
+		if not isAllowed( gate, ent ) then return end
 		local phys = ent:GetPhysicsObject()
 		if not IsValid( phys ) then return end
-		if not isAllowed( gate, ent ) then return end
 		if not isvector(vec) then vec = Vector (0, 0, 0) end
 		if not isvector(offset) then offset = Vector (0, 0, 0) end
 		vec = clamp(vec)
@@ -65,11 +63,9 @@ GateActions["entity_applyaf"] = {
 	inputtypes = { "ENTITY" , "ANGLE" },
 	timed = true,
 	output = function(gate, ent, angForce )
-		if not IsValid( ent ) then return end
-		if ent:IsPlayer() then return end
+		if not isAllowed( gate, ent ) then return end
 		local phys = ent:GetPhysicsObject()
 		if not IsValid( phys ) then return end
-		if not isAllowed( gate, ent ) then return end
 		local clampedForce = clamp(angForce)
 		if clampedForce.x == 0 and clampedForce.y == 0 and clampedForce.z == 0 then return end
 
@@ -113,11 +109,9 @@ GateActions["entity_applytorq"] = {
 	inputtypes = { "ENTITY" , "VECTOR" },
 	timed = true,
 	output = function(gate, ent, vec )
-		if not IsValid( ent ) then return end
-		if ent:IsPlayer() then return end
+		if not isAllowed( gate, ent ) then return end
 		local phys = ent:GetPhysicsObject()
 		if not IsValid( phys ) then return end
-		if not isAllowed( gate, ent ) then return end
 		if not isvector(vec) then vec = Vector (0, 0, 0) end
 		if not isvector(offset) then offset = Vector (0, 0, 0) end
 		vec 	= clamp(vec)

--- a/lua/wire/gates/entity.lua
+++ b/lua/wire/gates/entity.lua
@@ -18,6 +18,7 @@ GateActions["entity_applyf"] = {
 	timed = true,
 	output = function(gate, ent, vec )
 		if not IsValid( ent ) then return end
+		if ent:IsPlayer() then return end
 		local phys = ent:GetPhysicsObject()
 		if not IsValid( phys ) then return end
 		if not isAllowed( gate, ent ) then return end
@@ -39,6 +40,7 @@ GateActions["entity_applyof"] = {
 	timed = true,
 	output = function(gate, ent, vec, offset )
 		if not IsValid( ent ) then return end
+		if ent:IsPlayer() then return end
 		local phys = ent:GetPhysicsObject()
 		if not IsValid( phys ) then return end
 		if not isAllowed( gate, ent ) then return end
@@ -64,6 +66,7 @@ GateActions["entity_applyaf"] = {
 	timed = true,
 	output = function(gate, ent, angForce )
 		if not IsValid( ent ) then return end
+		if ent:IsPlayer() then return end
 		local phys = ent:GetPhysicsObject()
 		if not IsValid( phys ) then return end
 		if not isAllowed( gate, ent ) then return end
@@ -111,6 +114,7 @@ GateActions["entity_applytorq"] = {
 	timed = true,
 	output = function(gate, ent, vec )
 		if not IsValid( ent ) then return end
+		if ent:IsPlayer() then return end
 		local phys = ent:GetPhysicsObject()
 		if not IsValid( phys ) then return end
 		if not isAllowed( gate, ent ) then return end


### PR DESCRIPTION
I noticed for some reason these gates 4 can be used on players to freeze them. Since they don't work on players anyway, I think the best fix would be to just disallow them from working on other players.