### PR TITLE
Add entity:parentToAttachment()

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/cl_prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cl_prop.lua
@@ -51,6 +51,7 @@ E2Helper.Descriptions["setLocalAng(e:a)"] = "Set the rotation of an entity local
 E2Helper.Descriptions["rerotate(e:a)"] = "Deprecated. Kept for backwards-compatibility."
 E2Helper.Descriptions["parentTo(e:e)"] = "Parents one entity to another."
 E2Helper.Descriptions["parentTo(e:)"] = E2Helper.Descriptions["parentTo(e:e)"]
+E2Helper.Descriptions["parentToAttachment(e:es)"] = "Parents one entity to anothers attachment."
 E2Helper.Descriptions["deparent(e:)"] = "Unparents an entity, so it moves freely again."
 E2Helper.Descriptions["propBreak(e:)"] = "Breaks/Explodes breakable/explodable props (Useful for Mines)."
 E2Helper.Descriptions["propCanCreate()"] = "Returns 1 when propSpawn() will successfully spawn a prop until the limit is reached."

--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -197,7 +197,7 @@ local function boneVerify(self, bone)
 	return ent, index
 end
 
--- A way to statically blacklist a registered sent 
+-- A way to statically blacklist a registered sent
 local blacklistedSents = {
 	--gmod_wire_foo = true,
 }
@@ -1254,6 +1254,19 @@ e2function void entity:parentTo(entity target)
 	this:SetParent(target)
 end
 
+e2function void entity:parentToAttachment(entity target, string attachmentName)
+	if not ValidAction(self, this, "parent") then return self:throw("You do not have permission to parent to this prop!", nil) end
+	if not IsValid(target) then return self:throw("Target prop is invalid.", nil) end
+	if not isOwner(self, target) then return self:throw("You do not own the target prop!", nil) end
+	if not parent_antispam( this ) then return self:throw("You are parenting too fast!", nil) end
+	if this == target then return self:throw("You cannot parent a prop to itself") end
+	if not parent_check( self, this, target ) then return self:throw("Parenting chain of entities can't exceed 16 or crash may occur", nil) end
+	if attachmentName == nil then return self:throw("You cannot parent to nil attachment!", nil) end
+
+	this:SetParent(target)
+	this:Fire("SetParentAttachmentMaintainOffset", attachmentName)
+end
+
 __e2setcost(5)
 e2function void entity:deparent()
 	if not ValidAction(self, this, "deparent") then return end
@@ -1534,7 +1547,7 @@ local function E2CollisionEventHandler()
 		if IsValid(chip) then
 			if not chip.error then
 				for _,i in ipairs(ctx.data.E2QueuedCollisions) do
-					if i.cb then 
+					if i.cb then
 						-- Arguments for this were checked when we set it up, no need to typecheck
 						i.cb:UnsafeCall({i.us,i.xcd.HitEntity,i.xcd})
 						if chip.error then break end
@@ -1598,7 +1611,7 @@ e2function number trackCollision( entity ent, function cb )
 			local arg_sig = "(void)"
 			if #cb.arg_sig > 0 then
 				arg_sig = "("..cb.arg_sig..")"
-			end	
+			end
 			self:forceThrow("Collision callback expecting arguments (eexcd), got "..arg_sig)
 		end
 		startCollisionTracking(self,ent,entIndex,cb)


### PR DESCRIPTION
A propcore method for parenting props to attachments similiar to what holograms have, having this reduces the need for pointless hologram slave entities.