### PR TITLE
Sanitize CD Disk dupe information

### DIFF
--- a/lua/entities/gmod_wire_cd_disk.lua
+++ b/lua/entities/gmod_wire_cd_disk.lua
@@ -33,11 +33,7 @@ function ENT:BuildDupeInfo()
 		info["DiskMemory"][k] = dataptr
 		info["DiskData"..dataptr] = {}
 		for k2,v2 in pairs(self.DiskMemory[k]) do
-			if isnumber(v2) then
-				info["DiskData"..dataptr][k2] = v2
-			else
-				info["DiskData"..dataptr][k2] = 0
-			end
+			info["DiskData"..dataptr][k2] = isnumber(v2) and v2 or 0
 		end
 		dataptr = dataptr + 1
 	end
@@ -58,11 +54,7 @@ function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
 		local dataptr = info["DiskMemory"][k]
 			self.DiskMemory[k] = {}
 		for k2,v2 in pairs(info["DiskData"..dataptr]) do
-			if isnumber(v2) then
-				self.DiskMemory[k][k2] = v2
-			else
-				self.DiskMemory[k][k2] = 0
-			end
+				self.DiskMemory[k][k2] = isnumber(v2) and v2 or 0
 		end
 	end
 

--- a/lua/entities/gmod_wire_cd_disk.lua
+++ b/lua/entities/gmod_wire_cd_disk.lua
@@ -54,7 +54,7 @@ function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
 		local dataptr = info["DiskMemory"][k]
 			self.DiskMemory[k] = {}
 		for k2,v2 in pairs(info["DiskData"..dataptr]) do
-				self.DiskMemory[k][k2] = isnumber(v2) and v2 or 0
+			self.DiskMemory[k][k2] = isnumber(v2) and v2 or 0
 		end
 	end
 

--- a/lua/entities/gmod_wire_cd_disk.lua
+++ b/lua/entities/gmod_wire_cd_disk.lua
@@ -33,7 +33,11 @@ function ENT:BuildDupeInfo()
 		info["DiskMemory"][k] = dataptr
 		info["DiskData"..dataptr] = {}
 		for k2,v2 in pairs(self.DiskMemory[k]) do
-			info["DiskData"..dataptr][k2] = v2
+			if isnumber(v2) then
+				info["DiskData"..dataptr][k2] = v2
+			else
+				info["DiskData"..dataptr][k2] = 0
+			end
 		end
 		dataptr = dataptr + 1
 	end
@@ -54,7 +58,11 @@ function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
 		local dataptr = info["DiskMemory"][k]
 			self.DiskMemory[k] = {}
 		for k2,v2 in pairs(info["DiskData"..dataptr]) do
-			self.DiskMemory[k][k2] = v2
+			if isnumber(v2) then
+				self.DiskMemory[k][k2] = v2
+			else
+				self.DiskMemory[k][k2] = 0
+			end
 		end
 	end
 


### PR DESCRIPTION
When building a CD Disk's contents from dupe, or saving a CD Disk to dupe, the contents will be checked with isnumber() and set to 0 if not a number.

Does not sanitize disk contents during existence, only during dupe save & spawn.