### PR TITLE
Reduce index calls on EGP:ValidEGP

### DIFF
--- a/lua/entities/gmod_wire_egp/init.lua
+++ b/lua/entities/gmod_wire_egp/init.lua
@@ -2,6 +2,7 @@ AddCSLuaFile("cl_init.lua")
 AddCSLuaFile("shared.lua")
 include('shared.lua')
 
+ENT.IsEGP = true
 ENT.WireDebugName = "E2 Graphics Processor"
 
 function ENT:Initialize()

--- a/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
@@ -229,11 +229,11 @@ end
 -- Other
 --------------------------------------------------------
 do
-	local GetVar = FindMetaTable( "Entity" ).GetVar
+	local GetTable = FindMetaTable( "Entity" ).GetTable
 
 	function EGP:ValidEGP( Ent )
 		if not IsValid( Ent ) then return false end
-		return GetVar( Ent, "IsEGP", false )
+		return GetTable( Ent ).IsEGP == true
 	end
 end
 

--- a/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
@@ -229,7 +229,9 @@ end
 -- Other
 --------------------------------------------------------
 function EGP:ValidEGP( Ent )
-	return IsValid( Ent ) and (Ent:GetClass() == "gmod_wire_egp" or Ent:GetClass() == "gmod_wire_egp_hud" or Ent:GetClass() == "gmod_wire_egp_emitter")
+	if not IsValid( Ent ) then return false end
+	local class = Ent:GetClass()
+	return class == "gmod_wire_egp" or class == "gmod_wire_egp_hud" or class == "gmod_wire_egp_emitter"
 end
 
 

--- a/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
@@ -229,7 +229,9 @@ end
 -- Other
 --------------------------------------------------------
 do
-	local GetTable = FindMetaTable( "Entity" ).GetTable
+	local EntMeta = FindMetaTable( "Entity" )
+	local IsValid = EntMeta.IsValid
+	local GetTable = EntMeta.GetTable
 
 	function EGP:ValidEGP( Ent )
 		if not IsValid( Ent ) then return false end

--- a/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/usefulfunctions.lua
@@ -228,10 +228,13 @@ end
 --------------------------------------------------------
 -- Other
 --------------------------------------------------------
-function EGP:ValidEGP( Ent )
-	if not IsValid( Ent ) then return false end
-	local class = Ent:GetClass()
-	return class == "gmod_wire_egp" or class == "gmod_wire_egp_hud" or class == "gmod_wire_egp_emitter"
+do
+	local GetVar = FindMetaTable( "Entity" ).GetVar
+
+	function EGP:ValidEGP( Ent )
+		if not IsValid( Ent ) then return false end
+		return GetVar( Ent, "IsEGP", false )
+	end
 end
 
 

--- a/lua/entities/gmod_wire_egp_emitter.lua
+++ b/lua/entities/gmod_wire_egp_emitter.lua
@@ -4,6 +4,7 @@ ENT.PrintName       = "Wire E2 Graphics Processor Emitter"
 ENT.WireDebugName	= "E2 Graphics Processor Emitter"
 ENT.RenderGroup    = RENDERGROUP_BOTH
 
+ENT.IsEGP = true
 ENT.gmod_wire_egp_emitter = true
 
 local DrawOffsetPos = Vector(0, 0, 71)

--- a/lua/entities/gmod_wire_egp_hud/init.lua
+++ b/lua/entities/gmod_wire_egp_hud/init.lua
@@ -6,6 +6,7 @@ include("huddraw.lua")
 
 DEFINE_BASECLASS("base_wire_entity")
 
+ENT.IsEGP = true
 ENT.WireDebugName = "E2 Graphics Processor HUD"
 
 util.AddNetworkString("EGP_HUD_Use")


### PR DESCRIPTION
Simple optimization to reduce entity `__index` calls for this commonly-used method.
With only a few EGPs out, I recorded 77,762 `__index` calls from this method over a 10 second sample.

Also, from a high-level skim, it seems like this could even be cached on the EGP entity itself to make it even faster.