### PR TITLE
Fix wire_adv tool NULL error

### DIFF
--- a/lua/weapons/gmod_tool/stools/wire_adv.lua
+++ b/lua/weapons/gmod_tool/stools/wire_adv.lua
@@ -1272,7 +1272,7 @@ elseif CLIENT then
 
 					traceData.collisiongroup = LAST_SHARED_COLLISION_GROUP
 					local traceResult = util.TraceLine(traceData)
-					if WireLib.HasPorts(traceResult.Entity) then
+					if IsValid(traceResult.Entity) and WireLib.HasPorts(traceResult.Entity) then
 						self:UpdateTraceForSurface(traceResult, traceResult.Entity:GetParent())
 					end
 					render.AddBeam(traceResult.HitPos, width, scroll+(traceResult.HitPos-start):Length()/10, Color(100,100,100,255))


### PR DESCRIPTION
Fixes
```
[wire] addons/wire/lua/wire/wireshared.lua:437: attempt to index local 'entTbl' (a nil value)
  1. HasPorts - addons/wire/lua/wire/wireshared.lua:437
   2. func - addons/wire/lua/weapons/gmod_tool/stools/wire_adv.lua:1275
    3. unknown - addons/ulib/lua/includes/modules/hook.lua:260
```
Which happens because `:GetTable()` returns a `nil` on `NULL` entities. In this case the trace [traceResult](https://github.com/wrefgtzweve/wire/blob/7a81f713764dac671d83cff73ec04a52bf88e9c5/lua/weapons/gmod_tool/stools/wire_adv.lua#L1274) can return a NULL ent when the trace doesn't ever hit anything thus causing this error.