### PR TITLE
Fix direction not being set after duping

### DIFF
--- a/lua/entities/gmod_wire_wheel.lua
+++ b/lua/entities/gmod_wire_wheel.lua
@@ -27,8 +27,8 @@ function ENT:Setup(fwd, bck, stop, torque, direction, axis)
 	self.fwd = fwd
 	self.bck = bck
 	self.stop = stop
-	if torque then self:SetTorque(math.max(1, torque)) end
 	if direction then self:SetDirection( direction ) end
+	if torque then self:SetTorque(math.max(1, torque)) end
 	if axis then self.Axis = axis end
 
 	self:UpdateOverlayText()


### PR DESCRIPTION
Fixes: https://github.com/wiremod/advdupe2/issues/451