### PR TITLE
Fix issues involving math.tau

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/init.lua
+++ b/lua/entities/gmod_wire_expression2/core/init.lua
@@ -212,7 +212,10 @@ function E2Lib.registerConstant(name, value, description)
 			extension = E2Lib.currentextension
 		}
 	else
-		error("Invalid value passed to registerConstant. Only numbers, strings, vectors, angles and arrays can be constant values.")
+		local db = debug.getinfo(2, "l")
+		WireLib.Notify(nil,
+			string.format("[%s]:%d: Invalid value passed to registerConstant for \"%s\". Only numbers, strings, vectors, angles and arrays can be constant values.\n", E2Lib.currentextension, db.currentline, name),
+		3)
 	end
 end
 

--- a/lua/entities/gmod_wire_expression2/core/number.lua
+++ b/lua/entities/gmod_wire_expression2/core/number.lua
@@ -44,7 +44,7 @@ E2Lib.registerConstant("PI", pi)
 E2Lib.registerConstant("INF", inf)
 E2Lib.registerConstant("E", exp(1))
 E2Lib.registerConstant("PHI", (1+sqrt(5))/2)
-E2Lib.registerConstant("TAU", math.tau or 6.28318530718)
+E2Lib.registerConstant("TAU", math.pi * 2)
 
 --[[************************************************************************]]--
 

--- a/lua/entities/gmod_wire_expression2/core/number.lua
+++ b/lua/entities/gmod_wire_expression2/core/number.lua
@@ -44,7 +44,7 @@ E2Lib.registerConstant("PI", pi)
 E2Lib.registerConstant("INF", inf)
 E2Lib.registerConstant("E", exp(1))
 E2Lib.registerConstant("PHI", (1+sqrt(5))/2)
-E2Lib.registerConstant("TAU", math.tau)
+E2Lib.registerConstant("TAU", math.tau or 6.28318530718)
 
 --[[************************************************************************]]--
 

--- a/lua/wire/client/cl_wirelib.lua
+++ b/lua/wire/client/cl_wirelib.lua
@@ -262,6 +262,8 @@ local severity2word = {
 	[3] = "error"
 }
 
+local notify_antispam = 0 -- Used to avoid spamming sounds to the player
+
 --- Sends a colored message to the player's chat.
 --- When used serverside, setting the player as nil will only inform the server.
 --- When used clientside, the first argument is ignored and only the local player is informed.
@@ -279,7 +281,9 @@ local function notify(ply, msg, severity, chatprint, color)
 		chat.PlaySound()
 	else
 		MsgC(unpack(WireLib.NotifyBuilder(msg, severity, color)))
-		if severity > 1 then
+		local time = CurTime() + 1
+		if severity > 1 and notify_antispam < time then
+			notify_antispam = time
 			notification.AddLegacy(string.format("Wiremod %s! Check your console for details", severity2word[severity]), NOTIFY_ERROR, 5)
 			surface.PlaySound(severity == 3 and "vo/k_lab/kl_fiddlesticks.wav" or "buttons/button22.wav")
 		end

--- a/lua/wire/client/cl_wirelib.lua
+++ b/lua/wire/client/cl_wirelib.lua
@@ -281,9 +281,9 @@ local function notify(ply, msg, severity, chatprint, color)
 		chat.PlaySound()
 	else
 		MsgC(unpack(WireLib.NotifyBuilder(msg, severity, color)))
-		local time = CurTime() + 1
+		local time = CurTime()
 		if severity > 1 and notify_antispam < time then
-			notify_antispam = time
+			notify_antispam = time + 1
 			notification.AddLegacy(string.format("Wiremod %s! Check your console for details", severity2word[severity]), NOTIFY_ERROR, 5)
 			surface.PlaySound(severity == 3 and "vo/k_lab/kl_fiddlesticks.wav" or "buttons/button22.wav")
 		end


### PR DESCRIPTION
Many users have been complaining about the number extension suddenly not working. This is because some servers don't have `math.tau` defined on them for whatever reason. This PR presents a twofold solution:

1. It sets a fallback for `math.tau` when it is undefined.
2. It ensures any future invalid constants will not cause extensions to fail loading.

Changes:
- Add fallback for `math.tau`
- Change error in `E2Lib.registerConstant` to use `WireLib.Notify` instead so invalid constants don't break the extension.
- Added some context to the errors in `E2Lib.registerConstant` (This functionality should probably be moved to its own function)
- Added timeout for `WireLib.Notify` "nudges" on the client

Updated error form (note E2 executes extension files twice):
![New errors](https://github.com/wiremod/wire/assets/20892685/7322f368-3e1d-4e79-b5ed-61d7e1943629)
