### PR TITLE
Restore Contains method on RoundedBoxOutline

### DIFF
--- a/lua/entities/gmod_wire_egp/lib/objects/roundedboxoutline.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/roundedboxoutline.lua
@@ -27,6 +27,4 @@ Obj.DataStreamInfo = function( self )
 	return tbl
 end
 
-Obj.Contains = nil
-
 return Obj


### PR DESCRIPTION
For some reason this is `nil` but EGP expects it to always exist. It's a unicorn so probably just some specific leftover oversight.