### PR TITLE
Optimize overlay visibility logic

### DIFF
--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -226,7 +226,7 @@ if CLIENT then
 	end)
 
 	-- Custom better version of this base_gmodentity function
-	function ENT:WireBeingLookedAtByLocalPlayer()
+	function ENT:BeingLookedAtByLocalPlayer()
 		local trbool = BaseClass.BeingLookedAtByLocalPlayer(self)
 		local self_table = self:GetTable()
 
@@ -257,11 +257,14 @@ if CLIENT then
 		end
 
 		local cur_ent = ply:GetEyeTrace().Entity
-		local player_view_func = cur_ent.WireBeingLookedAtByLocalPlayer
 
-		if player_view_func and player_view_func(cur_ent) then
+		if cur_ent.IsWire and cur_ent:BeingLookedAtByLocalPlayer() then
 			looked_at = cur_ent
 		else
+			if IsValid(looked_at) then
+				looked_at:BeingLookedAtByLocalPlayer()
+			end
+
 			looked_at = nil
 		end
 	end)
@@ -273,7 +276,7 @@ if CLIENT then
 		else
 			self:DrawModel()
 		end
-		if not notip and looked_at then
+		if not notip and looked_at == self then
 			self:AddWorldTip()
 		end
 	end

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -258,13 +258,13 @@ if CLIENT then
 
 		local cur_ent = ply:GetEyeTrace().Entity
 
+		if cur_ent ~= looked_at and IsValid(looked_at) and looked_at.IsWire then
+			looked_at:BeingLookedAtByLocalPlayer()
+		end
+
 		if cur_ent.IsWire and cur_ent:BeingLookedAtByLocalPlayer() then
 			looked_at = cur_ent
 		else
-			if IsValid(looked_at) then
-				looked_at:BeingLookedAtByLocalPlayer()
-			end
-
 			looked_at = nil
 		end
 	end)

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -11,11 +11,6 @@ ENT.IsWire = true
 
 if CLIENT then
 	local wire_drawoutline = CreateClientConVar("wire_drawoutline", 1, true, false)
-	-- Funny reverse-detour because this function is sometimes nil and sometimes not, but is never nil when drawing for the first time.
-	local function beingLookedAtByLocalPlayer(self)
-		beingLookedAtByLocalPlayer = BaseClass.BeingLookedAtByLocalPlayer
-		return beingLookedAtByLocalPlayer(self)
-	end
 
 	function ENT:Initialize()
 		self.NextRBUpdate = CurTime() + 0.25
@@ -231,8 +226,8 @@ if CLIENT then
 	end)
 
 	-- Custom better version of this base_gmodentity function
-	function ENT:BeingLookedAtByLocalPlayer()
-		local trbool = beingLookedAtByLocalPlayer(self)
+	function ENT:WireBeingLookedAtByLocalPlayer()
+		local trbool = BaseClass.BeingLookedAtByLocalPlayer(self)
 		local self_table = self:GetTable()
 
 		if self_table.PlayerWasLookingAtMe ~= trbool then
@@ -251,9 +246,28 @@ if CLIENT then
 		return trbool
 	end
 
+	local looked_at
+
+	-- Shared by all derivative entities to determine if the overlay should be visible
+	hook.Add("Think", "wire_base_lookedatbylocalplayer", function()
+		local ply = LocalPlayer()
+		if not IsValid(ply) then
+			looked_at = nil
+			return
+		end
+
+		local cur_ent = ply:GetEyeTrace().Entity
+		local player_view_func = cur_ent.WireBeingLookedAtByLocalPlayer
+
+		if player_view_func and player_view_func(cur_ent) then
+			looked_at = cur_ent
+		else
+			looked_at = nil
+		end
+	end)
+
 	function ENT:DoNormalDraw(nohalo, notip)
-		local looked_at = self:BeingLookedAtByLocalPlayer()
-		if not nohalo and wire_drawoutline:GetBool() and looked_at then
+		if not nohalo and wire_drawoutline:GetBool() and looked_at == self then
 			self:DrawEntityOutline()
 			self:DrawModel()
 		else


### PR DESCRIPTION
When many entities derived from `base_wire_entity` exist at once, they all separately (and continuously) perform their own logic to test if the overlay should be visible or not, which can have a pretty notable performance impact clientside. This PR combines all of these potential calls into a single Think hook, which is way faster.

Here's a comparison between having 93 `base_wire_entity`-derived entities out before and after measured over 20 seconds for this logic:

![image45](https://github.com/wiremod/wire/assets/64441307/e34ee8c1-9b02-4385-8b15-8d460150ffbf)
![image46](https://github.com/wiremod/wire/assets/64441307/948dcd07-1e5c-43f2-90a4-b4e230d36841)