### PR TITLE
Cancel motor creation, tooltip for motor removal

### DIFF
--- a/lua/wire/stools/motor.lua
+++ b/lua/wire/stools/motor.lua
@@ -10,9 +10,12 @@ if CLIENT then
 	language.Add( "WireMotorTool_forcelimit", "Force Limit:" )
 	language.Add( "WireMotorTool_offset", "Position Offset:" )
 	TOOL.Information = {
-		{ name = "left_0", stage = 0, text = "Choose the wheel's axis" },
-		{ name = "left_1", stage = 1, text = "Choose the base's axis" },
-		{ name = "left_2", stage = 2, text = "Place the controller" },
+		{ name = "left_0",   stage = 0, text = "Choose the wheel's axis" },
+		{ name = "reload_0", stage = 0, text = "Remove wire motor constraint" },
+		{ name = "left_1",   stage = 1, text = "Choose the base's axis" },
+		{ name = "reload_1", stage = 1, text = "Cancel wire motor" },
+		{ name = "left_2",   stage = 2, text = "Place the controller" },
+		{ name = "reload_2", stage = 2, text = "Cancel wire motor" },
 	}
 end
 WireToolSetup.BaseLang()
@@ -182,10 +185,18 @@ function TOOL:RightClick( trace )
 end
 
 function TOOL:Reload( trace )
-	if not IsValid( trace.Entity ) or trace.Entity:IsPlayer() then return false end
-	if CLIENT then return true end
-
-	return constraint.RemoveConstraints( trace.Entity, "WireMotor" )
+	if self:GetStage() > 0 then
+		self:ClearObjects()
+		self:SetStage(0)
+		if CLIENT then
+			self:ReleaseGhostEntity()
+		end
+	else
+		if not IsValid( trace.Entity ) or trace.Entity:IsPlayer() then return false end
+		if CLIENT then return true end
+	
+		return constraint.RemoveConstraints( trace.Entity, "WireMotor" )
+	end
 end
 
 function TOOL:Think()

--- a/lua/wire/stools/motor.lua
+++ b/lua/wire/stools/motor.lua
@@ -188,9 +188,7 @@ function TOOL:Reload( trace )
 	if self:GetStage() > 0 then
 		self:ClearObjects()
 		self:SetStage(0)
-		if CLIENT then
-			self:ReleaseGhostEntity()
-		end
+		self:ReleaseGhostEntity()
 	else
 		if not IsValid( trace.Entity ) or trace.Entity:IsPlayer() then return false end
 		if CLIENT then return true end


### PR DESCRIPTION
Wire motors can now be cancelled midway through creation via the tool, adds a tooltip telling you that you can remove wire's motor constraints doing this too, which I don't recall ever being documented

Fixes the main issue in #3059

Stage 1 display(no selection)
![gmod_1z5CYfaisO](https://github.com/user-attachments/assets/7b8382e3-5e80-4e56-a643-7e0e744e353e)
Stage 2 display(selected one)
![gmod_cRM8ATrUT1](https://github.com/user-attachments/assets/409c4701-c1ad-473c-b109-6132367740fb)
Stage 3 display(constraint created, cancelling will leave the wheel constrained but that can be undone by pressing R on the wheel again after)
![gmod_TYktMELSxR](https://github.com/user-attachments/assets/546d551c-f134-42c7-bd90-de94a4baf939)
