### PR TITLE
Change GetContraption meta function to something different

### DIFF
--- a/lua/entities/gmod_wire_cameracontroller.lua
+++ b/lua/entities/gmod_wire_cameracontroller.lua
@@ -397,7 +397,7 @@ function ENT:Initialize()
 	self.NextGetContraption = 0
 	self.NextUpdateOutputs = 0
 
-	self:GetContraption()
+	self:GetCameraFilterEntities()
 
 	self:ColorByLinkStatus(self.LINK_STATUS_UNLINKED)
 end
@@ -503,7 +503,7 @@ end
 -- GetContraption
 -- Used in UpdateOutputs to make the traces ignore the contraption
 --------------------------------------------------
-function ENT:GetContraption()
+function ENT:GetCameraFilterEntities()
 	if CurTime() < self.NextGetContraption then return end
 	self.NextGetContraption = CurTime() + 5
 
@@ -626,7 +626,7 @@ function ENT:Think()
 		self:SyncPositions()
 	end
 
-	self:GetContraption()
+	self:GetCameraFilterEntities()
 	self:UpdateOutputs()
 
 	self:NextThink(CurTime())


### PR DESCRIPTION
Renamed from ENT:GetContraption() to ENT:GetCameraFilterEntities()

Fixes a conflict with Contraption Framework
- CFW adds a meta function to all entities, ENT:GetContraption, which returns the contraption an entity is a part of
- Prior to this PR, Wire Camera Controllers have a function of the same name that is called nowhere else within wire, and hopefully nowhere outside of wire either. This function serves as a way to get all of the entities part of a vehicle the camera pod is attached to, and then adds on whatever FilterEntities has.