### PR TITLE
`printColor` rewrite

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/cl_debug.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_debug.lua
@@ -24,9 +24,9 @@ net.Receive("wire_expression2_printColor", function()
 	local msg = {}
 
 	for i = 1, 1024 do
-		local head = net.ReadUInt(4)
-		if head == 0 then break end
-		msg[i] = printcolor_readers[head]()
+		local reader = printcolor_readers[net.ReadUInt(4)]
+		if not reader then break end
+		msg[i] = reader()
 	end
 
 	if console then

--- a/lua/entities/gmod_wire_expression2/core/cl_debug.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_debug.lua
@@ -3,7 +3,7 @@ CreateClientConVar( "wire_expression2_print_max_length", 1000, true, true )
 CreateClientConVar( "wire_expression2_print_delay", 0.3, true, true )
 local cvar_warn = CreateClientConVar("wire_expression2_printcolor_warn", 1, true, true, "Shows a warning when someone uses printColorDriver on you")
 
-local not_warned = true
+local not_warned = not game.SinglePlayer()
 
 local RED = Color(255, 0, 0)
 
@@ -34,7 +34,7 @@ net.Receive("wire_expression2_printColor", function()
 	else
 		if not_warned and ply ~= LocalPlayer() then
 			not_warned = false
-			if cvar_warn:GetBool() and not game.SinglePlayer() then
+			if cvar_warn:GetBool() then
 				chat.AddText(RED, "While in somone's seat/car/whatever, printColorDriver can be used to 100% realistically fake people talking, including admins.\
 Don't trust a word you hear while in a seat after seeing this message!")
 			end

--- a/lua/entities/gmod_wire_expression2/core/cl_debug.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_debug.lua
@@ -1,30 +1,48 @@
 CreateClientConVar( "wire_expression2_print_max", 15, true, true )
 CreateClientConVar( "wire_expression2_print_max_length", 1000, true, true )
 CreateClientConVar( "wire_expression2_print_delay", 0.3, true, true )
+local cvar_warn = CreateClientConVar("wire_expression2_printcolor_warn", 1, true, true, "Shows a warning when someone uses printColorDriver on you")
 
-local chips = {}
+local not_warned = true
 
-hook.Add("EntityRemoved", "wire_expression2_printColor", function(ent)
-	chips[ent] = nil
-end)
+local RED = Color(255, 0, 0)
 
-net.Receive("wire_expression2_printColor", function( len, ply )
-	local chip = net.ReadEntity()
+local printcolor_readers = {
+	[1] = function() return tostring(net.ReadDouble()) end,
+	[2] = function() return net.ReadString() end,
+	[3] = function() return net.ReadColor(false) end,
+	[4] = function()
+		local e = net.ReadEntity() -- Passing directly will set color as the player's color which isn't desirable I believe
+		return e:IsValid() and (e:IsPlayer() and e:GetName() or e:GetClass()) or "NULL" -- Also, MsgC doesn't have this feature, so adds parity
+	end
+}
+
+net.Receive("wire_expression2_printColor", function()
+	local ply = net.ReadEntity()
 	local console = net.ReadBool()
-	if chip and not chips[chip] then
-		chips[chip] = true
-		-- printColorDriver is used for the first time on us by this chip
-		chat.AddText(Color(255,0,0),"While in somone's seat/car/whatever, printColorDriver can be used to 100% realistically fake people talking, including admins.")
-		chat.AddText(Color(255,0,0),"Don't trust a word you hear while in a seat after seeing this message!")
+
+	local msg = {}
+
+	for i = 1, 1024 do
+		local head = net.ReadUInt(4)
+		if head == 0 then break end
+		msg[i] = printcolor_readers[head]()
 	end
 
 	if console then
-		MsgC(unpack(net.ReadTable()))
+		MsgC(unpack(msg))
 	else
-		chat.AddText(unpack(net.ReadTable()))
+		if not_warned and ply ~= LocalPlayer() then
+			not_warned = false
+			if cvar_warn:GetBool() and not game.SinglePlayer() then
+				chat.AddText(RED, "While in somone's seat/car/whatever, printColorDriver can be used to 100% realistically fake people talking, including admins.\
+Don't trust a word you hear while in a seat after seeing this message!")
+			end
+		end
+		chat.AddText(unpack(msg))
 	end
 end)
 
-net.Receive("wire_expression2_print", function(len, ply)
+net.Receive("wire_expression2_print", function()
 	chat.AddText(net.ReadString())
 end)


### PR DESCRIPTION
Add:
- Dynamic perf on `printColor` (1 op per bit sent)
- ConVar to disable warnings on `printColor`

Change:
- Rewrote `printColor` to be faster and more robust
- `printColor` now uses modified normal print max length to limit
- Print max length now use server's max length in singleplayer
- `printColor` warning now fires only once per session
- `printColor` warning does not appear for your own E2s (? Maybe controversial)