### PR TITLE
Check if registered_events exists

### DIFF
--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -560,15 +560,15 @@ function ENT:Setup(buffer, includes, restore, forcecompile, filepath)
 	end
 
 	-- Register events only after E2 has executed once
-    if self.registered_events then
-        for evt, _ in pairs(self.registered_events) do
-            if E2Lib.Env.Events[evt].constructor then
-                -- If the event has a constructor to run when the E2 is made and listening to the event.
-                E2Lib.Env.Events[evt].constructor(self.context)
-            end
-            E2Lib.Env.Events[evt].listening[self] = true
-        end
-    end
+	if self.registered_events then
+		for evt, _ in pairs(self.registered_events) do
+			if E2Lib.Env.Events[evt].constructor then
+				-- If the event has a constructor to run when the E2 is made and listening to the event.
+				E2Lib.Env.Events[evt].constructor(self.context)
+			end
+			E2Lib.Env.Events[evt].listening[self] = true
+		end
+	end
 
 	self:NextThink(CurTime())
 end

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -560,13 +560,15 @@ function ENT:Setup(buffer, includes, restore, forcecompile, filepath)
 	end
 
 	-- Register events only after E2 has executed once
-	for evt, _ in pairs(self.registered_events) do
-		if E2Lib.Env.Events[evt].constructor then
-			-- If the event has a constructor to run when the E2 is made and listening to the event.
-			E2Lib.Env.Events[evt].constructor(self.context)
-		end
-		E2Lib.Env.Events[evt].listening[self] = true
-	end
+    if self.registered_events then
+        for evt, _ in pairs(self.registered_events) do
+            if E2Lib.Env.Events[evt].constructor then
+                -- If the event has a constructor to run when the E2 is made and listening to the event.
+                E2Lib.Env.Events[evt].constructor(self.context)
+            end
+            E2Lib.Env.Events[evt].listening[self] = true
+        end
+    end
 
 	self:NextThink(CurTime())
 end


### PR DESCRIPTION
E2 already checks if `registered_events` exists in `ENT:Destruct()`, doing it in `ENT:Setup()` is only logical
Fixes https://github.com/wiremod/wire/issues/3060