### PR TITLE
lua/entities/gmod_wire_expression2/core/cl_files.lua:70: attempt to index a nil value

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/cl_files.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_files.lua
@@ -67,7 +67,14 @@ end)
 net.Receive("wire_expression2_file_download", function()
 	local path, name = process_filepath(net.ReadString())
 	local append = net.ReadBool()
-	if not E2Lib.isValidFileWritePath(name) then net.ReadStream(nil, function() end):Remove() return end
+	if not E2Lib.isValidFileWritePath(name) then
+		local stream = net.ReadStream(nil, function() end)
+		if stream then
+			stream:Remove()
+		end
+
+		return
+	end
 	if not file.Exists(path, "DATA") then file.CreateDir(path) end
 	net.ReadStream(nil, function(data)
 		if append then

--- a/lua/entities/gmod_wire_expression2/core/cl_files.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_files.lua
@@ -71,6 +71,8 @@ net.Receive("wire_expression2_file_download", function()
 		local stream = net.ReadStream(nil, function() end)
 		if stream then
 			stream:Remove()
+		else
+			ErrorNoHaltWithStack("Warning! Looks like the server uses an outdated version of Expression2's file module! Please update to the latest Wiremod version.")
 		end
 
 		return


### PR DESCRIPTION
I experienced this issue on server I'm currently maintaining.
After a 40+ minutes of fixing a problem I saw that we had an old version of `file.lua`. The structure of `wire_expression2_file_download` net message was different, and because of that `net.ReadString()` returned garbage on client and there was no stream message.

So, I decided to add a notify message about an old version, just to safe devs' time, who decided to update to the latest versions of Wiremod, but have old files and also to be safe from random net messages.

### Error
```
[Wiremod] lua/entities/gmod_wire_expression2/core/cl_files.lua:70: attempt to index a nil value
  1. func - lua/entities/gmod_wire_expression2/core/cl_files.lua:70
   2. unknown - lua/includes/extensions/net.lua:38
```

### What returned `net.ReadStream`
`nil`

### Expression2 test code
```lua
print(fileWrite("a.txt", "123"))
```

Also provide info for people who don't understand Lua:
![image](https://github.com/user-attachments/assets/5c4d9a9f-c4eb-4f13-8955-ff5b3b18f7c0)
