### PR TITLE
Use placeholder for E2 search text

### DIFF
--- a/lua/wire/client/wire_expression2_browser.lua
+++ b/lua/wire/client/wire_expression2_browser.lua
@@ -130,7 +130,7 @@ function PANEL:StartSearch( str )
 end
 
 function PANEL:Init()
-	self:SetDrawBackground(false)
+	self:SetPaintBackground(false)
 
 	self.SearchBox = vgui.Create( "DTextEntry", self )
 	self.SearchBox:Dock( TOP )

--- a/lua/wire/client/wire_expression2_browser.lua
+++ b/lua/wire/client/wire_expression2_browser.lua
@@ -135,7 +135,7 @@ function PANEL:Init()
 	self.SearchBox = vgui.Create( "DTextEntry", self )
 	self.SearchBox:Dock( TOP )
 	self.SearchBox:DockMargin( 0,0,0,0 )
-	self.SearchBox:SetPlaceholderText( "Search..." )
+	self.SearchBox:SetPlaceholderText("Search...")
 
 	local clearsearch = vgui.Create( "DImageButton", self.SearchBox )
 	clearsearch:SetMaterial( "icon16/cross.png" )

--- a/lua/wire/client/wire_expression2_browser.lua
+++ b/lua/wire/client/wire_expression2_browser.lua
@@ -14,23 +14,6 @@ local invalid_filename_chars = {
 	[" "] = "_",
 }
 
-local function GetFileName(name)
-	local name = string.Replace(name, ".txt", "")
-	return string.Replace(name, "/", "")
-end
-
-local function InternalDoClick(self)
-	self:GetRoot():SetSelectedItem(self)
-	if (self:DoClick()) then return end
-	if (self:GetRoot():DoClick(self)) then return end
-end
-
-local function InternalDoRightClick(self)
-	self:GetRoot():SetSelectedItem(self)
-	if (self:DoRightClick()) then return end
-	if (self:GetRoot():DoRightClick(self)) then return end
-end
-
 local function fileName(filepath)
 	return string.match(filepath, "[/\\]?([^/\\]*)$")
 end

--- a/lua/wire/client/wire_expression2_browser.lua
+++ b/lua/wire/client/wire_expression2_browser.lua
@@ -152,7 +152,7 @@ function PANEL:Init()
 	self.SearchBox = vgui.Create( "DTextEntry", self )
 	self.SearchBox:Dock( TOP )
 	self.SearchBox:DockMargin( 0,0,0,0 )
-	self.SearchBox:SetValue( "Search..." )
+	self.SearchBox:SetPlaceholderText( "Search..." )
 
 	local clearsearch = vgui.Create( "DImageButton", self.SearchBox )
 	clearsearch:SetMaterial( "icon16/cross.png" )
@@ -160,30 +160,11 @@ function PANEL:Init()
 	function clearsearch:DoClick()
 		src:SetValue( "" )
 		src:OnEnter()
-		src:SetValue( "Search..." )
 	end
 	clearsearch:DockMargin( 2,2,4,2 )
 	clearsearch:Dock( RIGHT )
 	clearsearch:SetSize( 14, 10 )
 	clearsearch:SetVisible( false )
-
-
-	local old = self.SearchBox.OnGetFocus
-	function self.SearchBox:OnGetFocus()
-		if self:GetValue() == "Search..." then -- If "Search...", erase it
-			self:SetValue( "" )
-		end
-		old( self )
-	end
-
-	-- On lose focus
-	local old = self.SearchBox.OnLoseFocus
-	function self.SearchBox:OnLoseFocus()
-		if self:GetValue() == "" then -- if empty, reset "Search..." text
-			timer.Simple( 0, function() self:SetValue( "Search..." ) end )
-		end
-		old( self )
-	end
 
 	function self.SearchBox.OnEnter()
 		local str = self.SearchBox:GetValue()


### PR DESCRIPTION
Replaces the current :SetValue logic with the build in :SetPlaceHolder, has no real visual difference but simplifies the code.
The branch has error fix in it as there are some weird dtree errors, which happened when i used the searchbar with no text in it, however i wasn't able to replicate them so it's just a simple code cleanup pr for now.