### PR TITLE
Add option to disable GetOwner() check in E2

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -220,7 +220,7 @@ function E2Lib.generate_signature(signature, rets, argnames)
 	local new_signature = string.format("%s(%s)", funcname, table.concat(args, ","))
 	if thistype then new_signature = thistype .. ":" .. new_signature end
 
-	return (not rets or rets == "") and (new_signature) or (E2Lib.typeName(rets) .. "=" .. new_signature)
+	return (not rets or rets == "") and new_signature or (E2Lib.typeName(rets) .. "=" .. new_signature)
 end
 
 -- ------------------------ various entity checkers ----------------------------
@@ -1211,7 +1211,7 @@ function E2Lib.compileScript(code, owner)
 	local status, tree, dvars = E2Lib.Parser.Execute(tokens)
 	if not status then return false, tree end
 
-	local status, script, inst = E2Lib.Compiler.Execute(tree, directives, dvars, {})
+	local status, script = E2Lib.Compiler.Execute(tree, directives, dvars, {})
 	if not status then return false, script end
 
 	local ctx = RuntimeContext.builder()

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -246,6 +246,9 @@ function E2Lib.validPhysics(entity)
 end
 
 -- This function gets wrapped when CPPI is detected, see very end of this file
+local getOwnerEnabled = CreateConVar("wire_expression2_getowner", "1", FCVAR_ARCHIVE, "Whether or not to use :GetOwner() get the owner of an entity."):GetBool()
+cvars.AddChangeCallback( "wire_expression2_getowner", function(_, _, new) getOwnerEnabled = tobool(new) end)
+
 function E2Lib.getOwner(self, entity)
 	if entity == nil then return end
 	if entity == self.entity or entity == self.player then return self.player end
@@ -268,7 +271,7 @@ function E2Lib.getOwner(self, entity)
 		end
 	end
 
-	if entity.GetOwner then
+	if getOwnerEnabled and entity.GetOwner then
 		local ply = entity:GetOwner()
 		if IsValid(ply) then return ply end
 	end
@@ -943,6 +946,7 @@ hook.Add("InitPostEntity", "e2lib", function()
 				local owner = entity:CPPIGetOwner()
 				if IsValid(owner) then return owner end
 
+                if not getOwnerEnabled then return end
 				return _getOwner(self, entity)
 			end)
 		end

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -946,7 +946,7 @@ hook.Add("InitPostEntity", "e2lib", function()
 				local owner = entity:CPPIGetOwner()
 				if IsValid(owner) then return owner end
 
-                if not getOwnerEnabled then return end
+				if not getOwnerEnabled then return end
 				return _getOwner(self, entity)
 			end)
 		end

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -946,7 +946,6 @@ hook.Add("InitPostEntity", "e2lib", function()
 				local owner = entity:CPPIGetOwner()
 				if IsValid(owner) then return owner end
 
-				if not getOwnerEnabled then return end
 				return _getOwner(self, entity)
 			end)
 		end


### PR DESCRIPTION
Currently if CPPI fails it defaults back to :GetOwner(), this is rather bad on a lot of servers as :GetOwner() isn't a prop ownership thing, it's used in weapons and projectiles
This gives players the ability to do things they're not supposed to do.
This PR adds a convar to be able to turn this behavior off while keeping the old system functional.