### PR TITLE
Pod controller refactoring

### DIFF
--- a/lua/entities/gmod_wire_pod.lua
+++ b/lua/entities/gmod_wire_pod.lua
@@ -1,8 +1,7 @@
 AddCSLuaFile()
-DEFINE_BASECLASS( "base_wire_entity" )
+DEFINE_BASECLASS("base_wire_entity")
 ENT.PrintName       = "Wire Pod Controller"
 ENT.WireDebugName	= "Pod Controller"
-ENT.AllowLockInsideVehicle = CreateConVar( "wire_pod_allowlockinsidevehicle", "0", FCVAR_ARCHIVE, "Allow or disallow people to be locked inside of vehicles" )
 
 if CLIENT then
 	local hideHUD = 0
@@ -13,34 +12,39 @@ if CLIENT then
 	local toolgunHUDFunc = nil
 	local function blank() end
 
-	usermessage.Hook( "wire pod hud", function( um )
-		hideHUD = um:ReadShort()
+	net.Receive("wire_pod_hud", function()
+		hideHUD = net.ReadUInt(2)
 		if hideHUD > 0 and not HUDHidden then
+			local ply = LocalPlayer()
 			HUDHidden = true
+
 			if firstTime then
-				LocalPlayer():ChatPrint( "The owner of this vehicle has hidden your hud using a pod controller. If it gets stuck this way, use the console command 'wire_pod_hud_show' to forcibly enable it again." )
+				ply:ChatPrint("The owner of this vehicle has hidden your hud using a pod controller. If it gets stuck this way, use the console command 'wire_pod_hud_show' to forcibly enable it again.")
 				firstTime = false
 			end
-			--Hide toolgun HUD
-			local toolgun = LocalPlayer():GetWeapon("gmod_tool")
+
+			-- Hide toolgun HUD
+			local toolgun = ply:GetWeapon("gmod_tool")
 			if IsValid(toolgun) then
 				toolgunHUDFunc = toolgun.DrawHUD
 				toolgun.DrawHUD = blank
 			end
-			--Hide all HUDPaints except for EGP HUD
+
+			-- Hide all HUDPaints except for EGP HUD
 			local hooks = hook.GetTable()["HUDPaint"]
 			savedHooks = table.Copy(hooks)
 			for k in pairs(hooks) do
 				if hideHUD > 2 or k ~= "EGP_HUDPaint" then
-					hook.Add( "HUDPaint", k, blank )
+					hook.Add("HUDPaint", k, blank)
 				end
 			end
-			--Hide other HUD elements
-			hook.Add( "DrawDeathNotice", "Wire pod DrawDeathNotice", function() return false end)
-			hook.Add( "HUDDrawTargetID", "Wire pod HUDDrawTargetID", function() return false end)
-			hook.Add( "HUDShouldDraw", "Wire pod HUDShouldDraw", function( name )
+
+			-- Hide other HUD elements
+			hook.Add("DrawDeathNotice", "wire_pod_drawdeathnotice", function() return false end)
+			hook.Add("HUDDrawTargetID", "wire_pod_huddrawtargetid", function() return false end)
+			hook.Add("HUDShouldDraw", "wire_pod_hudshoulddraw", function(name)
 				if hideHUD > 0 then
-					if LocalPlayer():InVehicle() then
+					if ply:InVehicle() then
 						--Allow crosshair (it can be hidden using the other input) and CHudGMod (for the EGP HUDPaint to pass through). Hide the chat if the input is higher than 1
 						if name ~= "CHudCrosshair" and name ~= "CHudGMod" and (hideHUD > 1 and name == "CHudChat" or name ~= "CHudChat")  then return false end
 					else
@@ -48,7 +52,7 @@ if CLIENT then
 					end
 				else
 					--Restore toolgun HUD
-					local toolgun = LocalPlayer():GetWeapon("gmod_tool")
+					local toolgun = ply:GetWeapon("gmod_tool")
 					if IsValid(toolgun) and toolgun.DrawHUD == blank and toolgunHUDFunc ~= nil then
 						toolgun.DrawHUD = toolgunHUDFunc
 					end
@@ -57,56 +61,60 @@ if CLIENT then
 					local hooks = hook.GetTable()["HUDPaint"]
 					for k,v in pairs(hooks) do
 						if v == blank and savedHooks ~= nil and savedHooks[k] ~= nil then
-							hook.Add( "HUDPaint", k, savedHooks[k] )
+							hook.Add("HUDPaint", k, savedHooks[k])
 						end
 					end
 					savedHooks = nil
 
-					hook.Remove( "HUDShouldDraw", "Wire pod HUDShouldDraw")
-					hook.Remove( "DrawDeathNotice", "Wire pod DrawDeathNotice")
-					hook.Remove( "HUDDrawTargetID", "Wire pod HUDDrawTargetID")
+					hook.Remove("HUDShouldDraw", "wire_pod_hudshoulddraw")
+					hook.Remove("DrawDeathNotice", "wire_pod_drawdeathnotice")
+					hook.Remove("HUDDrawTargetID", "wire_pod_huddrawtargetid")
 					HUDHidden = false
 				end
 			end)
 		end
 	end)
 
-	concommand.Add( "wire_pod_hud_show", function(ply,cmd,args)
+	concommand.Add("wire_pod_hud_show", function(ply, cmd, args)
 		hideHUD = 0
 	end)
 
-	usermessage.Hook( "wire pod cursor", function( um )
-		local b = um:ReadShort() ~= 0
+	net.Receive("wire_pod_cursor", function()
+		local b = net.ReadBool()
 		local pnl = vgui.GetWorldPanel()
-		pnl:SetWorldClicker( b ) -- this allows the cursor to move the player's eye
+		pnl:SetWorldClicker(b) -- This allows the cursor to move the player's eye
 		if b then RestoreCursorPosition() else RememberCursorPosition() end
-		gui.EnableScreenClicker( b )
+		gui.EnableScreenClicker(b)
 
 		if b and firstTimeCursor then
-			LocalPlayer():ChatPrint( "The owner of this vehicle has enabled your cursor using a pod controller. If it gets stuck this way, use the console command 'wire_pod_cursor_disable' to forcibly disable it." )
+			LocalPlayer():ChatPrint("The owner of this vehicle has enabled your cursor using a pod controller. If it gets stuck this way, use the console command 'wire_pod_cursor_disable' to forcibly disable it.")
 			firstTimeCursor = false
 		end
 	end)
 
-	concommand.Add( "wire_pod_cursor_disable", function(ply,cmd,args)
+	concommand.Add("wire_pod_cursor_disable", function(ply, cmd, args)
 		local pnl = vgui.GetWorldPanel()
-		pnl:SetWorldClicker( false )
-		gui.EnableScreenClicker( false )
+		pnl:SetWorldClicker(false)
+		gui.EnableScreenClicker(false)
 	end)
 
-	return  -- No more client
+	return -- No more client
 end
 
 -- Server
 
+util.AddNetworkString("wire_pod_hud")
+util.AddNetworkString("wire_pod_cursor")
+
 local pods = ents.FindByClass("gmod_wire_pod") or {}
+local allowLockInsideVehicle = CreateConVar("wire_pod_allowlockinsidevehicle", "0", FCVAR_ARCHIVE, "Allow or disallow people to be locked inside of vehicles")
 local PlayerBindDownHook, PlayerBindUpHook, Wire_Pod_EnterVehicle, Wire_Pod_ExitVehicle, Wire_Pod_CanExitVehicle
 
 function ENT:Initialize()
-	self:PhysicsInit( SOLID_VPHYSICS )
-	self:SetMoveType( MOVETYPE_VPHYSICS )
-	self:SetSolid( SOLID_VPHYSICS )
-	self:SetUseType( SIMPLE_USE )
+	self:PhysicsInit(SOLID_VPHYSICS)
+	self:SetMoveType(MOVETYPE_VPHYSICS)
+	self:SetSolid(SOLID_VPHYSICS)
+	self:SetUseType(SIMPLE_USE)
 
 	table.insert(pods, self)
 	if #pods == 1 then
@@ -154,13 +162,13 @@ function ENT:Initialize()
 		"Vehicle [ENTITY]"
 	}
 
-	self.Inputs = WireLib.CreateInputs( self, inputs )
-	self.Outputs = WireLib.CreateOutputs( self, outputs )
+	self.Inputs = WireLib.CreateInputs(self, inputs)
+	self.Outputs = WireLib.CreateOutputs(self, outputs)
 
-	self:SetLocked( false )
-	self:SetHidePlayer( false )
-	self:SetHideHUD( 0 )
-	self:SetShowCursor( 0 )
+	self:SetLocked(false)
+	self:SetHidePlayer(false)
+	self:SetHideHUD(0)
+	self:SetShowCursor(0)
 	self.HidePlayerVal = false
 	self.Crosshairs = false
 	self.Disable = false
@@ -168,23 +176,36 @@ function ENT:Initialize()
 	self.Relative = false
 	self.MouseDown = false
 
-	self:SetActivated( false )
+	self.LastX = 0
+	self.LastY = 0
+	self.LastZ = 0
+	self.LastTeam = 0
+	self.LastHealth = 0
+	self.LastArmor = 0
+	self.LastAimPos = 0
+	self.LastDistance = 0
+	self.LastBearing = 0
+	self.LastElevation = 0
+	self.LastThirdPerson = 0
+
+	self:SetActivated(false)
 
 	self:ColorByLinkStatus(self.LINK_STATUS_UNLINKED)
 
-	self:SetOverlayText( "Pod Controller" )
+	self:SetOverlayText("Pod Controller")
 end
 
 -- Accessor funcs for certain functions
-function ENT:SetLocked( b )
-	if not self:HasPod() or self.Locked == b then return end
+function ENT:SetLocked(b)
+	local pod = self:GetPod()
+	if not pod or self.Locked == b then return end
 
 	self.Locked = b
-	self.Pod:Fire( b and "Lock" or "Unlock", "1", 0 )
+	pod:Fire(b and "Lock" or "Unlock", "1", 0)
 end
 
-function ENT:SetActivated( b )
-	if (self.Activated == b) then return end
+function ENT:SetActivated(b)
+	if self.Activated == b then return end
 
 	self:ColorByLinkStatus(b and self.LINK_STATUS_ACTIVE or self.LINK_STATUS_LINKED)
 
@@ -192,10 +213,11 @@ function ENT:SetActivated( b )
 	WireLib.TriggerOutput(self, "Active", b and 1 or 0)
 end
 
-function ENT:HidePlayer( b )
-	if not self:HasPly() then return end
+function ENT:HidePlayer(b)
+	local ply = self:GetPly()
+	if not ply then return end
 
-	local c = self:GetPly():GetColor()
+	local c = ply:GetColor()
 	if b then
 		self.OldPlyAlpha = c.a
 		c.a = 0
@@ -203,40 +225,40 @@ function ENT:HidePlayer( b )
 		c.a = self.OldPlyAlpha or 255
 		self.OldPlyAlpha = nil
 	end
-	self:GetPly():SetColor(c)
-	self:GetPly():SetRenderMode(c.a ~= 255 and RENDERMODE_TRANSALPHA or RENDERMODE_NORMAL)
+	ply:SetColor(c)
+	ply:SetRenderMode(c.a ~= 255 and RENDERMODE_TRANSALPHA or RENDERMODE_NORMAL)
 end
 
-function ENT:SetHidePlayer( b )
-	if (self.HidePlayer == b) then return end
+function ENT:SetHidePlayer(b)
+	if self.HidePlayer == b then return end
 
 	self.HidePlayerVal = b
 
-	if (self:HasPly()) then
-		self:HidePlayer( b )
+	if self:GetPly() then
+		self:HidePlayer(b)
 	end
 end
 
-function ENT:LinkEnt( pod )
-	pod = WireLib.GetClosestRealVehicle(pod,self:GetPos(),self:GetPlayer())
+function ENT:LinkEnt(pod)
+	pod = WireLib.GetClosestRealVehicle(pod, self:GetPos(), self:GetPlayer())
 
 	-- if pod is still not a vehicle even after all of the above, then error out
 	if not IsValid(pod) or not pod:IsVehicle() then return false, "Must link to a vehicle" end
-	if not WireLib.CanTool(self:GetPlayer(), pod, "wire_pod" ) then return false, "You do not have permission to access this vehicle" end
+	if not WireLib.CanTool(self:GetPlayer(), pod, "wire_pod") then return false, "You do not have permission to access this vehicle" end
 
-	self:SetPod( pod )
-	WireLib.SendMarks(self, {pod})
+	self:SetPod(pod)
+	WireLib.SendMarks(self, { pod })
 	return true
 end
 function ENT:UnlinkEnt()
 	if IsValid(self.Pod) then
 		self.Pod:RemoveCallOnRemove("wire_pod_remove")
 	end
-	self:SetShowCursor( 0 )
+	self:SetShowCursor(0)
 	self.Pod = nil
 	self:PlayerExited()
 	WireLib.SendMarks(self, {})
-	WireLib.TriggerOutput( self, "Entity", NULL )
+	WireLib.TriggerOutput(self, "Entity", NULL)
 	self:ColorByLinkStatus(self.LINK_STATUS_UNLINKED)
 	return true
 end
@@ -252,23 +274,27 @@ function ENT:OnRemove()
 	end
 end
 
-function ENT:HasPod() return (self.Pod and self.Pod:IsValid()) end
-function ENT:GetPod() return self.Pod end
-function ENT:SetPod( pod )
+-- function ENT:HasPod() return (self.Pod and self.Pod:IsValid()) end
+function ENT:GetPod()
+	local pod = self.Pod
+	if not IsValid(pod) then return end
+	return pod
+end
+function ENT:SetPod(pod)
 	if pod and pod:IsValid() and not pod:IsVehicle() then return false end
 
-	if self:HasPly() then
+	if self:GetPly() then
 		self:PlayerExited()
 	else
 		self:ColorByLinkStatus(IsValid(pod) and self.LINK_STATUS_LINKED or self.LINK_STATUS_UNLINKED)
 	end
 
 	self.Pod = pod
-	WireLib.TriggerOutput( self, "Entity", pod )
+	WireLib.TriggerOutput(self, "Entity", pod)
 
 	if not IsValid(pod) then return true end
 
-	pod:CallOnRemove("wire_pod_remove",function()
+	pod:CallOnRemove("wire_pod_remove", function()
 		if self:IsValid() then self:UnlinkEnt(pod) end
 	end)
 
@@ -279,40 +305,45 @@ function ENT:SetPod( pod )
 	return true
 end
 
-function ENT:HasPly()
-	return (self.Ply and self.Ply:IsValid())
-end
+-- function ENT:HasPly() return self.Ply and self.Ply:IsValid() end
 function ENT:GetPly()
-	return self.Ply
+	local ply = self.Ply
+	if not IsValid(ply) then return end
+	return ply
 end
-function ENT:SetPly( ply )
+function ENT:SetPly(ply)
 	if IsValid(ply) and not ply:IsPlayer() then return false end
 	self.Ply = ply
-	WireLib.TriggerOutput( self, "Driver", ply )
+	WireLib.TriggerOutput(self, "Driver", ply)
 	return true
 end
 
-function ENT:SetHideHUD( val )
+function ENT:SetHideHUD(val)
+	local ply = self:GetPly()
 	self.HideHUD = val
 
-	if self:HasPly() and self:HasPod() then -- If we have a player, we SHOULD always have a pod as well, but just in case.
-		umsg.Start( "wire pod hud", self:GetPly() )
-			umsg.Short( self.HideHUD )
-		umsg.End()
+	if ply and self:GetPod() then -- If we have a player, we SHOULD always have a pod as well, but just in case.
+		net.Start("wire_pod_hud")
+			net.WriteUInt(self.HideHUD, 2)
+		net.Send(ply)
 	end
 end
 function ENT:GetHideHUD() return self.HideHUD end
 
-function ENT:NetShowCursor( val, ply )
-	umsg.Start( "wire pod cursor", ply or self:GetPly() )
-		umsg.Short( val or self.ShowCursor )
-	umsg.End()
+function ENT:NetShowCursor(val, ply)
+	ply = ply or self:GetPly()
+	if not ply then return end
+
+	net.Start("wire_pod_cursor")
+		net.WriteBool(val or self.ShowCursor)
+	net.Send(ply)
 end
-function ENT:SetShowCursor( val )
+function ENT:SetShowCursor(val)
+	local ply = self:GetPly()
 	self.ShowCursor = val
 
-	if self:HasPly() and self:HasPod() then
-		self:NetShowCursor()
+	if ply and self:GetPod() then
+		self:NetShowCursor(val, ply)
 	end
 end
 function ENT:GetShowCursor() return self.ShowCursor end
@@ -370,79 +401,82 @@ function ENT:RCEject()
 	self.RC:Off()
 end
 
-function ENT:TriggerInput( name, value )
-	if (name == "Lock") then
-		if (self.RC) then return end
-		if not self:HasPod() then return end
-		self:SetLocked( value ~= 0 )
-	elseif (name == "Terminate") then
-		if value == 0 or not self:HasPly() then return end
+function ENT:TriggerInput(name, value)
+	if name == "Lock" then
+		if self.RC then return end
+		if not self:GetPod() then return end
+		self:SetLocked(value ~= 0)
+	elseif name == "Terminate" then
 		local ply = self:GetPly()
-		if (self.RC) then self:RCEject( ply ) end
+		if value == 0 or not ply then return end
+		if self.RC then self:RCEject(ply) end
 		ply:Kill()
-	elseif (name == "Strip weapons") then
-		if value == 0 or not self:HasPly() then return end
+	elseif name == "Strip weapons" then
 		local ply = self:GetPly()
-		if (self.RC) then
-			ply:ChatPrint( "Your control has been terminated, and your weapons stripped!" )
-			self:RCEject( ply )
+		if value == 0 or not ply then return end
+		if self.RC then
+			ply:ChatPrint("Your control has been terminated, and your weapons stripped!")
+			self:RCEject(ply)
 		else
-			ply:ChatPrint( "Your weapons have been stripped!" )
+			ply:ChatPrint("Your weapons have been stripped!")
 		end
 		ply:StripWeapons()
-	elseif (name == "Eject") then
-		if value == 0 or not self:HasPly() then return end
-		if (self.RC) then
-			self:RCEject( self:GetPly() )
+	elseif name == "Eject" then
+		local ply = self:GetPly()
+		if value == 0 or not ply then return end
+		if self.RC then
+			self:RCEject(ply)
 		else
-			self:GetPly():ExitVehicle()
+			ply:ExitVehicle()
 		end
-	elseif (name == "Disable") then
+	elseif name == "Disable" then
 		self.Disable = value ~= 0
 
-		if (self.Disable) then
-			for _, output in pairs( bindingToOutput ) do
-				WireLib.TriggerOutput( self, output, 0 )
+		if self.Disable then
+			for _, output in pairs(bindingToOutput) do
+				WireLib.TriggerOutput(self, output, 0)
 			end
 		end
-	elseif (name == "Crosshairs") then
+	elseif name == "Crosshairs" then
 		self.Crosshairs = value ~= 0
-		if (self:HasPly()) then
-			if (self.Crosshairs) then
-				self:GetPly():CrosshairEnable()
-			else
-				self:GetPly():CrosshairDisable()
-			end
-		end
-	elseif (name == "Brake") then
-		if not self:HasPod() then return end
-		local pod = self:GetPod()
-		if value ~= 0 then
-			pod:Fire("TurnOff","1",0)
-			pod:Fire("HandBrakeOn","1",0)
+		local ply = self:GetPly()
+		if not ply then return end
+		if self.Crosshairs then
+			ply:CrosshairEnable()
 		else
-			pod:Fire("TurnOn","1",0)
-			pod:Fire("HandBrakeOff","1",0)
+			ply:CrosshairDisable()
 		end
-	elseif (name == "Damage Health") then
-		if not self:HasPly() or value <= 0 then return end
-		self:GetPly():TakeDamage( math.min(value, 100) )
-	elseif (name == "Damage Armor") then
-		if not self:HasPly() or value <= 0 then return end
-		local dmg = math.max(self:GetPly():Armor() - value, 0)
-		self:GetPly():SetArmor( dmg )
-	elseif (name == "Allow Buttons") then
+	elseif name == "Brake" then
+		local pod = self:GetPod()
+		if not pod then return end
+		if value ~= 0 then
+			pod:Fire("TurnOff", "1", 0)
+			pod:Fire("HandBrakeOn", "1", 0)
+		else
+			pod:Fire("TurnOn", "1", 0)
+			pod:Fire("HandBrakeOff", "1", 0)
+		end
+	elseif name == "Damage Health" then
+		local ply = self:GetPly()
+		if not ply or value <= 0 then return end
+		ply:TakeDamage(math.min(value, 100))
+	elseif name == "Damage Armor" then
+		local ply = self:GetPly()
+		if not ply or value <= 0 then return end
+		local dmg = math.max(ply:Armor() - value, 0)
+		ply:SetArmor(dmg)
+	elseif name == "Allow Buttons" then
 		self.AllowButtons = value ~= 0
-	elseif (name == "Relative") then
+	elseif name == "Relative" then
 		self.Relative = value ~= 0
-	elseif (name == "Hide Player") then
-		self:SetHidePlayer( value ~= 0 )
-	elseif (name == "Hide HUD") then
+	elseif name == "Hide Player" then
+		self:SetHidePlayer(value ~= 0)
+	elseif name == "Hide HUD" then
 		self:SetHideHUD( value )
-	elseif (name == "Show Cursor") then
-		self:SetShowCursor( value )
-	elseif (name == "Vehicle") then
-		if not IsValid(value) then return end -- only link if the input is valid. that way, it won't be unlinked if the wire is disconnected
+	elseif name == "Show Cursor" then
+		self:SetShowCursor(value)
+	elseif name == "Vehicle" then
+		if not IsValid(value) then return end -- Only link if the input is valid. That way, it won't be unlinked if the wire is disconnected
 		if value:IsPlayer() then return end
 		if value:IsNPC() then return end
 
@@ -456,163 +490,184 @@ local function fixupangle(angle)
 	return angle
 end
 
+local function recacheOutput(entity, selfTbl, oname, value)
+	if selfTbl["Last" .. oname] == value then return end
+	selfTbl["Last" .. oname] = value
+	WireLib.TriggerOutput(entity, oname, value)
+end
+
 function ENT:Think()
-	if (self:HasPly() and self.Activated) then
-		local ply = self:GetPly()
+	local selfTbl = self:GetTable()
+	local ply = self:GetPly()
+
+	if ply and selfTbl.Activated then
 		local pod = self:GetPod()
 
 		-- Tracing
-		local trace = util.TraceLine( { start = ply:GetShootPos(), endpos = ply:GetShootPos() + ply:GetAimVector() * 9999999999, filter = { ply, pod } } )
+		local shootPos = ply:GetShootPos()
+		local aimVector = ply:GetAimVector()
+		local trace = util.TraceLine({ start = shootPos, endpos = shootPos + aimVector * 9999999999, filter = { ply, pod } })
 		local distance
-		if (self:HasPod()) then distance = trace.HitPos:Distance( pod:GetPos() ) else distance = trace.HitPos:Distance( ply:GetShootPos() ) end
+		local hitPos = trace.HitPos
+		if pod then distance = hitPos:Distance(pod:GetPos()) else distance = hitPos:Distance(shootPos) end
 
-		if (trace.Hit) then
+		if trace.Hit then
 			-- Position
-			WireLib.TriggerOutput( self, "X", trace.HitPos.x )
-			WireLib.TriggerOutput( self, "Y", trace.HitPos.y )
-			WireLib.TriggerOutput( self, "Z", trace.HitPos.z )
-			WireLib.TriggerOutput( self, "AimPos", trace.HitPos )
-			WireLib.TriggerOutput( self, "Distance", distance )
-			self.VPos = trace.HitPos
+			recacheOutput(self, selfTbl, "X", hitPos.x)
+			recacheOutput(self, selfTbl, "Y", hitPos.y)
+			recacheOutput(self, selfTbl, "Z", hitPos.z)
+			recacheOutput(self, selfTbl, "AimPos", hitPos)
+			recacheOutput(self, selfTbl, "Distance", distance)
+			selfTbl.VPos = hitPos
 
 			-- Bearing & Elevation
-			local angle = ply:GetAimVector():Angle()
+			local angle = aimVector:Angle()
 
-			if (self.Relative) then
+			if selfTbl.Relative then
 				local originalangle
-				if (self.RC) then
-					originalangle = self.RC.InitialAngle
+				if selfTbl.RC then
+					originalangle = selfTbl.RC.InitialAngle
 				else
-					local attachment = pod:LookupAttachment( "vehicle_driver_eyes" )
-					if (attachment > 0) then
-						originalangle = pod:GetAttachment( attachment ).Ang
+					local attachment = pod:LookupAttachment("vehicle_driver_eyes")
+					if attachment > 0 then
+						originalangle = pod:GetAttachment(attachment).Ang
 					else
 						originalangle = pod:GetAngles()
 					end
 				end
-				WireLib.TriggerOutput( self, "Bearing", fixupangle( angle.y - originalangle.y ) )
-				WireLib.TriggerOutput( self, "Elevation", fixupangle( angle.p - originalangle.p ) )
+				recacheOutput(self, selfTbl, "Bearing", fixupangle(angle.y - originalangle.y))
+				recacheOutput(self, selfTbl, "Elevation", fixupangle(angle.p - originalangle.p))
 			else
-				WireLib.TriggerOutput( self, "Bearing", fixupangle( angle.y ) )
-				WireLib.TriggerOutput( self, "Elevation", fixupangle( -angle.p ) )
+				recacheOutput(self, selfTbl, "Bearing", fixupangle(angle.y))
+				recacheOutput(self, selfTbl, "Elevation", fixupangle(-angle.p))
 			end
 		else
-			WireLib.TriggerOutput( self, "X", 0 )
-			WireLib.TriggerOutput( self, "Y", 0 )
-			WireLib.TriggerOutput( self, "Z", 0 )
-			WireLib.TriggerOutput( self, "AimPos", Vector(0,0,0) )
-			WireLib.TriggerOutput( self, "Bearing", 0 )
-			WireLib.TriggerOutput( self, "Elevation", 0 )
-			self.VPos = Vector(0,0,0)
+			recacheOutput(self, selfTbl, "X", 0)
+			recacheOutput(self, selfTbl, "Y", 0)
+			recacheOutput(self, selfTbl, "Z", 0)
+			recacheOutput(self, selfTbl, "AimPos", vector_origin)
+			recacheOutput(self, selfTbl, "Bearing", 0)
+			recacheOutput(self, selfTbl, "Elevation", 0)
+			selfTbl.VPos = vector_origin
 		end
 
 		-- Button pressing
-		if (self.AllowButtons and distance < 82) then
+		if selfTbl.AllowButtons and distance < 82 then
 			local button = trace.Entity
-			if IsValid(button) and (ply:KeyDown( IN_ATTACK ) and not self.MouseDown) and not button:IsVehicle() and button.Use then
+			local inAttack = ply:KeyDown(IN_ATTACK)
+			local mouseDown = selfTbl.MouseDown
+
+			if IsValid(button) and (inAttack and not mouseDown) and not button:IsVehicle() and button.Use then
 				-- Generic support (Buttons, Dynamic Buttons, Levers, EGP screens, etc)
-				self.MouseDown = true
+				selfTbl.MouseDown = true
 				button:Use(ply, self, USE_ON, 0)
-			elseif not ply:KeyDown( IN_ATTACK ) and self.MouseDown then
-				self.MouseDown = false
+			elseif not inAttack and mouseDown then
+				selfTbl.MouseDown = false
 			end
 		end
 
 		-- Other info
-		WireLib.TriggerOutput(self, "Team", ply:Team())
-		WireLib.TriggerOutput(self, "Health", ply:Health())
-		WireLib.TriggerOutput(self, "Armor", ply:Armor())
-		if self:HasPod() then WireLib.TriggerOutput(self, "ThirdPerson", pod:GetThirdPersonMode() and 1 or 0) end
+		recacheOutput(self, selfTbl, "Team", ply:Team())
+		recacheOutput(self, selfTbl, "Health", ply:Health())
+		recacheOutput(self, selfTbl, "Armor", ply:Armor())
+		if pod then recacheOutput(self, selfTbl, "ThirdPerson", pod:GetThirdPersonMode() and 1 or 0) end
 	end
 
-	self:NextThink( CurTime() )
+	self:NextThink(CurTime())
 	return true
 end
 
-function ENT:PlayerEntered( ply, RC )
-	if (self:HasPly()) then return end
-	self:SetPly( ply )
+function ENT:PlayerEntered(ply, RC)
+	if self:GetPly() then return end
+	self:SetPly(ply)
 
 	self.RC = RC
 
-	if (self.Crosshairs) then
+	if self.Crosshairs then
 		ply:CrosshairEnable()
 	end
 
-	if self.HideHUD > 0 and self:HasPod() then
-		timer.Simple(0.1,function()
-			umsg.Start( "wire pod hud", ply )
-				umsg.Short( self.HideHUD )
-			umsg.End()
+	local pod = self:GetPod()
+
+	if self.HideHUD > 0 and pod then
+		timer.Simple(0.1, function()
+			net.Start("wire_pod_hud")
+				net.WriteUInt(self.HideHUD, 2)
+			net.Send(ply)
 		end)
 	end
 
-	if self.ShowCursor > 0 and self:HasPod() then
-		timer.Simple(0.1,function()
+	if self.ShowCursor > 0 and pod then
+		timer.Simple(0.1, function()
 			self:NetShowCursor(self.ShowCursor, ply)
 		end)
 	end
 
-	if (self.HidePlayerVal) then
-		self:HidePlayer( true )
+	if self.HidePlayerVal then
+		self:HidePlayer(true)
 	end
 
-	self:SetActivated( true )
+	self:SetActivated(true)
 end
 
 function ENT:PlayerExited()
-	if not self:HasPly() then return end
-
 	local ply = self:GetPly()
 
-	self:HidePlayer( false )
+	if not ply then return end
+
+	self:HidePlayer(false)
 
 	self:NetShowCursor(0, ply)
 
 	ply:CrosshairEnable()
 
-	self:SetActivated( false )
+	self:SetActivated(false)
 
 	for _, output in pairs(bindingToOutput) do
-		WireLib.TriggerOutput( self, output, 0 )
+		WireLib.TriggerOutput(self, output, 0)
 	end
 
-	WireLib.TriggerOutput( self, "X", 0 )
-	WireLib.TriggerOutput( self, "Y", 0 )
-	WireLib.TriggerOutput( self, "Z", 0 )
-	WireLib.TriggerOutput( self, "AimPos", Vector(0,0,0) )
+	WireLib.TriggerOutput(self, "X", 0)
+	WireLib.TriggerOutput(self, "Y", 0)
+	WireLib.TriggerOutput(self, "Z", 0)
+	WireLib.TriggerOutput(self, "AimPos", vector_origin)
 
-	WireLib.TriggerOutput( self, "Distance", 0 )
-	WireLib.TriggerOutput( self, "Bearing", 0 )
-	WireLib.TriggerOutput( self, "Elevation", 0 )
+	WireLib.TriggerOutput(self, "Distance", 0)
+	WireLib.TriggerOutput(self, "Bearing", 0)
+	WireLib.TriggerOutput(self, "Elevation", 0)
 
-	WireLib.TriggerOutput( self, "ThirdPerson", 0 )
-	WireLib.TriggerOutput( self, "Team", 0 )
-	WireLib.TriggerOutput( self, "Health", 0 )
-	WireLib.TriggerOutput( self, "Armor", 0 )
+	WireLib.TriggerOutput(self, "ThirdPerson", 0)
+	WireLib.TriggerOutput(self, "Team", 0)
+	WireLib.TriggerOutput(self, "Health", 0)
+	WireLib.TriggerOutput(self, "Armor", 0)
 
-	self:SetPly( nil )
+	self:SetPly(nil)
 end
 
-function Wire_Pod_EnterVehicle( ply, vehicle )
+function Wire_Pod_EnterVehicle(ply, vehicle)
 	for _, v in ipairs(pods) do
-		if (v:HasPod() and v:GetPod() == vehicle) then
-			v:PlayerEntered( ply )
+		local pod = v:GetPod()
+		if pod and pod == vehicle then
+			v:PlayerEntered(ply)
 		end
 	end
 end
 
-function Wire_Pod_ExitVehicle( ply, vehicle )
+function Wire_Pod_ExitVehicle(ply, vehicle)
 	for _, v in ipairs(pods) do
-		if (v:HasPod() and v:GetPod() == vehicle) then
+		local pod = v:GetPod()
+		if pod and pod == vehicle then
 			v:PlayerExited()
 		end
 	end
 end
 
-function Wire_Pod_CanExitVehicle( vehicle, ply )
+function Wire_Pod_CanExitVehicle(vehicle, ply)
+	local allowLock = allowLockInsideVehicle:GetBool()
+
 	for _, v in ipairs(pods) do
-		if (v:HasPod() and v:GetPod() == vehicle) and v.Locked and v.AllowLockInsideVehicle:GetBool() then
+		local pod = v:GetPod()
+		if pod and pod == vehicle and v.Locked and allowLock then
 			return false
 		end
 	end
@@ -622,14 +677,16 @@ function ENT:GetBeaconPos(sensor)
 	return self.VPos
 end
 function ENT:GetBeaconVelocity(sensor)
-	return self:HasPod() and self:GetPod():GetVelocity() or self:GetVelocity()
+	local pod = self:GetPod()
+	return pod and pod:GetVelocity() or self:GetVelocity()
 end
 
 --Duplicator support to save pod link (TAD2020)
 function ENT:BuildDupeInfo()
 	local info = BaseClass.BuildDupeInfo(self) or {}
-	if self:HasPod() and not self.RC then
-		info.pod = self.Pod:EntIndex()
+	local pod = self:GetPod()
+	if pod and not self.RC then
+		info.pod = pod:EntIndex()
 	end
 	return info
 end
@@ -645,15 +702,15 @@ end
 
 function ENT:Use( User, caller )
 	if User ~= self:GetPlayer() then return end
-	if not hook.Run("PlayerGiveSWEP", User, "remotecontroller", weapons.Get( "remotecontroller" )) then return end
+	if not hook.Run("PlayerGiveSWEP", User, "remotecontroller", weapons.Get("remotecontroller")) then return end
 	User:PrintMessage(HUD_PRINTTALK, "Hold down your use key for 2 seconds to get and link a Remote Controller.")
-	timer.Create("pod_use_"..self:EntIndex(), 2, 1, function()
+	timer.Create("pod_use_" .. self:EntIndex(), 2, 1, function()
 		if not IsValid(User) or not User:IsPlayer() then return end
 		if not User:KeyDown(IN_USE) then return end
 		if not User:GetEyeTrace().Entity or User:GetEyeTrace().Entity ~= self then return end
 
 		if not IsValid(User:GetWeapon("remotecontroller")) then
-			if not hook.Run("PlayerGiveSWEP", User, "remotecontroller", weapons.Get( "remotecontroller" )) then return end
+			if not hook.Run("PlayerGiveSWEP", User, "remotecontroller", weapons.Get("remotecontroller")) then return end
 			User:Give("remotecontroller")
 		end
 

--- a/lua/entities/gmod_wire_pod.lua
+++ b/lua/entities/gmod_wire_pod.lua
@@ -43,21 +43,25 @@ if CLIENT then
 			hook.Add("DrawDeathNotice", "wire_pod_drawdeathnotice", function() return false end)
 			hook.Add("HUDDrawTargetID", "wire_pod_huddrawtargetid", function() return false end)
 			hook.Add("HUDShouldDraw", "wire_pod_hudshoulddraw", function(name)
+				local ply = LocalPlayer()
+
 				if hideHUD > 0 then
 					if ply:InVehicle() then
-						--Allow crosshair (it can be hidden using the other input) and CHudGMod (for the EGP HUDPaint to pass through). Hide the chat if the input is higher than 1
+						-- Allow crosshair (it can be hidden using the other input) and CHudGMod (for the EGP HUDPaint to pass through). Hide the chat if the input is higher than 1
 						if name ~= "CHudCrosshair" and name ~= "CHudGMod" and (hideHUD > 1 and name == "CHudChat" or name ~= "CHudChat")  then return false end
 					else
 						hideHUD = 0
 					end
 				else
-					--Restore toolgun HUD
+					-- Restore toolgun HUD
 					local toolgun = ply:GetWeapon("gmod_tool")
+
 					if IsValid(toolgun) and toolgun.DrawHUD == blank and toolgunHUDFunc ~= nil then
 						toolgun.DrawHUD = toolgunHUDFunc
 					end
 					toolgunHUDFunc = nil
-					--Restore HUDPaints and other HUD elements
+
+					-- Restore HUDPaints and other HUD elements
 					local hooks = hook.GetTable()["HUDPaint"]
 					for k,v in pairs(hooks) do
 						if v == blank and savedHooks ~= nil and savedHooks[k] ~= nil then
@@ -155,7 +159,7 @@ function ENT:Initialize()
 	}
 
 	local inputs = {
-		"Lock", "Terminate", "Strip weapons", "Eject",
+		"Lock", "Terminate", "Strip Weapons", "Eject",
 		"Disable", "Crosshairs", "Brake", "Allow Buttons",
 		"Relative (If this is non-zero, the 'Bearing' and 'Elevation' outputs will be relative to the vehicle.)",
 		"Damage Health (Damages the driver's health.)", "Damage Armor (Damages the driver's armor.)", "Hide Player", "Hide HUD", "Show Cursor",
@@ -274,7 +278,6 @@ function ENT:OnRemove()
 	end
 end
 
--- function ENT:HasPod() return (self.Pod and self.Pod:IsValid()) end
 function ENT:GetPod()
 	local pod = self.Pod
 	if not IsValid(pod) then return end
@@ -305,7 +308,6 @@ function ENT:SetPod(pod)
 	return true
 end
 
--- function ENT:HasPly() return self.Ply and self.Ply:IsValid() end
 function ENT:GetPly()
 	local ply = self.Ply
 	if not IsValid(ply) then return end
@@ -411,7 +413,7 @@ function ENT:TriggerInput(name, value)
 		if value == 0 or not ply then return end
 		if self.RC then self:RCEject(ply) end
 		ply:Kill()
-	elseif name == "Strip weapons" then
+	elseif name == "Strip Weapons" then
 		local ply = self:GetPly()
 		if value == 0 or not ply then return end
 		if self.RC then


### PR DESCRIPTION
- Styling is now consistent throughout the whole file
- Usermessages replaced with net messages
- HasPod() and HasPly() have been removed, with their functionality being merged into GetPod() and GetPly(), respectively. These functions were only used in this file and have had all uses replaced
- Instead of constantly triggering updates to the pod's many outputs, they are now cached on the pod itself and only updated when they change, which is significantly faster overall
- Reduced many __index calls and other miscellaneous optimizations