### PR TITLE
More miscellaneous EGP fixes

### DIFF
--- a/lua/entities/gmod_wire_egp/lib/egplib/parenting.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/parenting.lua
@@ -128,16 +128,15 @@ local function getGlobalVertices(ent, obj)
 	if obj.verticesindex then
 		local _, globalpos = GetGlobalPos(ent, obj)
 		local gx, gy, gang = globalpos.x, globalpos.y, globalpos.angle
+		local ox, oy = obj.x, obj.y
+		local delta_ang = Angle(0, obj.angle - gang, 0)
 
-		local r = makeArray(obj, obj.parent ~= NULL_EGPOBJECT)
-		local globalvec, globalang = Vector(gx, gy, 0), Angle(0, -gang, 0)
-		local objang = obj._angle or obj.angle or 0
+		local r = makeArray(obj, obj.parent ~= 0)
+		local globalvec = Vector(gx, gy, 0)
 		for i = 1, #r, 2 do
-			local x_ = r[i]
-			local y_ = r[i + 1]
-			local vec = LocalToWorld(Vector(x_, y_, 0), Angle(0, objang, 0), globalvec, globalang)
-			r[i] = vec.x
-			r[i + 1] = vec.y
+			local vec = LocalToWorld(Vector(r[i] - ox, r[i + 1] - oy, 0), angle_zero, globalvec, delta_ang)
+			r[i] = vec[1]
+			r[i + 1] = vec[2]
 		end
 
 		local ret

--- a/lua/entities/gmod_wire_egp/lib/objects/poly.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/poly.lua
@@ -10,8 +10,7 @@ local clamp = math.Clamp
 
 -- Returns whether c is to the left of the line from a to b.
 local function counterclockwise( a, b, c )
-	local area = (a.x - c.x) * (b.y - c.y) - (b.x - c.x) * (a.y - c.y)
-	return area > 0
+	return (a.x - c.x) * (b.y - c.y) - (b.x - c.x) * (a.y - c.y) > 0
 end
 
 Obj.Draw = function( self )
@@ -61,7 +60,7 @@ function Obj:Contains(x, y)
 	if #self.vertices < 3 then return false end
 	-- Convert into {x,y} format that poly uses.
 	local point = { x = x, y = y }
-	local _, realpos = EGP:GetGlobalPos(self.EGP, self)
+	local realpos = EGP.GetGlobalVertices(self.EGP, self)
 	local vertices = realpos.vertices
 
 	-- To check whether a point is in the polygon, we check whether it's to the
@@ -122,8 +121,11 @@ function Obj:SetPos(x, y, angle)
 	x = clamp(x, -32768, 32767) -- Simple clamp to avoid moving to huge numbers and invoking NaN. Transmit size is u16
 	y = clamp(y, -32768, 32767)
 
+	local delta_ang = Angle(0, sa - angle, 0)
+	local pos = Vector(x, y, 0)
+
 	for _, v in ipairs(self.vertices) do
-		local vec = LocalToWorld(Vector(v.x - sx, v.y - sy, 0), angle_zero, Vector(x, y, 0), Angle(0, sa - angle, 0))
+		local vec = LocalToWorld(Vector(v.x - sx, v.y - sy, 0), angle_zero, pos, delta_ang)
 		v.x, v.y = vec[1], vec[2]
 	end
 	self.x, self.y, self.angle = x, y, angle

--- a/lua/entities/gmod_wire_egp/lib/objects/poly.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/poly.lua
@@ -95,7 +95,7 @@ function Obj:EditObject(args)
 		ret = true
 	end
 	if args.x or args.y or args.angle then
-		ret = self:SetPos(args.x or self.x, args.y or self.y, args.angle or self.angle)
+		ret = ret or self:SetPos(args.x or self.x, args.y or self.y, args.angle or self.angle)
 		args.x = nil
 		args.y = nil
 		args.angle = nil

--- a/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
@@ -1000,11 +1000,6 @@ e2function string wirelink:egpObjectType(number index)
 	return ""
 end
 
-e2function egpobject wirelink:egpObject(number index)
-	local bool, _, obj = EGP:HasObject(this, index)
-	return bool and obj or nil
-end
-
 --------------------------------------------------------
 -- Additional Functions
 --------------------------------------------------------

--- a/lua/entities/gmod_wire_expression2/core/egpobjects.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpobjects.lua
@@ -562,7 +562,6 @@ e2function void egpobject:hide()
 
 	EGP:DoAction(egp, self, "RemoveObject", this.index)
 	this._nodraw = true
-	print(this.x, this.y, "not nil?")
 	Update(self, egp)
 end
 

--- a/lua/entities/gmod_wire_expression2/core/egpobjects.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpobjects.lua
@@ -547,7 +547,9 @@ e2function void egpobject:draw()
 	this._nodraw = nil
 	if not EGP:IsAllowed(self, egp) then return end
 
-	if EGP:CreateObject(egp, this.ID, this) then
+	local args = { unpack(this) }
+
+	if EGP:CreateObject(egp, this.ID, args) then
 		EGP:DoAction(egp, self, "SendObject", this)
 		Update(self, egp)
 	end
@@ -560,6 +562,7 @@ e2function void egpobject:hide()
 
 	EGP:DoAction(egp, self, "RemoveObject", this.index)
 	this._nodraw = true
+	print(this.x, this.y, "not nil?")
 	Update(self, egp)
 end
 

--- a/lua/entities/gmod_wire_expression2/core/egpobjects.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpobjects.lua
@@ -547,7 +547,10 @@ e2function void egpobject:draw()
 	this._nodraw = nil
 	if not EGP:IsAllowed(self, egp) then return end
 
-	local args = { unpack(this) }
+	local args = {}
+	for k, v in pairs(this) do
+		args[k] = v
+	end
 
 	if EGP:CreateObject(egp, this.ID, args) then
 		EGP:DoAction(egp, self, "SendObject", this)


### PR DESCRIPTION
- Harden EGP Poly `EditObject` to avoid a very improbable bug
- Fixed `egpobject:show()` would remove elements from the object causing errors
- Fixed `EGP.GetGlobalVertices` didn't work properly
- Fixed Poly `Contains` function was outdated
- Removed redundant `wirelink:egpObject(number)` function defined in `egpfunctions.lua`