### PR TITLE
Reduce E2 __index calls

### DIFF
--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -120,11 +120,10 @@ function ENT:Execute()
 
 	self:PCallHook("preexecute")
 
-	local name = selfTbl.name
 	context.stackdepth = context.stackdepth + 1
 
 	if context.stackdepth >= 150 then
-		self:Error("Expression 2 (" .. name .. "): stack quota exceeded", "stack quota exceeded")
+		self:Error("Expression 2 (" .. selfTbl.name .. "): stack quota exceeded", "stack quota exceeded")
 	end
 
 	local bench = SysTime()
@@ -139,12 +138,12 @@ function ENT:Execute()
 		elseif msg == "perf" then
 			local trace = context.trace
 			self:UpdatePerf()
-			self:Error("Expression 2 (" .. name .. "): tick quota exceeded (at line " .. trace.start_line .. ", char " .. trace.start_col .. ")", "tick quota exceeded")
+			self:Error("Expression 2 (" .. selfTbl.name .. "): tick quota exceeded (at line " .. trace.start_line .. ", char " .. trace.start_col .. ")", "tick quota exceeded")
 		elseif trace then
-			self:Error("Expression 2 (" .. name .. "): Runtime error '" .. msg .. "' at line " .. trace.start_line .. ", char " .. trace.start_col, "script error")
+			self:Error("Expression 2 (" .. selfTbl.name .. "): Runtime error '" .. msg .. "' at line " .. trace.start_line .. ", char " .. trace.start_col, "script error")
 		else
 			local trace = context.trace
-			self:Error("Expression 2 (" .. name .. "): Internal error '" .. msg .. "' at line " .. trace.start_line .. ", char " .. trace.start_col, "script error")
+			self:Error("Expression 2 (" .. selfTbl.name .. "): Internal error '" .. msg .. "' at line " .. trace.start_line .. ", char " .. trace.start_col, "script error")
 		end
 	end
 
@@ -182,7 +181,7 @@ function ENT:Execute()
 
 	if context.prfcount + context.prf - e2_softquota > e2_hardquota then
 		local trace = context.trace
-		self:Error("Expression 2 (" .. name .. "): tick quota exceeded (at line " .. trace.start_line .. ", char " .. trace.start_col .. ")", "hard quota exceeded")
+		self:Error("Expression 2 (" .. selfTbl.name .. "): tick quota exceeded (at line " .. trace.start_line .. ", char " .. trace.start_col .. ")", "hard quota exceeded")
 	end
 
 	if self.error then


### PR DESCRIPTION
This skips the expensive entity __index calls in some frequently called functions by just calling GetTable() directly and reuses calls where possible, which helps to reduce the general performance impact of E2 execution a little bit.