### PR TITLE
Fix `getBone` not working

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/constraint.lua
+++ b/lua/entities/gmod_wire_expression2/core/constraint.lua
@@ -291,6 +291,8 @@ e2function entity entity:parent()
 	return this:GetParent()
 end
 
+local getBone = E2Lib.getBone
+
 --- Returns the '''bone''' <this> is parented to.
 e2function bone entity:parentBone()
 	if not IsValid(this) then return nil end

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -699,6 +699,8 @@ e2function vector entity:aimNormal()
 	return this:GetEyeTraceNoCursor().HitNormal
 end
 
+local getBone = E2Lib.getBone
+
 --- Returns the bone the player is currently aiming at.
 e2function bone entity:aimBone()
 	if not IsValid(this) then return self:throw("Invalid entity!", nil) end


### PR DESCRIPTION
Resolves issue with formerly global `getBone` being used while undefined.