### PR TITLE
Added CallOnRemove on entity to stop emitting sound on entity deletion

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/sound.lua
+++ b/lua/entities/gmod_wire_expression2/core/sound.lua
@@ -308,8 +308,9 @@ local function EmitSound(e2, ent, snd, level, pitch, volume)
     ent:SetVar("E2_emitting_sounds", emitting_sounds)
 
     ent:CallOnRemove("E2_EmitSound_stop_all", function()
-        local emitting_sounds = ent:GetVar("E2_emitting_sounds", {})
-        for _, snd in pairs(emitting_sounds) do
+        local emitting_sounds = ent:GetVar("E2_emitting_sounds")
+        if not emitting_sounds then return end
+        for _, snd in ipairs(emitting_sounds) do
             ent:StopSound(snd)
         end
     end)

--- a/lua/entities/gmod_wire_expression2/core/sound.lua
+++ b/lua/entities/gmod_wire_expression2/core/sound.lua
@@ -304,14 +304,16 @@ local function EmitSound(e2, ent, snd, level, pitch, volume)
     end
 
     local emitting_sounds = ent:GetVar("E2_emitting_sounds", {})
-    table.insert(emitting_sounds, snd)
+    emitting_sounds[snd] = (emitting_sounds[snd] or 0) + 1
     ent:SetVar("E2_emitting_sounds", emitting_sounds)
 
     ent:CallOnRemove("E2_EmitSound_stop_all", function()
         local emitting_sounds = ent:GetVar("E2_emitting_sounds")
         if not emitting_sounds then return end
-        for _, snd in ipairs(emitting_sounds) do
-            ent:StopSound(snd)
+        for snd, count in pairs(emitting_sounds) do
+            for i = 1, count do
+                ent:StopSound(snd)
+            end
         end
     end)
 

--- a/lua/entities/gmod_wire_expression2/core/sound.lua
+++ b/lua/entities/gmod_wire_expression2/core/sound.lua
@@ -303,6 +303,17 @@ local function EmitSound(e2, ent, snd, level, pitch, volume)
         level = maxlevel
     end
 
+    local emitting_sounds = ent:GetVar("E2_emitting_sounds", {})
+    table.insert(emitting_sounds, snd)
+    ent:SetVar("E2_emitting_sounds", emitting_sounds)
+
+    ent:CallOnRemove("E2_EmitSound_stop_all", function()
+        local emitting_sounds = ent:GetVar("E2_emitting_sounds", {})
+        for _, snd in pairs(emitting_sounds) do
+            ent:StopSound(snd)
+        end
+    end)
+
     ent:EmitSound(snd, level, pitch, volume)
 end
 

--- a/lua/entities/gmod_wire_expression2/core/sound.lua
+++ b/lua/entities/gmod_wire_expression2/core/sound.lua
@@ -304,7 +304,7 @@ local function EmitSound(e2, ent, snd, level, pitch, volume)
     end
 
     local emitting_sounds = ent:GetVar("E2_emitting_sounds", {})
-    emitting_sounds[snd] = (emitting_sounds[snd] or 0) + 1
+    emitting_sounds[snd] = math.min((emitting_sounds[snd] or 0) + 1, 32)
     ent:SetVar("E2_emitting_sounds", emitting_sounds)
 
     ent:CallOnRemove("E2_EmitSound_stop_all", function()


### PR DESCRIPTION
This will fix the issue where props do not stop their current emitting sounds when deleted.
Having a table to store every sounds is useful when you have to delete two or more sounds playing simultaneously. If we had something like : 
```lua
ent:CallOnRemove("E2_EmitSound_stop_all", function()
    ent:StopSound(snd)
end
```
It would not have worked since CallOnRemove overwrites the last call with the same identifier.

By the way, even though the rule on indentation is to use Tab instead of Space, I used Space since this is the indentation used in the EmitSound function declaration. 

Fixes #2815