### PR TITLE
Check if sound exists, fix sound emitter stuck bug

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/sound.lua
+++ b/lua/entities/gmod_wire_expression2/core/sound.lua
@@ -74,7 +74,7 @@ local function soundCreate(self, entity, index, time, path, fade)
 	path = string.Trim(string.sub(path, 1, 260))
 	if path:match('["?]') then return end
 
-    if not file.Exists("sound/" .. path, "GAME") then return end
+	if not file.Exists("sound/" .. path, "GAME") then return end
 	local data = self.data.sound_data
 	if not isAllowed( self ) then return end
 
@@ -294,15 +294,15 @@ e2function number soundPlaying( string index ) = e2function number soundPlaying(
 -- EmitSound
 
 local function EmitSound(e2, ent, snd, level, pitch, volume)
-    if not isAllowed(e2) then return end
+	if not isAllowed(e2) then return end
 
-    if not IsValid(ent) then return e2:throw("Invalid entity!", nil) end
-    if not isOwner(e2, ent) then return e2:throw("You do not own this entity!", nil) end
+	if not IsValid(ent) then return e2:throw("Invalid entity!", nil) end
+	if not isOwner(e2, ent) then return e2:throw("You do not own this entity!", nil) end
 
-    local maxlevel = wire_expression2_sound_level_max:GetInt()
-    if level ~= nil and level > maxlevel then
-        level = maxlevel
-    end
+	local maxlevel = wire_expression2_sound_level_max:GetInt()
+	if level ~= nil and level > maxlevel then
+		level = maxlevel
+	end
 
 	snd = string.sub(snd, 1, 260)
 	if snd:match('["?]') then return end
@@ -311,26 +311,26 @@ end
 
 __e2setcost(20)
 e2function void entity:emitSound(string soundName, number soundLevel, number pitchPercent, number volume)
-    EmitSound(self, this, soundName, soundLevel, pitchPercent, volume)
+	EmitSound(self, this, soundName, soundLevel, pitchPercent, volume)
 end
 
 e2function void entity:emitSound(string soundName, number soundLevel, number pitchPercent)
-    EmitSound(self, this, soundName, soundLevel, pitchPercent)
+	EmitSound(self, this, soundName, soundLevel, pitchPercent)
 end
 
 e2function void entity:emitSound(string soundName, number soundLevel)
-    EmitSound(self, this, soundName, soundLevel)
+	EmitSound(self, this, soundName, soundLevel)
 end
 
 e2function void entity:emitSound(string soundName)
-    EmitSound(self, this, soundName)
+	EmitSound(self, this, soundName)
 end
 
 e2function void entity:emitSoundStop(string soundName)
-    if not IsValid(this) then return self:throw("Invalid entity!", nil) end
-    if not isOwner(self, this) then return self:throw("You do not own this entity!", nil) end
+	if not IsValid(this) then return self:throw("Invalid entity!", nil) end
+	if not isOwner(self, this) then return self:throw("You do not own this entity!", nil) end
 
-    this:StopSound(soundName)
+	this:StopSound(soundName)
 end
 
 ---------------------------------------------------------------

--- a/lua/entities/gmod_wire_expression2/core/sound.lua
+++ b/lua/entities/gmod_wire_expression2/core/sound.lua
@@ -73,6 +73,8 @@ end
 local function soundCreate(self, entity, index, time, path, fade)
 	path = string.Trim(string.sub(path, 1, 260))
 	if path:match('["?]') then return end
+
+    if not file.Exists("sound/" .. path, "GAME") then return end
 	local data = self.data.sound_data
 	if not isAllowed( self ) then return end
 

--- a/lua/entities/gmod_wire_soundemitter.lua
+++ b/lua/entities/gmod_wire_soundemitter.lua
@@ -133,9 +133,17 @@ end
 
 function ENT:UpdateSound()
 	if self.NeedsRefresh or self.sound ~= self.ActiveSample then
+        if not file.Exists("sound/" .. self.sound, "GAME") then return end
+
 		self.NeedsRefresh = nil
 		local filter = RecipientFilter()
 		filter:AddAllPlayers()
+
+        if self.SoundObj then
+            self.SoundObj:Stop()
+            self.SoundObj = nil
+        end
+
 		self.SoundObj = CreateSound(self, self.sound, filter)
 		self.ActiveSample = self.sound
 

--- a/lua/entities/gmod_wire_soundemitter.lua
+++ b/lua/entities/gmod_wire_soundemitter.lua
@@ -133,16 +133,16 @@ end
 
 function ENT:UpdateSound()
 	if self.NeedsRefresh or self.sound ~= self.ActiveSample then
-        if not file.Exists("sound/" .. self.sound, "GAME") then return end
+		if not file.Exists("sound/" .. self.sound, "GAME") then return end
 
 		self.NeedsRefresh = nil
 		local filter = RecipientFilter()
 		filter:AddAllPlayers()
 
-        if self.SoundObj then
-            self.SoundObj:Stop()
-            self.SoundObj = nil
-        end
+		if self.SoundObj then
+			self.SoundObj:Stop()
+			self.SoundObj = nil
+		end
 
 		self.SoundObj = CreateSound(self, self.sound, filter)
 		self.ActiveSample = self.sound


### PR DESCRIPTION
Fixes a exploit that allows clients to spam the server/other clients with invalid sounds, was attempted to be fixed with https://github.com/wiremod/wire/pull/2975 but didn't fix the root issue.

Also fixes the sound emitter not properly stopping its old sound when it changes sounds.