### PR TITLE
Optimise wire holograms

### DIFF
--- a/lua/entities/gmod_wire_hologram.lua
+++ b/lua/entities/gmod_wire_hologram.lua
@@ -260,7 +260,7 @@ if CLIENT then
 
 			for i = count, 0, -1 do
 				local bone_scale = self.bone_scale[i] or Vector(1,1,1)
-				self:ManipulateBoneScale(i, bone_scale) // Note: Using ManipulateBoneScale currently causes RenderBounds to be reset every frame!
+				self:ManipulateBoneScale(i, bone_scale) -- Note: Using ManipulateBoneScale currently causes RenderBounds to be reset every frame!
 			end
 		end
 

--- a/lua/entities/gmod_wire_hologram.lua
+++ b/lua/entities/gmod_wire_hologram.lua
@@ -116,7 +116,7 @@ if CLIENT then
         local selfTbl = self:GetTable()
 		if selfTbl.blocked or selfTbl.notvisible then return end
 
-        local _, _, _, alpha = self:GetColor()
+        local _, _, _, alpha = self:GetColor4Part()
 		if alpha ~= 255 then
 			selfTbl.RenderGroup = RENDERGROUP_BOTH
 		else

--- a/lua/entities/gmod_wire_hologram.lua
+++ b/lua/entities/gmod_wire_hologram.lua
@@ -113,10 +113,10 @@ if CLIENT then
 	end
 
 	function ENT:Draw()
-        local selfTbl = self:GetTable()
+		local selfTbl = self:GetTable()
 		if selfTbl.blocked or selfTbl.notvisible then return end
 
-        local _, _, _, alpha = self:GetColor4Part()
+		local _, _, _, alpha = self:GetColor4Part()
 		if alpha ~= 255 then
 			selfTbl.RenderGroup = RENDERGROUP_BOTH
 		else

--- a/lua/entities/gmod_wire_hologram.lua
+++ b/lua/entities/gmod_wire_hologram.lua
@@ -77,11 +77,11 @@ if CLIENT then
 		hook.Remove("PlayerBindPress", "wire_hologram_scale_setup")
 	end)
 
-	function ENT:SetupClipping()
-		if next(self.clips) then
-			self.oldClipState = render.EnableClipping(true)
+	function ENT:SetupClipping(selfTbl)
+		if next(selfTbl.clips) then
+			selfTbl.oldClipState = render.EnableClipping(true)
 
-			for _, clip in pairs(self.clips) do
+			for _, clip in pairs(selfTbl.clips) do
 				if clip.enabled and clip.normal and clip.origin then
 					local norm = clip.normal
 					local origin = clip.origin
@@ -100,28 +100,30 @@ if CLIENT then
 		end
 	end
 
-	function ENT:FinishClipping()
-		if next(self.clips) then
-			for _, clip in pairs(self.clips) do
+	function ENT:FinishClipping(selfTbl)
+		if next(selfTbl.clips) then
+			for _, clip in pairs(selfTbl.clips) do
 				if clip.enabled and clip.normal and clip.origin then -- same logic as in SetupClipping
 					render.PopCustomClipPlane()
 				end
 			end
 
-			render.EnableClipping(self.oldClipState)
+			render.EnableClipping(selfTbl.oldClipState)
 		end
 	end
 
 	function ENT:Draw()
-		if self.blocked or self.notvisible then return end
+        local selfTbl = self:GetTable()
+		if selfTbl.blocked or selfTbl.notvisible then return end
 
-		if self:GetColor().a ~= 255 then
-			self.RenderGroup = RENDERGROUP_BOTH
+        local _, _, _, alpha = self:GetColor()
+		if alpha ~= 255 then
+			selfTbl.RenderGroup = RENDERGROUP_BOTH
 		else
-			self.RenderGroup = RENDERGROUP_OPAQUE
+			selfTbl.RenderGroup = RENDERGROUP_OPAQUE
 		end
 
-		self:SetupClipping()
+		self:SetupClipping(selfTbl)
 
 		local invert_model = self:GetNWInt("invert_model")
 		render.CullMode(invert_model)
@@ -138,7 +140,7 @@ if CLIENT then
 			render.CullMode(0)
 		end
 
-		self:FinishClipping()
+		self:FinishClipping(selfTbl)
 	end
 
 	-- -----------------------------------------------------------------------------

--- a/lua/entities/gmod_wire_hologram.lua
+++ b/lua/entities/gmod_wire_hologram.lua
@@ -77,7 +77,7 @@ if CLIENT then
 		hook.Remove("PlayerBindPress", "wire_hologram_scale_setup")
 	end)
 
-	function ENT:SetupClipping(selfTbl)
+	local function SetupClipping(selfTbl)
 		if next(selfTbl.clips) then
 			selfTbl.oldClipState = render.EnableClipping(true)
 
@@ -100,7 +100,7 @@ if CLIENT then
 		end
 	end
 
-	function ENT:FinishClipping(selfTbl)
+	local function FinishClipping(selfTbl)
 		if next(selfTbl.clips) then
 			for _, clip in pairs(selfTbl.clips) do
 				if clip.enabled and clip.normal and clip.origin then -- same logic as in SetupClipping
@@ -123,7 +123,7 @@ if CLIENT then
 			selfTbl.RenderGroup = RENDERGROUP_OPAQUE
 		end
 
-		self:SetupClipping(selfTbl)
+		SetupClipping(selfTbl)
 
 		local invert_model = self:GetNWInt("invert_model")
 		render.CullMode(invert_model)
@@ -140,7 +140,7 @@ if CLIENT then
 			render.CullMode(0)
 		end
 
-		self:FinishClipping(selfTbl)
+		FinishClipping(selfTbl)
 	end
 
 	-- -----------------------------------------------------------------------------


### PR DESCRIPTION
Reduces `ent.__index` calls and uses `GetColor4Part` instead of `GetColor` to prevent color objects from being created.

See https://github.com/Facepunch/garrysmod/pull/2010 why reducing `ent.__index` helps