### PR TITLE
Remove "self" from ModelPlug_AddToCPanel

### DIFF
--- a/lua/wire/client/wiredermaexts.lua
+++ b/lua/wire/client/wiredermaexts.lua
@@ -6,7 +6,7 @@ language.Add("wire_model", "Model:")
 function ModelPlug_AddToCPanel(panel, category, toolname, textbox_label, height)
 	local list = list.Get("Wire_"..category.."_Models")
 	if table.Count(list) > 1 then
-		local ModelSelect = vgui.Create("DWireModelSelect", self)
+		local ModelSelect = vgui.Create("DWireModelSelect", panel)
 		ModelSelect:SetModelList(list, toolname .. "_model")
 		ModelSelect:SetHeight(height)
 		panel:AddPanel(ModelSelect)


### PR DESCRIPTION
This function uses `self` which is normally not defined. This changes it to `panel`.

One user noted this causes an error if another addon accidentally creates a global variable named "self". By defining `self` globally on the clientside, you can replicate said error.