### PR TITLE
Add `declare function` E2 construct

### DIFF
--- a/data/expression2/tests/compiler/compiler/restrictions/fn_declare_define.txt
+++ b/data/expression2/tests/compiler/compiler/restrictions/fn_declare_define.txt
@@ -1,0 +1,15 @@
+## SHOULD_PASS:COMPILE
+@strict
+
+declare function test()
+
+function use_test() {
+    test() # Using declared-but-not-yet-defined function
+}
+
+
+declare function test() # Double-declaration is allowed
+
+function test() { 
+    print("Do something")
+}

--- a/data/expression2/tests/compiler/compiler/restrictions/fn_declare_no_define.txt
+++ b/data/expression2/tests/compiler/compiler/restrictions/fn_declare_no_define.txt
@@ -1,0 +1,6 @@
+## SHOULD_FAIL:COMPILE
+@strict
+
+declare function test() # No definition
+
+# Lack of users not matters

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -340,6 +340,10 @@ local function declareFunction(self, sig) -- Modifies sigdesc.param_names
 			end
 		end
 
+		local oldfn = self.user_methods[meta_type][name.value][sigtxt]
+		-- Don't replace function description table
+		if oldfn ~= nil then return oldfn, sigtxt end
+
 		self.user_methods[meta_type][name.value][sigtxt] = fn
 
 		-- Insert "This" variable
@@ -353,6 +357,11 @@ local function declareFunction(self, sig) -- Modifies sigdesc.param_names
 				self:Error("Cannot override variadic " .. opposite .. " function with variadic " .. variadic_ty .. " function to avoid ambiguity.", trace)
 			end
 		end
+		
+		local oldfn = self.user_functions[name.value][sigtxt]
+		-- Don't replace function description table
+		if oldfn ~= nil then return oldfn, sigtxt end
+
 		self.user_functions[name.value][sigtxt] = fn
 	end
 
@@ -1732,6 +1741,7 @@ local CompileVisitors = {
 			if self.strict then -- If @strict, functions are compile time constructs (like events).
 				return function(state)
 					local fn = user_function.op
+
 					local rargs = {}
 					for k = 1, nargs do
 						rargs[k] = args[k](state)

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -299,7 +299,7 @@ local function validateFunctionDeclaration(self, sig, is_definition)
 		self:Assert(fn_data.ret == nil, "Cannot override function returning void with differing return type", trace)
 	end
 
-	if is_definition then
+	if fn_data.op ~= nil and is_definition then
 		if not self.strict then
 			self:Warning("Do not override functions. This is a hard error with @strict.", trace)
 		else
@@ -362,6 +362,7 @@ end
 local function declareFunctionPost(self, fn_body, sig, sigtxt)
 	local meta_type = sig.meta_type
 	local return_type = sig.return_type
+	local name = sig.name
 
 	local sigtxt = name.value .. "(" .. (meta_type and (meta_type .. ":") or "") .. sigtxt .. ")"
 
@@ -808,7 +809,7 @@ local CompileVisitors = {
 
 		validateFunctionDeclaration(self, sig, false --[[is_definition]])
 
-		local fn_tbl, sigtext = declareFunction(self, sig)
+		local fn_tbl, sigtxt = declareFunction(self, sig)
 		return declareFunctionPost(self, nil --[[fn_body]], sig, sigtxt)
 	end,
 
@@ -2172,7 +2173,7 @@ function Compiler:EnsureFunctionsAreDefined()
 		end
 	end
 
-	for meta_ty, fns in pairs(self.user_methods)
+	for meta_ty, fns in pairs(self.user_methods) do
 		for name, overrides in pairs(fns) do
 			for sigtxt, desc in pairs(overrides) do
 				if desc.op ~= nil then goto next_mthd end

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -458,7 +458,9 @@ local Keyword = {
 	-- ``do``
 	Do = 20,
 	-- ``event``
-	Event = 21
+	Event = 21,
+	-- ``declare``
+	Declare = 22
 }
 
 E2Lib.Keyword = Keyword

--- a/lua/wire/client/text_editor/modes/e2.lua
+++ b/lua/wire/client/text_editor/modes/e2.lua
@@ -34,7 +34,8 @@ local keywords = {
 	["try"]    = { [true] = true },
 	["do"] = { [true] = true },
 	["event"] = { [true] = true },
-	["#include"] = { [true] = true }
+	["#include"] = { [true] = true },
+	["declare"] = { [true] = true }
 }
 
 EDITOR.Keywords = keywords

--- a/lua/wire/client/text_editor/modes/e2.lua
+++ b/lua/wire/client/text_editor/modes/e2.lua
@@ -280,9 +280,16 @@ function EDITOR:SyntaxColorLine(row)
 		cols = {{ self.tokendata, colors.directive }}
 	end
 
-	local found = self:SkipPattern( "( *function)" )
-	if found then
-		addToken( "keyword", found ) -- Add "function"
+	local found_declare  = self:SkipPattern("( *declare)")
+	local found_function = self:SkipPattern("( *function)")
+	if found_declare and not found_function then
+		addToken("notfound", found_declare)
+	elseif found_function then
+		if found_declare ~= nil then
+			addToken("keyword", found_declare)
+		end
+
+		addToken( "keyword", found_function ) -- Add "function"
 		self.tokendata = "" -- Reset tokendata
 
 		local spaces = self:SkipPattern( " *" )


### PR DESCRIPTION
Allows using a function before the line of code where it is defined.
Fixes #2910.

```
@strict

declare function test()

function use_test() {
    test() # Using declared-but-not-yet-defined function
}


declare function test() # Double-declaration is allowed

function test() { 
    print("Do something")
}
```