### PR TITLE
Convert file extension to use netstream

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/cl_files.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_files.lua
@@ -46,26 +46,22 @@ end
 
 net.Receive("wire_expression2_request_file", function()
 	local fpath,fname = process_filepath(net.ReadString())
-	if net.ReadBool() then
-		RunConsoleCommand("wire_expression2_file_singleplayer", fpath .. fname)
+	local fullpath = fpath .. fname
+
+	if file.Exists( fullpath,"DATA" ) and file.Size( fullpath, "DATA" ) <= (cv_max_transfer_size:GetInt() * 1024) then
+		local data = file.Read(fullpath, "DATA") or ""
+		net.Start("wire_expression2_file_upload")
+			net.WriteBool(true)
+			net.WriteUInt(#data, 32)
+			net.WriteStream(data)
+		net.SendToServer()
+
 	else
-		local fullpath = fpath .. fname
-
-		if file.Exists( fullpath,"DATA" ) and file.Size( fullpath, "DATA" ) <= (cv_max_transfer_size:GetInt() * 1024) then
-			local data = file.Read(fullpath, "DATA") or ""
-			net.Start("wire_expression2_file_upload")
-				net.WriteBool(true)
-				net.WriteUInt(#data, 32)
-				net.WriteStream(data)
-			net.SendToServer()
-
-		else
-			net.Start("wire_expression2_file_upload")
-				net.WriteBool(false)
-			net.SendToServer()
-		end
+		net.Start("wire_expression2_file_upload")
+			net.WriteBool(false)
+		net.SendToServer()
 	end
-end )
+end)
 
 --- File Write ---
 net.Receive("wire_expression2_file_download", function()

--- a/lua/entities/gmod_wire_expression2/core/cl_files.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_files.lua
@@ -5,11 +5,6 @@
 
 local cv_max_transfer_size = CreateConVar("wire_expression2_file_max_size", "300", { FCVAR_REPLICATED, FCVAR_ARCHIVE }, "Maximum file size in kibibytes.")
 
-local upload_buffer = {}
-local download_buffer = {}
-
-local upload_chunk_size = 20000 --Our overhead is pretty small so lets send it in moderate sized pieces, no need to max out the buffer
-
 local allowed_directories = { --prefix with >(allowed directory)/file.txt for files outside of e2files/ directory
 	["e2files"] = "e2files",
 	["e2shared"] = "expression2/e2shared",
@@ -49,28 +44,7 @@ end
 
 --- File Read ---
 
-local function upload_callback()
-	if not upload_buffer or not upload_buffer.data then return end
-
-	local chunk_size = math.Clamp(#upload_buffer.data, 0, upload_chunk_size)
-
-	net.Start("wire_expression2_file_upload")
-		net.WriteUInt(2, 2)
-		net.WriteUInt(chunk_size, 32)
-		net.WriteData(upload_buffer.data, chunk_size)
-	net.SendToServer()
-	upload_buffer.data = string.sub(upload_buffer.data, chunk_size + 1)
-
-	if upload_buffer.chunk >= upload_buffer.chunks then
-		net.Start("wire_expression2_file_upload") net.WriteUInt(3, 2) net.SendToServer()
-		timer.Remove( "wire_expression2_file_upload" )
-		return
-	end
-
-	upload_buffer.chunk = upload_buffer.chunk + 1
-end
-
-net.Receive("wire_expression2_request_file", function(netlen)
+net.Receive("wire_expression2_request_file", function()
 	local fpath,fname = process_filepath(net.ReadString())
 	if net.ReadBool() then
 		RunConsoleCommand("wire_expression2_file_singleplayer", fpath .. fname)
@@ -78,26 +52,17 @@ net.Receive("wire_expression2_request_file", function(netlen)
 		local fullpath = fpath .. fname
 
 		if file.Exists( fullpath,"DATA" ) and file.Size( fullpath, "DATA" ) <= (cv_max_transfer_size:GetInt() * 1024) then
-			local filedata = file.Read( fullpath,"DATA" ) or ""
-
-			local len = #filedata
-
-			upload_buffer = {
-				chunk = 1,
-				chunks = math.ceil(len / upload_chunk_size),
-				data = filedata
-			}
-
+			local data = file.Read(fullpath, "DATA") or ""
 			net.Start("wire_expression2_file_upload")
-				net.WriteUInt(1, 2)
-				net.WriteUInt(len, 32)
+				net.WriteBool(true)
+				net.WriteUInt(#data, 32)
+				net.WriteUInt(tonumber(util.CRC(data)), 32)
+				net.WriteStream(data)
 			net.SendToServer()
 
-			timer.Create( "wire_expression2_file_upload", 1/60, upload_buffer.chunks, upload_callback )
 		else
 			net.Start("wire_expression2_file_upload")
-				net.WriteUInt(1, 2)
-				net.WriteUInt(0, 32) -- 404 file not found, send len of 0
+				net.WriteBool(false)
 			net.SendToServer()
 		end
 	end
@@ -105,36 +70,22 @@ end )
 
 --- File Write ---
 net.Receive("wire_expression2_file_download", function()
-	local flag = net.ReadUInt(2)
-	if flag == 2 then -- Chunk
-		if not download_buffer.name then return end
-		local len = net.ReadUInt(32)
-		download_buffer.data = (download_buffer.data or "") .. net.ReadData(len)
-
-	elseif flag == 1 then -- Begin
-		local fpath,fname = process_filepath( net.ReadString() )
-		if not E2Lib.isValidFileWritePath(fname) then return end
-		if not file.Exists(fpath, "DATA") then file.CreateDir(fpath) end
-		download_buffer = {
-			name = fpath .. fname,
-			data = ""
-		}
-	elseif flag == 3 then -- End
-		if not download_buffer.name then return end
-
-		if net.ReadBool() then
-			file.Append( download_buffer.name, download_buffer.data )
+	local path, name = process_filepath(net.ReadString())
+	local append = net.ReadBool()
+	if not E2Lib.isValidFileWritePath(name) then net.ReadStream(nil, function() end):Remove() return end
+	if not file.Exists(path, "DATA") then file.CreateDir(path) end
+	net.ReadStream(nil, function(data)
+		if append then
+			file.Append(path .. name, data)
 		else
-			file.Write( download_buffer.name, download_buffer.data )
+			file.Write(path .. name, data)
 		end
-	else -- Abort
-		download_buffer = {}
-	end
-end )
+	end)
+end)
 
 --- File List ---
 
-net.Receive( "wire_expression2_request_list", function( netlen )
+net.Receive( "wire_expression2_request_list", function()
 	local dir = process_filepath(net.ReadString())
 
 	net.Start("wire_expression2_file_list")
@@ -151,9 +102,4 @@ net.Receive( "wire_expression2_request_list", function( netlen )
 			net.WriteData(fop .. "/")
 		end
 	net.SendToServer()
-end )
-
-net.Receive("wire_expression2_file_abort", function()
-	timer.Remove("wire_expression2_file_upload")
-	print("Aborted")
 end)

--- a/lua/entities/gmod_wire_expression2/core/cl_files.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_files.lua
@@ -3,7 +3,7 @@
 	By: Dan (McLovin)
 ]]--
 
-local cv_max_transfer_size = CreateConVar("wire_expression2_file_max_size", "300", { FCVAR_REPLICATED, FCVAR_ARCHIVE }, "Maximum file size in kibibytes.")
+local cv_max_transfer_size = CreateConVar("wire_expression2_file_max_size", "1024", { FCVAR_REPLICATED, FCVAR_ARCHIVE }, "Maximum file size in kibibytes.")
 
 local allowed_directories = { --prefix with >(allowed directory)/file.txt for files outside of e2files/ directory
 	["e2files"] = "e2files",

--- a/lua/entities/gmod_wire_expression2/core/cl_files.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_files.lua
@@ -56,7 +56,6 @@ net.Receive("wire_expression2_request_file", function()
 			net.Start("wire_expression2_file_upload")
 				net.WriteBool(true)
 				net.WriteUInt(#data, 32)
-				net.WriteUInt(tonumber(util.CRC(data)), 32)
 				net.WriteStream(data)
 			net.SendToServer()
 

--- a/lua/entities/gmod_wire_expression2/core/files.lua
+++ b/lua/entities/gmod_wire_expression2/core/files.lua
@@ -365,7 +365,7 @@ end
 -- Client -> Server
 
 local function file_execute(ply, file, status)
-	
+
 	local queue = uploads[ply]
 	local ent = file.ent
 

--- a/lua/entities/gmod_wire_expression2/core/files.lua
+++ b/lua/entities/gmod_wire_expression2/core/files.lua
@@ -300,7 +300,7 @@ registerCallback("destruct", function(self)
 	local iterable = { uploads[player], lists[player] } -- Ignore downloads in case the user is backing up data on removed
 
 	if iterable[1][1] and iterable[1][1].ent == entity then
-		iterable[1][1].stream:Remove() -- Special case for uploading files and only uploading files
+		iterable[1][1].Stream:Remove() -- Special case for uploading files and only uploading files
 	end
 	for _, tab in ipairs(iterable) do
 		local k = 2

--- a/lua/entities/gmod_wire_expression2/core/files.lua
+++ b/lua/entities/gmod_wire_expression2/core/files.lua
@@ -6,9 +6,9 @@
 local cv_max_transfer_size = CreateConVar("wire_expression2_file_max_size", "300", { FCVAR_REPLICATED, FCVAR_ARCHIVE }, "Maximum file size in kibibytes.")
 local cv_transfer_max      = CreateConVar("wire_expression2_file_max_queue", "5", { FCVAR_ARCHIVE }, "Maximum number of files that can be queued at once.")
 
-local download_chunk_size = 20000 -- Our overhead is pretty small so lets send it in moderate sized pieces, no need to max out the buffer
-
 E2Lib.RegisterExtension( "file", true, "Allows reading and writing of files in the player's local data directory." )
+
+local ent_IsValid = FindMetaTable("Entity").IsValid
 
 local FILE_UNKNOWN = 0
 local FILE_OK = 1
@@ -22,8 +22,11 @@ E2Lib.registerConstant( "FILE_TIMEOUT", FILE_TIMEOUT )
 E2Lib.registerConstant( "FILE_404", FILE_404 )
 E2Lib.registerConstant( "FILE_TRANSFER_ERROR", FILE_TRANSFER_ERROR )
 
+---@type table<Player, { name: string, uploading: boolean, uploaded: boolean, data: string, ent: Entity, Stream: table? }[]>
 local uploads = WireLib.RegisterPlayerTable()
+---@type table<Player, { name: string, data: string, started: boolean, downloading: boolean, downloaded: boolean, append: boolean, ent: Entity }[]>
 local downloads = WireLib.RegisterPlayerTable()
+---@type table<Player, { dir: string, data: string[], started: boolean, uploading: boolean, uploaded: boolean, ent: Entity }[]>
 local lists = WireLib.RegisterPlayerTable()
 local run_on = {
 	file = {
@@ -54,7 +57,8 @@ local function file_Upload(self, ply, entity, filename)
 		uploading = false,
 		uploaded = false,
 		data = "",
-		ent = entity
+		ent = entity,
+		Stream = nil
 	}
 
 	if #queue == 1 then
@@ -85,7 +89,6 @@ local function file_Download(self, ply, filename, data, append)
 	queue[#queue + 1] = {
 		name = filename,
 		data = data,
-		index = 0,
 		started = false,
 		downloading = true,
 		downloaded = false,
@@ -291,15 +294,13 @@ registerCallback("construct", function(self)
 	lists[player] = lists[player] or { last = {} }
 end )
 
-util.AddNetworkString("wire_expression2_file_abort")
-
 registerCallback("destruct", function(self)
 	local player, entity = self.player, self.entity
 
 	local iterable = { uploads[player], lists[player] } -- Ignore downloads in case the user is backing up data on removed
 
 	if iterable[1][1] and iterable[1][1].ent == entity then
-		net.Start("wire_expression2_file_abort") net.Send(player) -- Special case for uploading files and only uploading files
+		iterable[1][1].stream:Remove() -- Special case for uploading files and only uploading files
 	end
 	for _, tab in ipairs(iterable) do
 		local k = 2
@@ -325,68 +326,38 @@ util.AddNetworkString("wire_expression2_file_download")
 -- 2 - Upload
 -- 3 - End
 
-local function flushFileBufferInner()
-	local die = true
+flushFileBuffer = function()
 	for ply, queue in pairs(downloads) do
-		if IsValid(ply) then
+		if ent_IsValid(ply) then
 			local fdata = queue[1]
-			if fdata and fdata.downloading then
-				if not fdata.started then
-					net.Start("wire_expression2_file_download")
-						net.WriteUInt(1, 2)
-						net.WriteString(fdata.name or "")
-					net.Send(ply)
+			if fdata and not fdata.started then
+				fdata.started = true -- These extra flags are still needed for the old file functions
 
-					fdata.started = true
-					die = false
-				end
+				local name, data = fdata.name, fdata.data
 
-				local index = fdata.index
-				local data = fdata.data
+				net.Start("wire_expression2_file_download")
+					net.WriteString(name or "")
+					net.WriteBool(fdata.append)
+					net.WriteStream(data, function()
+						fdata.downloaded = true
+						fdata.downloading = false
 
-				local strlen = math.min(#data - index, download_chunk_size)
+						queue.last = fdata
 
-				if strlen > 0 then
-					net.Start("wire_expression2_file_download")
-					net.WriteUInt(2, 2)
-					net.WriteUInt(strlen, 32)
-					net.WriteData(data:sub(index + 1), strlen)
-					net.Send(ply)
+						local ent = fdata.ent
+						timer.Simple(0, function() -- Trigger one tick ahead so the client has time to write the file
+							if ent_IsValid(ent) and ent.ExecuteEvent then ent:ExecuteEvent("fileWritten", { name, data }) end
+						end)
 
-					fdata.index = strlen
+						table.remove(queue, 1)
 
-					die = false
-				elseif strlen <= 0 then
-					net.Start("wire_expression2_file_download")
-						net.WriteUInt(3, 2)
-						net.WriteBool(fdata.append or false)
-					net.Send(ply)
-
-					fdata.downloaded = true
-					fdata.downloading = false
-
-					queue.last = fdata
-
-					local ent, name = fdata.ent, fdata.name -- Store as an upvalue in case fdata gets removed
-					timer.Simple(0, function() -- Trigger one tick ahead so the client has time to write the file
-						if ent and ent.ExecuteEvent then ent:ExecuteEvent("fileWritten", { name, data }) end
+						if #queue ~= 0 and not timer.Exists("wire_expression2_flush_file_buffer") then -- Queue the next file
+							timer.Create("wire_expression2_flush_file_buffer", 0.2, 0, flushFileBuffer)
+						end
 					end)
-
-					table.remove(queue, 1)
-
-					if #queue ~= 0 then
-						die = false
-					end
-				end
+				net.Send(ply)
 			end
 		end
-	end
-	if die then timer.Remove("wire_expression2_flush_file_buffer") end
-end
-
-flushFileBuffer = function()
-	if not timer.Exists("wire_expression2_flush_file_buffer") then
-		timer.Create("wire_expression2_flush_file_buffer", 0.2, 0, flushFileBufferInner)
 	end
 end
 
@@ -396,9 +367,9 @@ end
 local function file_execute(ply, file, status)
 	
 	local queue = uploads[ply]
-	local ent, filename = file.ent
+	local ent = file.ent
 
-	if ent:IsValid() then
+	if ent_IsValid(ent) then
 		local filename = file.name
 		run_on.file.name = filename
 		run_on.file.status = status
@@ -432,80 +403,37 @@ end
 
 util.AddNetworkString("wire_expression2_file_upload")
 net.Receive("wire_expression2_file_upload", function(_, ply)
-	local flag = net.ReadUInt(2)
 	local pfile = uploads[ply][1]
-	if pfile and pfile.abort then flag = 0 end
+	if pfile then
+		if net.ReadBool() and not pfile.uploading and not pfile.uploaded then
+			local len = net.ReadUInt(32)
+			local CRC = net.ReadUInt(32)
+			if len / 1024 > cv_max_transfer_size:GetInt() then
+				pfile.uploading = false
+				pfile.uploaded = false
+				file_execute(ply, pfile, FILE_TRANSFER_ERROR)
+			else
+				pfile.uploading = true
+				pfile.Stream = net.ReadStream(nil, function(data)
+					pfile.data = data
+					pfile.uploading = false
+					pfile.uploaded = true
 
-	if flag == 2 then
-		if not pfile or not pfile.buffer then return end
-		if not pfile.uploading then
-			file_execute(ply, pfile, FILE_TRANSFER_ERROR)
-		end
-
-		local len = net.ReadUInt(32)
-		pfile.buffer = pfile.buffer .. net.ReadData(len)
-
-		timer.Create("wire_expression2_file_check_timeout_" .. ply:EntIndex(), 5, 1, function()
-			local pfile = uploads[ply][1]
-			if not pfile or pfile.abort then return end
-			pfile.uploading = false
-			pfile.uploaded = false
-			file_execute(ply, pfile, FILE_TIMEOUT)
-		end)
-	elseif flag == 1 then
-		if not pfile then return end
-
-		local len = net.ReadUInt(32)
-
-		if len == 0 then -- file not found
+					if tonumber(util.CRC(data)) ~= CRC then -- This isn't really possible but I guess it's nice to have
+						file_execute(ply, pfile, FILE_TRANSFER_ERROR)
+					else
+						file_execute(ply, pfile, FILE_OK)
+					end
+				end)
+			end
+		else
 			file_execute(ply, pfile, FILE_404)
-			return
-		end
-		if (len / 1024) > cv_max_transfer_size:GetInt() then return end
-
-		pfile.buffer = ""
-		pfile.len = len
-		pfile.uploading = true
-		pfile.uploaded = false
-
-		timer.Create("wire_expression2_file_check_timeout_" .. ply:EntIndex(), 5, 1, function()
-			local pfile = uploads[ply][1]
-			if not pfile or pfile.abort then return end
-			pfile.uploading = false
-			pfile.uploaded = false
-			file_execute(ply, pfile, FILE_TIMEOUT)
-		end)
-	elseif flag == 3 then
-		timer.Remove("wire_expression2_file_check_timeout_" .. ply:EntIndex())
-
-		if not pfile or not pfile.buffer then return end
-
-		pfile.uploading = false
-		pfile.data = pfile.buffer
-		pfile.buffer = ""
-
-		if string.len( pfile.data ) ~= pfile.len then -- transfer error
-			pfile.data = ""
-			file_execute(ply, pfile, FILE_TRANSFER_ERROR)
-			return
-		end
-		pfile.uploaded = true
-
-		file_execute(ply, pfile, FILE_OK)
-	else
-		timer.Remove("wire_expression2_file_check_timeout_" .. ply:EntIndex())
-
-		if #uploads[ply] ~= 0 then
-			net.Start("wire_expression2_request_file")
-				net.WriteString(queue[1].name)
-				net.WriteBool(ply:IsListenServerHost())
-			net.Send(ply)
 		end
 	end
 end)
 
-concommand.Add("wire_expression2_file_singleplayer", function(ply, cmd, args)
-	if not ply:IsListenServerHost() then ply:Kick("Do not use wire_expression2_file_singleplayer in multiplayer, unless you're the host!") end
+concommand.Add("wire_expression2_file_singleplayer", function(ply, _, args)
+	if not ply:IsListenServerHost() then return end
 	local pfile = uploads[ply][1]
 	if not pfile then return end
 
@@ -514,9 +442,6 @@ concommand.Add("wire_expression2_file_singleplayer", function(ply, cmd, args)
 		file_execute(ply, pfile, FILE_404)
 		return
 	end
-
-	timer.Remove("wire_expression2_file_check_timeout_" .. ply:EntIndex())
-
 
 	pfile.uploading = false
 	pfile.data = file.Read(path)
@@ -528,7 +453,7 @@ end)
 
 --- Listing ---
 util.AddNetworkString("wire_expression2_file_list")
-net.Receive("wire_expression2_file_list", function(netlen, ply)
+net.Receive("wire_expression2_file_list", function(_, ply)
 	local queue = lists[ply]
 	local plist = queue[1]
 	if not plist then return end

--- a/lua/entities/gmod_wire_expression2/core/files.lua
+++ b/lua/entities/gmod_wire_expression2/core/files.lua
@@ -396,7 +396,6 @@ local function file_execute(ply, file, status)
 	if #queue ~= 0 then
 		net.Start("wire_expression2_request_file")
 			net.WriteString(queue[1].name)
-			net.WriteBool(ply:IsListenServerHost())
 		net.Send(ply)
 	end
 end
@@ -407,7 +406,6 @@ net.Receive("wire_expression2_file_upload", function(_, ply)
 	if pfile then
 		if net.ReadBool() and not pfile.uploading and not pfile.uploaded then
 			local len = net.ReadUInt(32)
-			local CRC = net.ReadUInt(32)
 			if len / 1024 > cv_max_transfer_size:GetInt() then
 				pfile.uploading = false
 				pfile.uploaded = false
@@ -419,11 +417,7 @@ net.Receive("wire_expression2_file_upload", function(_, ply)
 					pfile.uploading = false
 					pfile.uploaded = true
 
-					if tonumber(util.CRC(data)) ~= CRC then -- This isn't really possible but I guess it's nice to have
-						file_execute(ply, pfile, FILE_TRANSFER_ERROR)
-					else
-						file_execute(ply, pfile, FILE_OK)
-					end
+					file_execute(ply, pfile, FILE_OK)
 				end)
 			end
 		else

--- a/lua/entities/gmod_wire_expression2/core/files.lua
+++ b/lua/entities/gmod_wire_expression2/core/files.lua
@@ -3,7 +3,7 @@
 	By: Dan (McLovin)
 ]]--
 
-local cv_max_transfer_size = CreateConVar("wire_expression2_file_max_size", "300", { FCVAR_REPLICATED, FCVAR_ARCHIVE }, "Maximum file size in kibibytes.")
+local cv_max_transfer_size = CreateConVar("wire_expression2_file_max_size", "1024", { FCVAR_REPLICATED, FCVAR_ARCHIVE }, "Maximum file size in kibibytes.")
 local cv_transfer_max      = CreateConVar("wire_expression2_file_max_queue", "5", { FCVAR_ARCHIVE }, "Maximum number of files that can be queued at once.")
 
 E2Lib.RegisterExtension( "file", true, "Allows reading and writing of files in the player's local data directory." )

--- a/lua/entities/gmod_wire_expression2/core/files.lua
+++ b/lua/entities/gmod_wire_expression2/core/files.lua
@@ -64,7 +64,6 @@ local function file_Upload(self, ply, entity, filename)
 	if #queue == 1 then
 		net.Start("wire_expression2_request_file")
 			net.WriteString(filename)
-			net.WriteBool(ply:IsListenServerHost())
 		net.Send(ply)
 	end
 
@@ -424,25 +423,6 @@ net.Receive("wire_expression2_file_upload", function(_, ply)
 			file_execute(ply, pfile, FILE_404)
 		end
 	end
-end)
-
-concommand.Add("wire_expression2_file_singleplayer", function(ply, _, args)
-	if not ply:IsListenServerHost() then return end
-	local pfile = uploads[ply][1]
-	if not pfile then return end
-
-	local path = args[1]
-	if not file.Exists(path, "DATA") then
-		file_execute(ply, pfile, FILE_404)
-		return
-	end
-
-	pfile.uploading = false
-	pfile.data = file.Read(path)
-	pfile.buffer = ""
-	pfile.uploaded = true
-
-	file_execute(ply, pfile, FILE_OK)
 end)
 
 --- Listing ---


### PR DESCRIPTION
Makes sending files between client and server use netstream.

Fixes #2989 

RFC:
- Should I move `process_filepath` in `cl_files.lua` to the server so I can remove the concmd for SP file management?