### PR TITLE
Make gtables and datasignals extensions

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/datasignal.lua
+++ b/lua/entities/gmod_wire_expression2/core/datasignal.lua
@@ -10,6 +10,8 @@ send the data at the same time.
 Have fun!
 ]]
 
+E2Lib.RegisterExtension( "datasignal", true, "Allows users to trigger remote actions on other E2s to transmit data and actions.", "Superceded by event remote" )
+
 local groups = {}
 local queue = {}
 

--- a/lua/entities/gmod_wire_expression2/core/globalvars.lua
+++ b/lua/entities/gmod_wire_expression2/core/globalvars.lua
@@ -3,6 +3,8 @@ gvars v2
 Made by Divran
 ]]
 
+E2Lib.RegisterExtension( "gtable", true, "Allows users to create gTables to transmit data between E2 chips.", "!!! Very easy to exploit to use a ton of server memory. Superceded by event remote." )
+
 local gvars = {}
 gvars.shared = {}
 gvars.safe = {} -- Safe from hacking using gTableSafe


### PR DESCRIPTION
No idea why they weren't, but now gtables and datasignals register extensions so they can be disabled.

This is especially important for gtables as they are so exploitable..

I'd love to have them disabled by default but I don't think that's an option atm.
Will need to see just how many chips use them.

People can move to `event remote` which is more of a datasignals replacement but can easily be used to replace gtables too...