### PR TITLE
Add isOwner checks to hologram parenting funcs

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/hologram.lua
@@ -1224,12 +1224,12 @@ end
 
 e2function void holoParent(index, entity ent)
 	if not IsValid(ent) then return end
-	local Holo = CheckIndex(self, index)
-	if not Holo then return end
-
 	if not E2Lib.isOwner(self, ent) then
 		return self:throw("You do not have permission to parent to this entity", nil)
 	end
+
+	local Holo = CheckIndex(self, index)
+	if not Holo then return end
 
 	if not Check_Parents(Holo.ent, ent) then return end
 
@@ -1238,12 +1238,12 @@ end
 
 e2function void holoParentAttachment(index, entity ent, string attachmentName)
 	if not IsValid(ent) then return end
-	local Holo = CheckIndex(self, index)
-	if not Holo then return end
-
 	if not E2Lib.isOwner(self, ent) then
 		return self:throw("You do not have permission to parent to this entity", nil)
 	end
+
+	local Holo = CheckIndex(self, index)
+	if not Holo then return end
 
 	Parent_Hologram(Holo, ent, attachmentName)
 end

--- a/lua/entities/gmod_wire_expression2/core/hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/hologram.lua
@@ -1227,6 +1227,10 @@ e2function void holoParent(index, entity ent)
 	local Holo = CheckIndex(self, index)
 	if not Holo then return end
 
+	if not E2Lib.isOwner(self, ent) then
+		return self:throw("You do not have permission to parent to this entity", nil)
+	end
+
 	if not Check_Parents(Holo.ent, ent) then return end
 
 	Parent_Hologram(Holo, ent, nil)
@@ -1236,6 +1240,10 @@ e2function void holoParentAttachment(index, entity ent, string attachmentName)
 	if not IsValid(ent) then return end
 	local Holo = CheckIndex(self, index)
 	if not Holo then return end
+
+	if not E2Lib.isOwner(self, ent) then
+		return self:throw("You do not have permission to parent to this entity", nil)
+	end
 
 	Parent_Hologram(Holo, ent, attachmentName)
 end


### PR DESCRIPTION
## Context

- The `holoParent(n, e)` and `holoParentAttachment(n, e, s)` functions allow you to parent holograms to any entity regardless of CPPI, including other players
- This has probably not been resolved as you can usually just block holos on your client
- This however allows you to then parent a regular prop to your now parented holo, effectively bypassing the permission checks done by the prop core
  - You can use this to create simple unblockable (without cs lua) blinders and more (like parenting invis props to players' heads to prevent them from interacting with the world)

## Changes

- Adds `E2Lib.isOwner` checks to the two functions mentioned above, throwing an error (on `@strict`) when the player doesn't have permissions for the target entity
  - Probably obvious to anyone familiar with the codebase, but `E2Lib.isOwner` will also return true if the players are CPPI friends despite the name

## Impact

- Prevents players from parenting actual props to players or entities that they do not have CPPI permissions for
- This also prevents traditional blinders which just parent a holo

⬆️ Obviously if a player has given you CPPI permissions, then this is still possible. This should minimise impact to non-malicious usage of this functionality (an example raised on our server was Santa hats).

## Testing

This PR is draft until we've QA'd the branch on our end

- When using `holoParent(n, e)`
  - I can parent a hologram to my own entities
  - I can parent a hologram to my own player entity
  - I can parent a hologram to entities owned by a player who has given me CPPI permissions
  - I can parent a hologram to a player who has given me CPPI permissions
  - I cannot parent a hologram to entities owned by players who have not given me CPPI permissions
  - I cannot parent a hologram to players who have not given me CPPI permissions
  - When I fail to parent a hologram due to permissions
    - and I'm using `@strict`, an error is thrown
    - and I'm not using `@strict`, no error is thrown but the holo is not parented
- When using `holoParentAttachment(n, e, s)`
  - Same test cases as above