### PR TITLE
RT Camera fixes and improvements

### DIFF
--- a/lua/entities/gmod_wire_rt_camera.lua
+++ b/lua/entities/gmod_wire_rt_camera.lua
@@ -55,9 +55,10 @@ if CLIENT then
     local cvar_filtering = CreateClientConVar("wire_rt_camera_filtering", "2", true, nil, nil, 0, 2)
     local cvar_hdr = CreateClientConVar("wire_rt_camera_hdr", "1", true, nil, nil, 0, 1)
 
-
+    -- array(Entity)
     WireLib.__RTCameras_Active = WireLib.__RTCameras_Active or {} 
     local ActiveCameras = WireLib.__RTCameras_Active
+    -- table(Entity, true)
     WireLib.__RTCameras_Observed = WireLib.__RTCameras_Observed or {} 
     local ObservedCameras = WireLib.__RTCameras_Observed
 
@@ -69,12 +70,14 @@ if CLIENT then
 
     local function SetCameraActive(camera, isActive)
         if isActive then
-            ActiveCameras[camera] = true
+            if not table.HasValue(ActiveCameras, camera) then
+                table.insert(ActiveCameras, camera)
+            end
         else
-            if camera.SetIsObserved then -- undefi
+            if camera.SetIsObserved then -- May be undefined (?)
                 camera:SetIsObserved(false)
             end
-            ActiveCameras[camera] = nil
+            table.RemoveByValue(ActiveCameras, camera)
         end
     end
 
@@ -165,7 +168,7 @@ if CLIENT then
 
         local renderedCameras = 0
         
-        for ent, _ in pairs(ActiveCameras) do
+        for _, ent in ipairs(ActiveCameras) do
             if not IsValid(ent) or not ent.IsObserved then goto next_camera end
             renderedCameras = renderedCameras + 1
 

--- a/lua/entities/gmod_wire_rt_camera.lua
+++ b/lua/entities/gmod_wire_rt_camera.lua
@@ -56,10 +56,10 @@ if CLIENT then
     local cvar_hdr = CreateClientConVar("wire_rt_camera_hdr", "1", true, nil, nil, 0, 1)
 
     -- array(Entity)
-    WireLib.__RTCameras_Active = WireLib.__RTCameras_Active or {} 
+    WireLib.__RTCameras_Active = WireLib.__RTCameras_Active or {}
     local ActiveCameras = WireLib.__RTCameras_Active
     -- table(Entity, true)
-    WireLib.__RTCameras_Observed = WireLib.__RTCameras_Observed or {} 
+    WireLib.__RTCameras_Observed = WireLib.__RTCameras_Observed or {}
     local ObservedCameras = WireLib.__RTCameras_Observed
 
     concommand.Add("wire_rt_camera_recreate", function()
@@ -168,7 +168,7 @@ if CLIENT then
         local renderW = cvar_resolution_w:GetInt()
 
         local renderedCameras = 0
-        
+
         for _, ent in ipairs(ActiveCameras) do
             if not IsValid(ent) or not ent.IsObserved then goto next_camera end
             renderedCameras = renderedCameras + 1
@@ -193,7 +193,7 @@ if CLIENT then
                     CameraIsDrawn = false
                 ent:SetNoDraw(oldNoDraw)
             render.PopRenderTarget()
-            
+
             ::next_camera::
         end
 
@@ -206,7 +206,7 @@ if CLIENT then
     local SkippedFrames = 0
     hook.Add("PreRender", "ImprovedRTCamera", function()
         SkippedFrames = SkippedFrames - 1
-    
+
         if SkippedFrames <= 0 then
             local rendered_cams = RenderCamerasImpl()
             SkippedFrames = math.ceil(rendered_cams * cvar_skip_frame_per_cam:GetFloat())

--- a/lua/entities/gmod_wire_rt_camera.lua
+++ b/lua/entities/gmod_wire_rt_camera.lua
@@ -63,7 +63,9 @@ if CLIENT then
     local ObservedCameras = WireLib.__RTCameras_Observed
 
     concommand.Add("wire_rt_camera_recreate", function()
+        print(table.Count(ObservedCameras))
         for _, cam in ipairs(ObservedCameras) do
+            print(cam)
             cam:InitRTTexture()
         end
     end)
@@ -103,15 +105,20 @@ if CLIENT then
         self.IsObserved = isObserved
 
         if isObserved then
-            local index = table.SeqCount(ObservedCameras) + 1
-            ObservedCameras[index] = self
-            self.ObservedCamerasIndex = index
+            self.ObservedCamerasIndex = table.insert(ObservedCameras, self)
 
             self:InitRTTexture()
         else
-            ObservedCameras[self.ObservedCamerasIndex] = nil
-            self.ObservedCamerasIndex = nil
             self.RenderTarget = nil
+
+            local oldi = table.RemoveFastByValue(ObservedCameras, self)
+            if oldi == nil then return end
+            self.ObservedCamerasIndex = nil
+            
+            local shifted_cam = ObservedCameras[oldi]
+            if IsValid(shifted_cam) then
+                shifted_cam.ObservedCamerasIndex = oldi
+            end
         end
     end
 

--- a/lua/entities/gmod_wire_rt_camera.lua
+++ b/lua/entities/gmod_wire_rt_camera.lua
@@ -103,7 +103,8 @@ if CLIENT then
         self.IsObserved = isObserved
 
         if isObserved then
-            local index = #ObservedCameras + 1
+            local index = table.SeqCount(ObservedCameras) + 1
+            print(self, index)
             ObservedCameras[index] = self
             self.ObservedCamerasIndex = index
 

--- a/lua/entities/gmod_wire_rt_camera.lua
+++ b/lua/entities/gmod_wire_rt_camera.lua
@@ -104,7 +104,6 @@ if CLIENT then
 
         if isObserved then
             local index = table.SeqCount(ObservedCameras) + 1
-            print(self, index)
             ObservedCameras[index] = self
             self.ObservedCamerasIndex = index
 

--- a/lua/entities/gmod_wire_rt_camera.lua
+++ b/lua/entities/gmod_wire_rt_camera.lua
@@ -63,9 +63,7 @@ if CLIENT then
     local ObservedCameras = WireLib.__RTCameras_Observed
 
     concommand.Add("wire_rt_camera_recreate", function()
-        print(table.Count(ObservedCameras))
         for _, cam in ipairs(ObservedCameras) do
-            print(cam)
             cam:InitRTTexture()
         end
     end)

--- a/lua/wire/stools/rt_camera.lua
+++ b/lua/wire/stools/rt_camera.lua
@@ -20,6 +20,11 @@ if CLIENT then
     language.Add("tool.wire_rt_camera.settings.cl_filtering_1", "Trilinear")
     language.Add("tool.wire_rt_camera.settings.cl_filtering_2", "Anisotropic")
     language.Add("tool.wire_rt_camera.settings.cl_apply", "Apply player-specific changes")
+    language.Add("tool.wire_rt_camera.settings.cl_skipframe", "Rendering slowdown")
+    language.Add("tool.wire_rt_camera.settings.cl_skipframe_hint",
+        "The greater this value, the greater your FPS is and the lesser FPS of the cameras is.\n"..
+        "Technically, it is amount of camera renders to skip per one rendered camera.\n"..
+        "Fractional values work too. Set to 0 to disable.")
 
     WireToolSetup.setToolMenuIcon( "icon16/camera.png" )
 end
@@ -69,4 +74,6 @@ function TOOL.BuildCPanel(panel)
     end
 
     panel:Button("#tool.wire_rt_camera.settings.cl_apply", "wire_rt_camera_recreate")
+    panel:NumSlider("#tool.wire_rt_camera.settings.cl_skipframe", "wire_rt_camera_skip_frame_per_camera", 0, 3, 2)
+    panel:Help("#tool.wire_rt_camera.settings.cl_skipframe_hint")
 end

--- a/lua/wire/wireshared.lua
+++ b/lua/wire/wireshared.lua
@@ -60,6 +60,19 @@ function table.SeqCount(tbl)
     return i - 1
 end
 
+-- Removes `value` from `tbl` by shifting last element of `tbl` to its place.
+-- Returns index of `value` if it was removed, nil otherwise.
+function table.RemoveFastByValue(tbl, value)
+    for i, v in ipairs(tbl) do
+        if v == value then
+            tbl[i] = tbl[#tbl]
+            tbl[#tbl] = nil
+
+            return i
+        end
+    end
+end
+
 function string.GetNormalizedFilepath( path ) -- luacheck: ignore
 	local null = string.find(path, "\x00", 1, true)
 	if null then path = string.sub(path, 1, null-1) end

--- a/lua/wire/wireshared.lua
+++ b/lua/wire/wireshared.lua
@@ -41,25 +41,6 @@ function table.Compact(tbl, cb, n) -- luacheck: ignore
 	end
 end
 
--- Works like #tbl, but works when item is removed from middle of the table without shifting.
---[[
-	local t = {1,2,3,4,5}
-	t[3] = nil
-
-	print(#t) -- May return 5, as it is undefined behaviour
-	print(table.SeqCount(t)) -- Will return 2
-
-]]
-function table.SeqCount(tbl)
-    local i = 0
-
-    repeat
-        i = i + 1
-    until tbl[i] == nil
-
-    return i - 1
-end
-
 -- Removes `value` from `tbl` by shifting last element of `tbl` to its place.
 -- Returns index of `value` if it was removed, nil otherwise.
 function table.RemoveFastByValue(tbl, value)

--- a/lua/wire/wireshared.lua
+++ b/lua/wire/wireshared.lua
@@ -41,6 +41,25 @@ function table.Compact(tbl, cb, n) -- luacheck: ignore
 	end
 end
 
+-- Works like #tbl, but works when item is removed from middle of the table without shifting.
+--[[
+	local t = {1,2,3,4,5}
+	t[3] = nil
+
+	print(#t) -- May return 5, as it is undefined behaviour
+	print(table.SeqCount(t)) -- Will return 2
+
+]]
+function table.SeqCount(tbl)
+    local i = 0
+
+    repeat
+        i = i + 1
+    until tbl[i] == nil
+
+    return i - 1
+end
+
 function string.GetNormalizedFilepath( path ) -- luacheck: ignore
 	local null = string.find(path, "\x00", 1, true)
 	if null then path = string.sub(path, 1, null-1) end


### PR DESCRIPTION
- Adds FPS limiting (that scales with amount of rendered cameras).
- Fixes cameras breaking after hot reload
- Makes `ActiveCameras` a array instead of table for performance.
- Fixes undefined behaviour in camera's `ENT:SetIsObserved`

On `ActiveCameras` change: 
This table is modified on cameras' creation, removal and "Active" input changes, and it is iterated each camera-rendering frame.
So modification is rarer than iteration.