### PR TITLE
Camera Controller Vehicles input (Pod's Vehicle like)

### DIFF
--- a/lua/entities/gmod_wire_cameracontroller.lua
+++ b/lua/entities/gmod_wire_cameracontroller.lua
@@ -378,7 +378,8 @@ function ENT:Initialize()
 		"Parent (Parents the camera to this entity.) [ENTITY]",
 		"FilterEntities (In addition to ignoring the contraption of the 'Parent' entity, or the cam controller itself\nif parent isn't used, entities in this list will be ignored by the 'HitPos' and 'Trace' outputs) [ARRAY]",
 		"FLIR",
-		"FOV"
+		"FOV",
+		"Vehicles (Links all vehicles of passed array to this cam controller) [ARRAY]",
 	})
 
 	self.Activated = false -- Whether or not to activate the cam controller for all players sitting in linked vehicles, or as soon as a player sits in a linked vehicle
@@ -429,7 +430,7 @@ end
 -- Setup
 --------------------------------------------------
 
-function ENT:Setup(ParentLocal,AutoMove,FreeMove,LocalMove,AllowZoom,AutoUnclip,DrawPlayer,AutoUnclip_IgnoreWater,DrawParent)
+function ENT:Setup(ParentLocal,AutoMove,FreeMove,LocalMove,AllowZoom,AutoUnclip,DrawPlayer,AutoUnclip_IgnoreWater,DrawParent,Vehicles)
 	self.ParentLocal = tobool(ParentLocal)
 	self.AutoMove = tobool(AutoMove)
 	self.FreeMove = tobool(FreeMove)
@@ -439,6 +440,14 @@ function ENT:Setup(ParentLocal,AutoMove,FreeMove,LocalMove,AllowZoom,AutoUnclip,
 	self.AutoUnclip_IgnoreWater = tobool(AutoUnclip_IgnoreWater)
 	self.DrawPlayer = tobool(DrawPlayer)
 	self.DrawParent = tobool(DrawParent)
+
+	if Vehicles then
+		for k,v in ipairs( Vehicles ) do
+			if( TypeID(v) ~= TYPE_ENTITY ) then continue end
+			if( not IsValid(v) ) then continue end
+			self:LinkEnt( v )
+		end
+	end
 
 	self:UpdateOverlay()
 end
@@ -838,6 +847,13 @@ function ENT:TriggerInput( name, value )
 		self.FLIR = value ~= 0
 		if not self.Activated then return end
 		self:SetFLIR()
+	elseif name == "Vehicles" then
+		self:ClearEntities()
+		for k, v in ipairs( value ) do
+			if( TypeID(v) ~= TYPE_ENTITY ) then continue end
+			if( not IsValid(v) ) then continue end
+			self:LinkEnt( v )
+		end
 	else
 		self:LocalizePositions(false)
 
@@ -1096,4 +1112,4 @@ end
 WireLib.AddInputAlias( "Zoom", "FOV" )
 WireLib.AddOutputAlias( "XYZ", "HitPos" )
 
-duplicator.RegisterEntityClass("gmod_wire_cameracontroller", WireLib.MakeWireEnt, "Data", "ParentLocal","AutoMove","FreeMove","LocalMove","AllowZoom","AutoUnclip","DrawPlayer","AutoUnclip_IgnoreWater","DrawParent")
+duplicator.RegisterEntityClass("gmod_wire_cameracontroller", WireLib.MakeWireEnt, "Data", "ParentLocal","AutoMove","FreeMove","LocalMove","AllowZoom","AutoUnclip","DrawPlayer","AutoUnclip_IgnoreWater","DrawParent","Vehicles")

--- a/lua/wire/server/sents_registry.lua
+++ b/lua/wire/server/sents_registry.lua
@@ -985,16 +985,28 @@ register("gmod_wire_locator", {
 })
 
 register("gmod_wire_cameracontroller", {
+	_preFactory = function(ply, self)
+		-- Verifies that all entities are valid, all entities are vehicles, and that passed table is an array
+		local i = 0
+		for _ in pairs(self.Vehicles) do
+			i = i + 1
+			if self.Vehicles[i] == nil then return "Vehicles parameter must be of type array!" end
+			if TypeID(self.Vehicles[i]) ~= TYPE_ENTITY then return "Vehicles parameter must consist only of entities" end
+			if not self.Vehicles[i]:IsVehicle() then return "Vehicles parameter must consist only of vehicles" end
+		end
+	end,
+
 	["Model"] = {TYPE_STRING, "models/jaanus/wiretool/wiretool_siren.mdl", "Path to model"},
-	["ParentLocal"] = {TYPE_BOOL, false},
-	["AutoMove"] = {TYPE_BOOL, false},
-	["FreeMove"] = {TYPE_BOOL, false},
-	["LocalMove"] = {TYPE_BOOL, false},
-	["AllowZoom"] = {TYPE_BOOL, false},
-	["AutoUnclip"] = {TYPE_BOOL, false},
-	["DrawPlayer"] = {TYPE_BOOL, true},
-	["AutoUnclip_IgnoreWater"] = {TYPE_BOOL, false},
-	["DrawParent"] = {TYPE_BOOL, true},
+	["ParentLocal"] = {TYPE_BOOL, false, "Should the coordinates be local to the parent?"},
+	["AutoMove"] = {TYPE_BOOL, false, "Allow the player to rotate camera using their mouse? (Coordinaets becomes center of orbit)"},
+	["FreeMove"] = {TYPE_BOOL, false, "Allow 360 rotation? The 'UnRoll' input can be toggled to match the parent entity's roll. (NOTE: Only used if 'AutoMove' is enabled)"},
+	["LocalMove"] = {TYPE_BOOL, false, "Is client movement local to parent? (NOTE: Only used if 'AutoMove' is enabled)"},
+	["AllowZoom"] = {TYPE_BOOL, false, "Allow user to move camera in and out using mouse scroller? (NOTE: Only used if 'AutoMove' is enabled. NOTE: Some outputs may become wrong)"},
+	["AutoUnclip"] = {TYPE_BOOL, false, "Prevent the camera from clipping into world? (By moving it closer)"},
+	["DrawPlayer"] = {TYPE_BOOL, true, "Should user be able to see himself?"},
+	["AutoUnclip_IgnoreWater"] = {TYPE_BOOL, false, "Should camera clip into water? (NOTE: Only used if 'AutoUnclip' is enabled)"},
+	["DrawParent"] = {TYPE_BOOL, true, "Should the parent of camera be rendered?"},
+	["Vehicles"] = {TYPE_TABLE, {}, "Autolink cameras to array of vehicles/seats"}
 })
 
 register("gmod_wire_dual_input", {


### PR DESCRIPTION
- Adds Vehicles[ARRAY] input, which lets you connect vehicles to cam controller by using wire.
- Updates spawnSent to reflect the change + added camcontroller's sentSpawn parameter descriptions.