### PR TITLE
Properly pass the chip entity instead of the runtimecontext

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -285,10 +285,10 @@ e2function void entity:use()
 	if not IsValid(ply) then return end -- if the owner isn't connected to the server, do nothing
 
 	if hook.Run( "PlayerUse", ply, this ) == false then return end
-	if hook.Run( "WireUse", ply, this, self ) == false then return end
+	if hook.Run( "WireUse", ply, this, self.entity ) == false then return end
 
 	if this.Use then
-		this:Use(ply,self,USE_ON,0)
+		this:Use(ply,self.entity,USE_ON,0)
 	else
 		this:Fire("use","1",0)
 	end


### PR DESCRIPTION
Fixes
sv: Expression 2 (chipname): Internal error 'entities/gmod_wire_expression2/core/custom/prop.lua:291: bad argument #2 to 'Use' (Entity expected, got table)' at line 179, char 5

Which broke after https://github.com/wiremod/wire/pull/3069

Also makes WireUse use the proper entity