### PR TITLE
Re-add pp/copy to the material blacklist

### DIFF
--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1271,6 +1271,7 @@ function WireLib.CheckRegex(data, pattern)
 end
 
 local material_blacklist = {
+	["pp/copy"] = true,
 	["engine/writez"] = true,
 	["debug/debugluxels"] = true, -- Crashes linux client
 	["effects/ar2_altfire1"] = true


### PR DESCRIPTION
It got removed recently via https://github.com/wiremod/wire/commit/b0fa290438124518ae46813cd21bb2dcb168ff2c, but turns out it's not fully fixed, see: https://github.com/Facepunch/garrysmod-issues/issues/5157#issuecomment-1872460112