### PR TITLE
Update WireLib.GetVersion

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Embed version
         run: |
-          echo -e "\ncachedversion = \"Canary ${GITHUB_SHA:0:7}\"" >> lua/wire/server/wirelib.lua
+          echo -e "\nversion = $(date +%y%m%d)\nversion_string = \"Canary $(date +%Y.%m.%d) (${GITHUB_SHA:0:7})\"" >> lua/wire/server/wirelib.lua
 
       - uses: wiremod/gmod-upload@master
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
 
       - name: Embed version
         run: |
-          echo -e "\ncachedversion = \"Workshop ${GITHUB_SHA:0:7}\"" >> lua/wire/server/wirelib.lua
+          echo -e "\nversion = $(date +%y%m%d)\nversion_string = \"Workshop $(date +%Y.%m.%d) (${GITHUB_SHA:0:7})\"" >> lua/wire/server/wirelib.lua
 
       - uses: wiremod/gmod-upload@master
         with:

--- a/lua/entities/gmod_wire_expression2/core/selfaware.lua
+++ b/lua/entities/gmod_wire_expression2/core/selfaware.lua
@@ -4,6 +4,12 @@
 
 local isOwner = E2Lib.isOwner
 
+do
+	local v1, v2 = WireLib.GetVersion()
+	E2Lib.registerConstant("WIREVERSION", v1)
+	E2Lib.registerConstant("WIREVERSION_STR", v2)
+end
+
 __e2setcost(1) -- temporary
 
 [nodiscard]
@@ -243,7 +249,6 @@ __e2setcost(5)
 e2function number getExtensionStatus(string extension)
 	return getExtensionStatus(extension) and 1 or 0
 end
-
 
 --[[******************************************************************************]]--
 


### PR DESCRIPTION
Now outputs two values, first one is numerical representation of version similar to Gmod version constant, second is a fancy string representation for printing.

Output examples:
```
// Version number
240406

// Locally installed (git)
Local 2024.04.06 (master:bc614de)

// Workshop/Canary
Workshop 2024.04.06 (bc614de)
Canary 2024.04.06 (bc614de)
```

Add `_WIREVERSION` and `_WIREVESRION_STR` E2 constants to get version.

Removed SVN searching.

Fixes #3030