### PR TITLE
E2 Incoming hispeed read/write events

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/wirelink.lua
+++ b/lua/entities/gmod_wire_expression2/core/wirelink.lua
@@ -643,17 +643,13 @@ end
 -- functions for returning hispeed error & value are the best compromise.
 
 __e2setcost(2)
-e2function void returnHiSpeedValue(number value)
+e2function void hispeedReturnValue(number value)
 	self.data.hispeedIOError = false
 	self.data.readCellValue = value
 end
 
-e2function void setHiSpeedError(number value)
+e2function void hispeedSetError(number value)
 	self.data.hispeedIOError = value ~= 0
-end
-
-e2function void returnHiSpeedError()
-	self.data.hispeedIOError = true
 end
 
 E2Lib.registerEvent("readCell",

--- a/lua/entities/gmod_wire_expression2/core/wirelink.lua
+++ b/lua/entities/gmod_wire_expression2/core/wirelink.lua
@@ -641,7 +641,7 @@ end
 -- Events can't have return values, lambdas can't have multiple return types
 -- Don't want to risk a magic number as error causing a collision, so I figure
 -- functions for returning hispeed error & value are the best compromise.
-e2function void returnReadValue(number value)
+e2function void returnHiSpeedValue(number value)
 	self.data.hispeedIOError = false
 	self.data.readCellValue = value
 end

--- a/lua/entities/gmod_wire_expression2/core/wirelink.lua
+++ b/lua/entities/gmod_wire_expression2/core/wirelink.lua
@@ -655,40 +655,7 @@ end
 E2Lib.registerEvent("readCell",
 	{
 		{"Address","n"}
-	},
-	function(ctx) -- Constructor
-		local function readCellEvent(self,addr)
-			if self.error then return nil end
-			ctx.data.hispeedIOError = false
-			ctx.data.readCellValue = 0
-			self:ExecuteEvent("readCell",{addr})
-			if ctx.data.hispeedIOError or self.error then return nil end
-			return ctx.data.readCellValue
-		end
-		local ent = ctx.entity
-		if ent.ReadCell == ent.E2ReadCellEvent or not ent.ReadCell then
-			ent.ReadCell = readCellEvent
-			ent.E2ReadCellEvent = readCellEvent
-		else
-			ctx:throw("E2's entity has a different ReadCell function present already! Disable strict to overwrite.")
-			-- Good idea to save so we can restore it after, best not to brick our entity's I/O
-			ent.E2OldReadCell = ent.ReadCell
-			ent.ReadCell = readCellEvent
-		end
-	end,
-	function(ctx)
-		local ent = ctx.entity
-		-- If it's not ours, then whatever context gave us the function can handle its removal.
-		if ent.ReadCell == ent.E2ReadCellEvent then
-			if ent.OldE2ReadCell then
-				ent.ReadCell = ent.OldE2ReadCell
-			else
-				ent.ReadCell = nil
-			end
-		end
-		ent.E2ReadCellEvent = nil
-		ent.OldE2ReadCell = nil
-	end
+	}
 )
 
 
@@ -696,35 +663,5 @@ E2Lib.registerEvent("writeCell",
 	{
 		{"Address","n"},
 		{"Value","n"}
-	},
-	function(ctx) -- Constructor
-		local function writeCellEvent(self,addr,value)
-			if self.error then return nil end
-			ctx.data.hispeedIOError = false
-			self:ExecuteEvent("writeCell",{addr,value})
-			if ctx.data.hispeedIOError or self.error then return nil end
-			return true
-		end
-		local ent = ctx.entity
-		if ent.WriteCell == ent.E2WriteCellEvent or not ent.WriteCell then
-			ent.WriteCell = writeCellEvent
-			ent.E2WriteCellEvent = writeCellEvent
-		else
-			ctx:throw("E2's entity has a different WriteCell function present already! Remove @strict to overwrite.")
-			ent.OldE2WriteCell = ent.WriteCell
-			ent.WriteCell = writeCellEvent
-		end
-	end,
-	function(ctx)
-		local ent = ctx.entity
-		if ent.WriteCell == ent.E2WriteCellEvent then
-			if ent.OldE2WriteCell then
-				ent.WriteCell = ent.OldE2WriteCell
-			else
-				ent.WriteCell = nil
-			end
-		end
-		ent.E2WriteCellEvent = nil
-		ent.OldE2WriteCell = nil
-	end
+	}
 )

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -585,6 +585,27 @@ function ENT:Reset()
 	end)
 end
 
+function ENT:ReadCell(Address)
+	local selfTbl = self:GetTable()
+	if selfTbl.error or not selfTbl.registered_events["readCell"] then return nil end
+	local ctx = selfTbl.context
+	ctx.data.hispeedIOError = false
+	ctx.data.readCellValue = 0
+	self:ExecuteEvent("readCell",{Address})
+	if ctx.data.hispeedIOError or self.error then return nil end
+	return ctx.data.readCellValue
+end
+
+function ENT:WriteCell(addr,value)
+	local selfTbl = self:GetTable()
+	if selfTbl.error or not selfTbl.registered_events["writeCell"] then return nil end
+	local ctx = selfTbl.context
+	ctx.data.hispeedIOError = false
+	self:ExecuteEvent("writeCell",{addr,value})
+	if ctx.data.hispeedIOError or self.error then return nil end
+	return true
+end
+
 function ENT:TriggerInput(key, value)
 	if self.error then return end
 	if key and self.inports and self.inports[3][key] then

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -796,9 +796,8 @@ E2Helper.Descriptions["outputs(xwl:)"] = "Returns an array of all the outputs th
 E2Helper.Descriptions["inputType(xwl:s)"] = "Returns the type of input that S is in lowercase. ( \"NORMAL\" is changed to \"number\" )"
 E2Helper.Descriptions["outputType(xwl:s)"] = "Returns the type of output that S is in lowercase. ( \"NORMAL\" is changed to \"number\" )"
 E2Helper.Descriptions["setXyz(xwl:v)"] = "Sets the X/Y/Z to the corresponding values in the vector"
-E2Helper.Descriptions["returnHiSpeedError()"] = "If used from inside of event readCell or event writeCell, indicates that the read/write request couldn't be fulfilled.\nDoesn't error your chip."
-E2Helper.Descriptions["setHiSpeedError(n)"] = "If argument is zero, clears error flag for readcell/writecell event, if non-zero, sets the error flag.\nSee returnHiSpeedError() for more info"
-E2Helper.Descriptions["returnHiSpeedValue(n)"] = "If used from inside of event readCell, satisfies the incoming read request with the provided number. Clears returnHiSpeedError if previously called."
+E2Helper.Descriptions["hispeedSetError(n)"] = "If used from inside of event readCell or event writeCell, non-zero indicates that the read/write request couldn't be fulfilled.\nDoesn't error your chip."
+E2Helper.Descriptions["hispeedReturnValue(n)"] = "If used from inside of event readCell, satisfies the incoming read request with the provided number.\nClears HiSpeed error flag."
 
 
 -- Quaternions

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -796,6 +796,9 @@ E2Helper.Descriptions["outputs(xwl:)"] = "Returns an array of all the outputs th
 E2Helper.Descriptions["inputType(xwl:s)"] = "Returns the type of input that S is in lowercase. ( \"NORMAL\" is changed to \"number\" )"
 E2Helper.Descriptions["outputType(xwl:s)"] = "Returns the type of output that S is in lowercase. ( \"NORMAL\" is changed to \"number\" )"
 E2Helper.Descriptions["setXyz(xwl:v)"] = "Sets the X/Y/Z to the corresponding values in the vector"
+E2Helper.Descriptions["returnHiSpeedError()"] = "If used from inside of event readCell or event writeCell, indicates that the read/write request couldn't be fulfilled.\nDoesn't error your chip."
+E2Helper.Descriptions["returnHiSpeedValue(n)"] = "If used from inside of event readCell, satisfies the incoming read request with the provided number. Clears returnHiSpeedError if previously called."
+
 
 -- Quaternions
 E2Helper.Descriptions["comp()"] = "Returns complex zero"

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -797,6 +797,7 @@ E2Helper.Descriptions["inputType(xwl:s)"] = "Returns the type of input that S is
 E2Helper.Descriptions["outputType(xwl:s)"] = "Returns the type of output that S is in lowercase. ( \"NORMAL\" is changed to \"number\" )"
 E2Helper.Descriptions["setXyz(xwl:v)"] = "Sets the X/Y/Z to the corresponding values in the vector"
 E2Helper.Descriptions["returnHiSpeedError()"] = "If used from inside of event readCell or event writeCell, indicates that the read/write request couldn't be fulfilled.\nDoesn't error your chip."
+E2Helper.Descriptions["setHiSpeedError(n)"] = "If argument is zero, clears error flag for readcell/writecell event, if non-zero, sets the error flag.\nSee returnHiSpeedError() for more info"
 E2Helper.Descriptions["returnHiSpeedValue(n)"] = "If used from inside of event readCell, satisfies the incoming read request with the provided number. Clears returnHiSpeedError if previously called."
 
 


### PR DESCRIPTION
Part of wirelink.lua

Adds events for read, and write
```typescript
event readCell(Address:number) {}
event writeCell(Address:number, Value:number) {}
```

Three functions for use inside of these events.

```typescript
void hispeedReturnValue(Value:number)
```
Returns Value when exiting a readCell event, also clears hispeed error flag

```typescript
void hispeedSetError(Value:number)
```
If nonzero, indicates that the request couldn't be satisfied, doesn't error your chip but may raise errors in things like ZCPU which use return of nil/false from read/write to indicate out of range or other errors.