### PR TITLE
Fix beingLookedAtByLocalPlayer

### DIFF
--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -11,11 +11,14 @@ ENT.IsWire = true
 
 if CLIENT then
 	local wire_drawoutline = CreateClientConVar("wire_drawoutline", 1, true, false)
-	local beingLookedAtByLocalPlayer
+	-- Funny reverse-detour because this function is sometimes nil and sometimes not, but is never nil when drawing for the first time.
+	local function beingLookedAtByLocalPlayer(self)
+		beingLookedAtByLocalPlayer = BaseClass.BeingLookedAtByLocalPlayer
+		return beingLookedAtByLocalPlayer(self)
+	end
 
 	function ENT:Initialize()
 		self.NextRBUpdate = CurTime() + 0.25
-		beingLookedAtByLocalPlayer = BaseClass.BeingLookedAtByLocalPlayer
 	end
 
 	function ENT:Draw()
@@ -416,12 +419,14 @@ net.Receive( "wire_overlay_request", function( len, ply )
 	end
 end)
 
-function ENT:Initialize()
-	BaseClass.Initialize(self)
-	self:PhysicsInit(SOLID_VPHYSICS)
-	self:SetMoveType(MOVETYPE_VPHYSICS)
-	self:SetSolid(SOLID_VPHYSICS)
-	self.WireDebugName = self.WireDebugName or (self.PrintName and self.PrintName:sub(6)) or self:GetClass():gsub("gmod_wire", "")
+if SERVER then
+	function ENT:Initialize()
+		BaseClass.Initialize(self)
+		self:PhysicsInit(SOLID_VPHYSICS)
+		self:SetMoveType(MOVETYPE_VPHYSICS)
+		self:SetSolid(SOLID_VPHYSICS)
+		self.WireDebugName = self.WireDebugName or (self.PrintName and self.PrintName:sub(6)) or self:GetClass():gsub("gmod_wire", "")
+	end
 end
 
 function ENT:OnRemove()


### PR DESCRIPTION
1. Encapsulates serverside `Initialize` function in base entity in case that overrides the client one (this isn't related but it seems important regardless).
2. Fix for `beingLookAtByLocalPlayer` by initializing it on its first call.
   Okay, hear me out:
   Pros:
   - No indirection after first call
   - No need to worry about execution order (As we have experienced before, `BaseClass.BeingLookedAtByLocalPlayer` is always defined by the time the draw function is called)
   
   Cons:
   - Will confuse the JIT for 1 frame

Fixes #3045