### PR TITLE
Add fallback to use typename in debugger when no format defined

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/table.lua
+++ b/lua/entities/gmod_wire_expression2/core/table.lua
@@ -79,7 +79,7 @@ local function temp( ret, tbl, k, v, orientvertical, isnum )
 			end
 		end
 	else
-		ret = ret .. formatPort[longtype]( v, orientvertical )
+			ret = ret .. formatPort[longtype](v, orientvertical)
 	end
 
 	if (orientvertical) then
@@ -105,8 +105,7 @@ WireLib.registerDebuggerFormat( "table", function( value, orientvertical )
 		if (n > 7) then break end
 		ret = temp( ret, value, k3, v3, orientvertical, false )
 	end
-	ret = ret:Left(-3)
-	return "{" .. ret .. "}"
+	return "{" .. ret:sub(1, orientvertical and -2 or -3) .. "}"
 end)
 
 --------------------------------------------------------------------------------

--- a/lua/wire/server/debuggerlib.lua
+++ b/lua/wire/server/debuggerlib.lua
@@ -1,4 +1,8 @@
-local formatPort = {}
+local formatPort = setmetatable({}, { __index = function(t, k)
+	return rawget(t, k) or function() return k end
+end
+})
+
 WireLib.Debugger = { formatPort = formatPort } -- Make it global
 function formatPort.NORMAL(value)
 	return string.format("%.3f",value)
@@ -42,8 +46,6 @@ function formatPort.MATRIX4(value)
 		  RetText = RetText..",41="..value[13]..",42="..value[14]..",43="..value[15]..",44="..value[16].."]"
 	return RetText
 end
-
-function formatPort.RANGER(value) return "ranger" end
 
 function formatPort.ARRAY(value, OrientVertical)
 	local RetText = ""
@@ -153,7 +155,6 @@ function formatPort.TABLE(value, OrientVertical)
 	RetText = string.sub(RetText,1,-3)
 	return "{"..RetText.."}"
 end
-
 
 function WireLib.registerDebuggerFormat(typename, func)
 	formatPort[typename:upper()] = func

--- a/lua/wire/server/debuggerlib.lua
+++ b/lua/wire/server/debuggerlib.lua
@@ -1,5 +1,5 @@
-local formatPort = setmetatable({}, { __index = function(t, k)
-	return rawget(t, k) or function() return k end
+local formatPort = setmetatable({}, { __index = function(_, k)
+	return function() return k end
 end
 })
 


### PR DESCRIPTION
Fixes #3034. The bug here is that the table function expects `formatPort` to be defined for all types. In the event that it's not, it will call a nil function and error. This PR solves this by adding a default type for all possible types using a metatable that returns the input typename if the index is not found.

- Fixed bug with table cutting off a single character
- Removed ranger debugger format (was just "ranger")

![image](https://github.com/wiremod/wire/assets/20892685/5c70ba72-b7c6-4347-89a9-8b9671d31911)
