### PR TITLE
Fix NULL error in wire_adv tool

### DIFF
--- a/lua/weapons/gmod_tool/stools/wire_adv.lua
+++ b/lua/weapons/gmod_tool/stools/wire_adv.lua
@@ -620,6 +620,11 @@ elseif CLIENT then
 		end
 
 		if self:GetStage() == 2 then
+            if not IsValid( self.CurrentEntity ) then
+                self:SetStage(0)
+                return
+            end
+
 			local _, outputs = self:GetPorts( self.CurrentEntity )
 
 			if alt then -- Auto wiring


### PR DESCRIPTION
Fixes
```
[wire] addons/wire/lua/weapons/gmod_tool/stools/wire_adv.lua:664: attempt to index local 'outputs' (a nil value)
    1. LeftClick - addons/wire/lua/weapons/gmod_tool/stools/wire_adv.lua:664
        2. unknown - gamemodes/sandbox/entities/weapons/gmod_tool/shared.lua:229
```