### PR TITLE
Fix includes with errors in main file would lock the E2 editor

### DIFF
--- a/lua/entities/gmod_wire_expression2/cl_init.lua
+++ b/lua/entities/gmod_wire_expression2/cl_init.lua
@@ -57,7 +57,7 @@ function E2Lib.Validate(buffer)
 
 	-- invoke preprocessor
 	local status, directives, buffer, preprocessor = E2Lib.PreProcessor.Execute(buffer)
-	if not status then table.Add(errors, directives) end
+	if not status then table.Add(errors, directives) return errors end
 	---@cast directives PPDirectives
 	table.Add(warnings, preprocessor.warnings)
 


### PR DESCRIPTION
This error was caused because the local `directives` can be `PPDirective` or `Error[]` type, and this was not properly accounted for in the later `Include` function calls. It's likely this was an oversight as the code suggests the function would return early if it errored. This adds a return to that section to follow that logic.

- `E2Lib.Validate` now returns early when preprocessor fails.

Fixes #3043