### PR TITLE
Move playerWasLookingAtMe to be a property of self

### DIFF
--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -19,6 +19,7 @@ if CLIENT then
 
 	function ENT:Initialize()
 		self.NextRBUpdate = CurTime() + 0.25
+		self.PlayerWasLookingAtMe = false
 	end
 
 	function ENT:Draw()
@@ -229,23 +230,22 @@ if CLIENT then
 		ent:DrawWorldTip()
 	end)
 
-	local playerWasLookingAtMe = false
-
 	-- Custom better version of this base_gmodentity function
 	function ENT:BeingLookedAtByLocalPlayer()
 		local trbool = beingLookedAtByLocalPlayer(self)
+		local self_table = self:GetTable()
 
-		if playerWasLookingAtMe ~= trbool then
+		if self_table.PlayerWasLookingAtMe ~= trbool then
 			net.Start("wire_overlay_request")
 				if trbool then
 					net.WriteBool(true)
 					net.WriteEntity(self)
-					net.WriteFloat(self.OverlayData and self.OverlayData.__time or 0)
+					net.WriteFloat(self_table.OverlayData and self_table.OverlayData.__time or 0)
 				else
 					net.WriteBool(false)
 				end
 			net.SendToServer()
-			playerWasLookingAtMe = trbool
+			self_table.PlayerWasLookingAtMe = trbool
 		end
 
 		return trbool


### PR DESCRIPTION
This local value is shared across all instances of entities and therefore will be reset every frame for every entity. Which is bad. Really bad. This is not how entities work and I should've known that.