### PR TITLE
Change instances of Entity:Use to use the correct caller

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -288,7 +288,7 @@ e2function void entity:use()
 	if hook.Run( "WireUse", ply, this, self ) == false then return end
 
 	if this.Use then
-		this:Use(ply,ply,USE_ON,0)
+		this:Use(ply,self,USE_ON,0)
 	else
 		this:Fire("use","1",0)
 	end

--- a/lua/entities/gmod_wire_user.lua
+++ b/lua/entities/gmod_wire_user.lua
@@ -39,7 +39,7 @@ function ENT:TriggerInput(iname, value)
 		if hook.Run( "WireUse", ply, trace.Entity, self ) == false then return false end
 
 		if trace.Entity.Use then
-			trace.Entity:Use(ply,ply,USE_ON,0)
+			trace.Entity:Use(ply,self,USE_ON,0)
 		else
 			trace.Entity:Fire("use","1",0)
 		end


### PR DESCRIPTION
Wire User and Expression 2's `entity:use()` call `Entity:Use` with the caller argument as the player. They are responsible for the input so the caller should be themself and not the player.