### PR TITLE
Fix RT Camera OnRemove detection

### DIFF
--- a/lua/entities/gmod_wire_rt_camera.lua
+++ b/lua/entities/gmod_wire_rt_camera.lua
@@ -110,7 +110,7 @@ if CLIENT then
             local oldi = table.RemoveFastByValue(ObservedCameras, self)
             if oldi == nil then return end
             self.ObservedCamerasIndex = nil
-            
+
             local shifted_cam = ObservedCameras[oldi]
             if IsValid(shifted_cam) then
                 shifted_cam.ObservedCamerasIndex = oldi

--- a/lua/entities/gmod_wire_rt_camera.lua
+++ b/lua/entities/gmod_wire_rt_camera.lua
@@ -85,12 +85,10 @@ if CLIENT then
         SetCameraActive(self, isActive)
     end
 
-    function ENT:OnRemove()
-        timer.Simple( 0, function()
-            if not IsValid(self) then
-                SetCameraActive(self, false)
-            end
-        end)
+    function ENT:OnRemove(fullUpdate)
+        if not fullUpdate then
+            SetCameraActive(self, false)
+        end
     end
 
     function ENT:SetIsObserved(isObserved)


### PR DESCRIPTION
Currently `ObservedCamerasIndex` isn't fully cleared which can cause RT material leakage.

After talking with @stepa2 he localized the issue to be in OnRemove which this PR fixes.

This also fixes the console command `wire_rt_camera_recreate` erroring.

The argument passed into OnRemove should be available on gmod main branch too but it's not entirely clear on the wiki, i've aksed the gmod devs to be sure.