### PR TITLE
Prevent CD error on attempting to disable the CD's Lock

### DIFF
--- a/lua/entities/gmod_wire_cd_lock.lua
+++ b/lua/entities/gmod_wire_cd_lock.lua
@@ -97,7 +97,9 @@ function ENT:AttachDisk(disk)
 
 	self.Const:CallOnRemove("wire_cd_remove_on_weld",function()
 		self.Const = nil
-		self.Disk.Lock = nil
+		if(IsValid(self.Disk)) then
+			self.Disk.Lock = nil
+		end
 		self.Disk = nil
 		self.NoCollideConst = nil
 

--- a/lua/entities/gmod_wire_cd_lock.lua
+++ b/lua/entities/gmod_wire_cd_lock.lua
@@ -97,7 +97,7 @@ function ENT:AttachDisk(disk)
 
 	self.Const:CallOnRemove("wire_cd_remove_on_weld",function()
 		self.Const = nil
-		if(IsValid(self.Disk)) then
+		if IsValid(self.Disk) then
 			self.Disk.Lock = nil
 		end
 		self.Disk = nil

--- a/lua/entities/gmod_wire_cd_lock.lua
+++ b/lua/entities/gmod_wire_cd_lock.lua
@@ -96,6 +96,7 @@ function ENT:AttachDisk(disk)
 	end
 
 	self.Const:CallOnRemove("wire_cd_remove_on_weld",function()
+		if not self:IsValid() then return end
 		self.Const = nil
 		if IsValid(self.Disk) then
 			self.Disk.Lock = nil


### PR DESCRIPTION
When disabling a CD Lock with the "Disable" wire input while it's holding a CD, it will cause an error due to attempting to index an entity/table that doesn't exist.

This will check if the disk exists on self before attempting to remove the lock on it, preventing the error.