### PR TITLE
Use setPos/setAng directly on the entity instead of phys

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -628,7 +628,7 @@ end
 __e2setcost(20)
 e2function void entity:setPos(vector pos)
 	if not ValidAction(self, this, "pos") then return end
-	WireLib.setPos(this, pos)
+	setPos(this, pos)
 end
 
 e2function void entity:setLocalPos(vector pos)
@@ -641,7 +641,7 @@ e2function void entity:reposition(vector pos) = e2function void entity:setPos(ve
 
 e2function void entity:setAng(angle rot)
 	if not ValidAction(self, this, "ang") then return end
-	WireLib.setAng(this, rot)
+	setAng(this, rot)
 end
 
 e2function void entity:setLocalAng(angle rot)

--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -628,7 +628,7 @@ end
 __e2setcost(20)
 e2function void entity:setPos(vector pos)
 	if not ValidAction(self, this, "pos") then return end
-	PhysManipulate(this, pos, nil, nil, nil, nil)
+	WireLib.setPos(this, pos)
 end
 
 e2function void entity:setLocalPos(vector pos)
@@ -641,7 +641,7 @@ e2function void entity:reposition(vector pos) = e2function void entity:setPos(ve
 
 e2function void entity:setAng(angle rot)
 	if not ValidAction(self, this, "ang") then return end
-	PhysManipulate(this, nil, rot, nil, nil, nil)
+	WireLib.setAng(this, nil, rot, nil, nil, nil)
 end
 
 e2function void entity:setLocalAng(angle rot)

--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -641,7 +641,7 @@ e2function void entity:reposition(vector pos) = e2function void entity:setPos(ve
 
 e2function void entity:setAng(angle rot)
 	if not ValidAction(self, this, "ang") then return end
-	WireLib.setAng(this, nil, rot, nil, nil, nil)
+	WireLib.setAng(this, rot)
 end
 
 e2function void entity:setLocalAng(angle rot)

--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -298,7 +298,7 @@ __e2setcost(30)
 local function removeAllIn( self, tbl )
 	local count = 0
 	for k,v in pairs( tbl ) do
-		if (IsValid(v) and isOwner(self,v) and !v:IsPlayer()) then
+		if (IsValid(v) and isOwner(self,v) and not v:IsPlayer()) then
 			count = count + 1
 			v:Remove()
 		end
@@ -425,9 +425,10 @@ e2function number entity:propGetElasticity()
 	return this:GetElasticity()
 end
 
+local persistCvar = GetConVar("sbox_persist")
 e2function void entity:propMakePersistent(number persistent)
 	if not ValidAction(self, this, "persist") then return end
-	if GetConVarString("sbox_persist") == "0" then return end
+	if not persistCvar:GetBool() then return end
 	if not gamemode.Call("CanProperty", self.player, "persist", this) then return end
 	this:SetPersistent(persistent ~= 0)
 end


### PR DESCRIPTION
This pr makes it so E2 setPos and setAng are called on entities instead of their physics objects. Also fixes some linting issues in the file.

Example of previous weird behaviour:
```js
local P = vec( random(1,100), random(1,100),random(1,100))
entity():setPos( P )
print( entity():pos(), "|", P )
```
![image](https://github.com/wiremod/wire/assets/69946827/a96655ea-c2ee-4598-bc47-80da8e5f9cec)
New behaviour:
![image](https://github.com/wiremod/wire/assets/69946827/1d415f81-2e92-4dde-a174-0d414609e2de)

The same applies for setAng:
```js
local P = ang(vec( random(1,100), random(1,100),random(1,100)))
entity():setAng( P )
print( entity():angles(), "|", P )
```
Previous:
![image](https://github.com/wiremod/wire/assets/69946827/4d31a3d2-d3df-405a-80ca-9cb18e8aea2c)
New:
![image](https://github.com/wiremod/wire/assets/69946827/1e0a5096-7356-4069-843b-8e5f0c0b0aa9)


This also makes setPos and setAng no longer weirdly lerped and actually makes them properly snap in place.
Before the PR:

https://github.com/wiremod/wire/assets/69946827/6991fbbc-432b-440a-816f-d678539980a1

After:

https://github.com/wiremod/wire/assets/69946827/8dc61641-7d57-472f-b7c3-f548ca656ca7

