### PR TITLE
Mitigate nil addition in EGP.umsg.End

### DIFF
--- a/lua/entities/gmod_wire_egp/lib/egplib/umsgsystem.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/umsgsystem.lua
@@ -3,7 +3,7 @@
 --------------------------------------------------------
 local EGP = EGP
 
-local CurSender
+local CurSender = NULL
 local LastErrorTime = 0
 --[[ Transmit Sizes:
 	Angle = 12
@@ -21,7 +21,7 @@ local LastErrorTime = 0
 EGP.umsg = {}
 
 function EGP.umsg.Start( name, sender )
-	if CurSender then
+	if CurSender:IsValid() then
 		if (LastErrorTime + 1 < CurTime()) then
 			ErrorNoHalt("[EGP] Umsg error. It seems another umsg is already sending, but it occured over 1 second ago. Ending umsg.")
 			EGP.umsg.End()
@@ -40,10 +40,15 @@ function EGP.umsg.Start( name, sender )
 end
 
 function EGP.umsg.End()
-	if CurSender then
+	if CurSender:IsValid() then
 		if not EGP.IntervalCheck[CurSender] then EGP.IntervalCheck[CurSender] = { bytes = 0, time = 0 } end
-		EGP.IntervalCheck[CurSender].bytes = EGP.IntervalCheck[CurSender].bytes + net.BytesWritten()
+		local bytes = net.BytesWritten()
+		if bytes then
+			EGP.IntervalCheck[CurSender].bytes = EGP.IntervalCheck[CurSender].bytes + bytes
+		else
+			ErrorNoHalt("Tried to end EGP net message outside of net context?")
+		end
 	end
 	net.Broadcast()
-	CurSender = nil
+	CurSender = NULL
 end

--- a/lua/entities/gmod_wire_egp/lib/egplib/umsgsystem.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/umsgsystem.lua
@@ -35,7 +35,7 @@ function EGP.umsg.Start( name, sender )
 	end
 	CurSender = sender
 
-	net.Start( name )
+	net.Start(name)
 	return true
 end
 
@@ -48,7 +48,10 @@ function EGP.umsg.End()
 		else
 			ErrorNoHalt("Tried to end EGP net message outside of net context?")
 		end
+		net.Broadcast()
+
+	else
+		net.Send(NULL)
 	end
-	net.Broadcast()
 	CurSender = NULL
 end


### PR DESCRIPTION
Was sitting on this but thought it was just a fluke.
I don't know the cause, EGP's net messages seem to be properly contained as best as I can tell.