### PR TITLE
Fix Friends List would limit to 4 outputted friends

### DIFF
--- a/lua/entities/gmod_wire_friendslist.lua
+++ b/lua/entities/gmod_wire_friendslist.lua
@@ -61,12 +61,12 @@ function ENT:UpdateFriendslist( friends_steamids )
 	local plys = player.GetHumans()
 	for i = 1, #plys do
 		local ply = plys[i]
-		local steamid = ply:SteamID()
 
-		if self.friends_lookup[ply] then return end
-
-		if self.steamids_lookup[steamid] then
-			self.friends_lookup[ply] = true
+		if not self.friends_lookup[ply] then
+			local steamid = ply:SteamID()
+			if self.steamids_lookup[steamid] then
+				self.friends_lookup[ply] = true
+			end
 		end
 	end
 

--- a/lua/entities/gmod_wire_friendslist.lua
+++ b/lua/entities/gmod_wire_friendslist.lua
@@ -59,8 +59,15 @@ function ENT:UpdateFriendslist( friends_steamids )
 	end
 
 	local plys = player.GetHumans()
-	for i=1,#plys do
-		self:Connected( plys[i] )
+	for i = 1, #plys do
+		local ply = plys[i]
+		local steamid = ply:SteamID()
+
+		if self.friends_lookup[ply] then return end
+
+		if self.steamids_lookup[steamid] then
+			self.friends_lookup[ply] = true
+		end
 	end
 
 	self:UpdateOutputs()


### PR DESCRIPTION
`WireLib.TriggerOutput` has an execution limit of 4. `UpdateFriendsList` calls `Connected` which calls `UpdateOutputs` which can trigger more than 4 times (and is extremely redundant).
This avoids calling the `Connected` method in `UpdateFriendsList` by inlining all the relevant parts.