### PR TITLE
Add string compression functions

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -514,5 +514,5 @@ end
 
 e2function string decompress(string compressed)
 	self.prf = self.prf + #compressed * 0.5
-	return decompress(compressed) or ""
+	return decompress(compressed) or self:throw("Invalid input for decompression!", "")
 end

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -500,3 +500,19 @@ e2function number string:unicodeLength(number startPos, number endPos)
 	end
 	return -1
 end
+
+--[[******************************************************************************]]--
+__e2setcost(10)
+
+local compress = util.Compress
+local decompress = util.Decompress
+
+e2function string compress(string plaintext)
+	self.prf = self.prf + #plaintext * 0.1
+	return compress(plaintext)
+end
+
+e2function string decompress(string compressed)
+	self.prf = self.prf + #compressed * 0.5
+	return decompress(compressed) or ""
+end

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -508,11 +508,15 @@ local compress = util.Compress
 local decompress = util.Decompress
 
 e2function string compress(string plaintext)
-	self.prf = self.prf + #plaintext * 0.1
+	local len = #plaintext
+	if len > 32768 then return self:throw("Input string is too long!", "") end
+	self.prf = self.prf + len * 0.1
 	return compress(plaintext)
 end
 
 e2function string decompress(string compressed)
-	self.prf = self.prf + #compressed * 0.5
+	local len = #compressed
+	if len > 32768 then return self:throw("Input string is too long!", "") end
+	self.prf = self.prf + len * 0.5
 	return decompress(compressed) or self:throw("Invalid input for decompression!", "")
 end

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -174,6 +174,8 @@ E2Helper.Descriptions["matchFirst(s:s)"] = "runs string.match(S, S2) and returns
 E2Helper.Descriptions["matchFirst(s:sn)"] = "runs string.match(S, S2, N) and returns the first match or an empty string if the match failed"
 E2Helper.Descriptions["gmatch(s:s)"] = "runs string.gmatch(S, S2) and returns the captures in arrays in a table"
 E2Helper.Descriptions["gmatch(s:sn)"] = "runs string.gmatch(S, S2, N) and returns the captures in arrays in a table"
+E2Helper.Descriptions["compress(s)"] = "Compresses the input string using LZMA compression. See decompress(string)"
+E2Helper.Descriptions["decompress(s)"] = "Decompresses an LZMA-compressed string. See compress(string)"
 
 -- Entity/Player
 E2Helper.Descriptions["entity(n)"] = "Gets the entity associated with the id"


### PR DESCRIPTION
Adds `compress(string)` and `decompress(string)` functions that use Gmod's built-in compression system. `decompress` throws on an input string that isn't LZMA compressed.
The compression is very fast, with inputs of 64k+ characters barely taking any time, so I think the op counter limit is fine where it is.

I swear I'm going crazy thinking these existed. Maybe it was something else I was testing.