### PR TITLE
Fix removing and readding items in EGP

### DIFF
--- a/lua/entities/gmod_wire_egp/lib/egplib/queuesystem.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/queuesystem.lua
@@ -26,7 +26,6 @@ function EGP:AddQueueObject( Ent, ply, Function, Object )
 					end
 					return
 				end
-				::_continue::
 			end
 			-- Not found, add it to queue
 			LastItem.Args[1][#LastItem.Args[1]+1] = Object

--- a/lua/entities/gmod_wire_egp/lib/egplib/queuesystem.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/queuesystem.lua
@@ -12,23 +12,21 @@ function EGP:AddQueueObject( Ent, ply, Function, Object )
 		local LastItem = self.Queue[ply][n]
 		if (LastItem.Ent == Ent and LastItem.Action == "Object") then
 			for k,v in ipairs( LastItem.Args[1] ) do
-				if (v.index == Object.index) then
-
+				if v.index == Object.index and not v.remove then
 					if (Object.remove) then -- The object has been removed
-						table.remove( LastItem.Args[1], k )
+						LastItem.Args[1][k] = Object
 					elseif (v.ID ~= Object.ID) then -- Not the same kind of object, create new
 						if (v.OnRemove) then v:OnRemove() end
-						local Obj = self:GetObjectByID( Object.ID )
-						Obj:EditObject(Object:DataStreamInfo())
+						local Obj =  EGP:GetObjectByID( Object.ID )
+						Obj:Initialize(Object:DataStreamInfo())
 						Obj.index = v.index
-						if (Obj.OnCreate) then Obj:OnCreate() end
 						LastItem.Args[1][k] = Obj
 					else -- Edit
 						v:EditObject(Object:DataStreamInfo())
 					end
-
 					return
 				end
+				::_continue::
 			end
 			-- Not found, add it to queue
 			LastItem.Args[1][#LastItem.Args[1]+1] = Object

--- a/lua/entities/gmod_wire_egp/lib/egplib/transmitreceive.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/transmitreceive.lua
@@ -248,20 +248,8 @@ if (SERVER) then
 
 				if (v.remove == true) then
 					net.WriteUInt(0, 8) -- Object is to be removed, send a 0
-					local bool, k, v = EGP:HasObject( Ent, v.index )
-					if (bool) then
-						-- Unparent all objects parented to this object
-						for k2,v2 in pairs( Ent.RenderTable ) do
-							if (v2.parent and v.index and v2.parent == v.index) then
-								EGP:UnParent( Ent, v2 )
-							end
-						end
-
-						table.remove( Ent.RenderTable, k )
-					end
 				else
 					net.WriteUInt(v.ID, 8) -- Else send the ID of the object
-
 					if (Ent.Scaling or Ent.TopLeft) then
 						local original = v
 						v = table.Copy(v) -- Make a copy of the table so it doesn't overwrite the serverside object
@@ -319,16 +307,18 @@ if (SERVER) then
 			local Data = {...}
 			local obj = Data[1]
 
-			if (E2 and E2.entity and E2.entity:IsValid()) then
-				E2.prf = E2.prf + 20
+			local remove_index
+			for i, v in ipairs(Ent.RenderTable) do
+				E2.prf = E2.prf + 0.3
+				if v.index == obj then
+					remove_index = i
+				elseif v.parent and v.parent == obj then
+					EGP:UnParent(Ent, v)
+				end
 			end
 
-			for i=1,#Ent.RenderTable do
-				E2.prf = E2.prf + 0.3
-				if Ent.RenderTable[i].index == obj then
-					table.remove( Ent.RenderTable, i )
-					break
-				end
+			if remove_index then
+				table.remove(Ent.RenderTable, remove_index)
 			end
 
 			self:AddQueueObject( Ent, E2.player, SendObjects, { index = Data[1], remove = true } )

--- a/lua/entities/gmod_wire_egp/lib/objects/box.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/box.lua
@@ -19,7 +19,7 @@ Obj.Transmit = function( self )
 end
 
 Obj.Receive = function( self )
-	tbl = {}
+	local tbl = {}
 	EGP.ReceiveSize(tbl)
 	table.Merge(tbl, base.Receive(self))
 	return tbl


### PR DESCRIPTION
1. Makes it so at least one remove action on an EGP object will be kept in the queue before any objects are recreated to avoid errors with not removing objects when sent to client.
2. Moves the EGP object removal from rendertable out of the network sending action and into the removal action itself. This is because objects would otherwise be erroneously removed from the EGP on the server.

I think I'm finally beginning to understand the current EGP Queue.

Fixes #3039, thought it would be more mysterious but I managed to bang my head against it enough times.

