### PR TITLE
Fix wirelink issues

### DIFF
--- a/lua/entities/gmod_wire_egp/init.lua
+++ b/lua/entities/gmod_wire_egp/init.lua
@@ -13,7 +13,9 @@ function ENT:Initialize()
 
 	self.RenderTable = {}
 
-	WireLib.CreateOutputs( self, { "User (Outputs the player who used the screen for a single tick) [ENTITY]", "wirelink [WIRELINK]" } )
+	WireLib.CreateOutputs(self, { "User (Outputs the player who used the screen for a single tick) [ENTITY]", "wirelink [WIRELINK]" })
+
+	WireLib.TriggerOutput(self, "wirelink", self)
 
 	self.xScale = { 0, 512 }
 	self.yScale = { 0, 512 }

--- a/lua/entities/gmod_wire_egp_hud/init.lua
+++ b/lua/entities/gmod_wire_egp_hud/init.lua
@@ -24,10 +24,13 @@ function ENT:Initialize()
 	self:SetUseType(SIMPLE_USE)
 	self:AddEFlags( EFL_FORCE_CHECK_TRANSMIT )
 
-	self.Inputs = WireLib.CreateInputs( self, {
-		"0 to 512 (If enabled, changes the resolution of the egp hud to be between 0 and 512 instead of the user's monitor's resolution.\nWill cause objects to look stretched out on most screens, so your UI will need to be designed with this in mind.\nIt's recommended to use the egpScrW, egpScrH, and egpScrSize functions instead.)",
-		"wirelink [WIRELINK]"
+	WireLib.CreateInputs(self, {
+		"0 to 512 (If enabled, changes the resolution of the egp hud to be between 0 and 512 instead of the user's monitor's resolution.\nWill cause objects to look stretched out on most screens, so your UI will need to be designed with this in mind.\nIt's recommended to use the egpScrW, egpScrH, and egpScrSize functions instead.)"
 	})
+
+	WireLib.CreateOutputs(self, { "wirelink [WIRELINK]" })
+
+	WireLib.TriggerOutput(self, "wirelink", self)
 
 	self.xScale = { 0, 512 }
 	self.yScale = { 0, 512 }

--- a/lua/entities/gmod_wire_expression2/core/custom/cl_wiring.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cl_wiring.lua
@@ -1,5 +1,6 @@
 E2Helper.Descriptions["createWire(e:essnvs)"] = "Creates a wire from specified input of first entity to the output of second entity, with specified wire width, color and material"
 E2Helper.Descriptions["createWire(e:ess)"] = "Creates a wire from specified input of first entity to the output of second entity"
+E2Helper.Descriptions["createWirelink(e:)"] = "Creates a wirelink output on the entity"
 E2Helper.Descriptions["deleteWire(e:s)"] = "Unwires the specified input of the entity"
 E2Helper.Descriptions["getWireInputs(e:)"] = "Returns array of all inputs of the entity"
 E2Helper.Descriptions["getWireOutputs(e:)"] = "Returns array of all outputs of the entity"

--- a/lua/entities/gmod_wire_expression2/core/custom/wiring.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/wiring.lua
@@ -108,7 +108,17 @@ __e2setcost(5)
 e2function wirelink entity:wirelink()
 	if not IsValid(this) then return self:throw("Invalid entity!", nil) end
 	if not isOwner(self, this) then return self:throw("You do not own this entity!", nil) end
-	
+
+	return this
+end
+
+e2function wirelink entity:createWirelink()
+	if not IsValid(this) then return self:throw("Invalid entity!", nil) end
+	if not isOwner(self, this) then return self:throw("You do not own this entity!", nil) end
+
+	if not this.extended then
+		WireLib.CreateWirelinkOutput(self.player, this, { true })
+	end
 	return this
 end
 

--- a/lua/entities/gmod_wire_expression2/core/wirelink.lua
+++ b/lua/entities/gmod_wire_expression2/core/wirelink.lua
@@ -9,9 +9,11 @@ registerCallback("construct", function(self)
 	self.triggercache = {}
 end)
 
+local FLAG_WL = { wirelink = true }
+
 registerCallback("postexecute", function(self)
 	for _,ent,portname,value in pairs_map(self.triggercache, unpack) do
-		WireLib.TriggerInput(ent, portname, value)
+		WireLib.TriggerInput(ent, portname, value, FLAG_WL)
 	end
 
 	self.triggercache = {}
@@ -28,7 +30,6 @@ end
 
 local function validWirelink(self, ent)
 	if not IsValid(ent) then return false end
-	if not ent.extended then return false end
 	if not isOwner(self, ent) then return false end
 	return true
 end


### PR DESCRIPTION
- Add `createWirelink` to reintroduce creating wirelink outputs
- Wirelink `TriggerOutput` now sends a table with field `wirelink = true` to indicate it's a wirelink trigger
- Fixed `validWirelink` would consider most wirelinks invalid
- Fixed EGP wirelink outputted nothing

Fixes #2940