### PR TITLE
Fix e2 soundcore & sound emitter from not playing soundscripts & sounds with sound characters.

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/sound.lua
+++ b/lua/entities/gmod_wire_expression2/core/sound.lua
@@ -70,11 +70,16 @@ local function soundStop(self, index, fade)
 	timer.Remove( "E2_sound_stop_" .. self.entity:EntIndex() .. "_" .. index )
 end
 
+local function soundExists(path)
+	if istable(sound.GetProperties(path)) then return true end
+	if file.Exists("sound/" .. string.gsub(path, "^%W", ""), "GAME") then return true end
+end
+
 local function soundCreate(self, entity, index, time, path, fade)
 	path = string.Trim(string.sub(path, 1, 260))
 	if path:match('["?]') then return end
 
-	if not file.Exists("sound/" .. path, "GAME") then return end
+	if not soundExists(path) then return end
 	local data = self.data.sound_data
 	if not isAllowed( self ) then return end
 

--- a/lua/entities/gmod_wire_expression2/core/sound.lua
+++ b/lua/entities/gmod_wire_expression2/core/sound.lua
@@ -72,9 +72,8 @@ end
 
 
 local function soundCreate(self, entity, index, time, path, fade)
-	if path:match('["?]') then return end
-
-	if not WireLib.SoundExists(path) then return end
+	path = WireLib.SoundExists(path)
+	if not path then return end
 	local data = self.data.sound_data
 	if not isAllowed( self ) then return end
 

--- a/lua/entities/gmod_wire_expression2/core/sound.lua
+++ b/lua/entities/gmod_wire_expression2/core/sound.lua
@@ -76,7 +76,6 @@ local function soundExists(path)
 end
 
 local function soundCreate(self, entity, index, time, path, fade)
-	path = string.Trim(string.sub(path, 1, 260))
 	if path:match('["?]') then return end
 
 	if not soundExists(path) then return end

--- a/lua/entities/gmod_wire_expression2/core/sound.lua
+++ b/lua/entities/gmod_wire_expression2/core/sound.lua
@@ -70,15 +70,11 @@ local function soundStop(self, index, fade)
 	timer.Remove( "E2_sound_stop_" .. self.entity:EntIndex() .. "_" .. index )
 end
 
-local function soundExists(path)
-	if istable(sound.GetProperties(path)) then return true end
-	if file.Exists("sound/" .. string.gsub(path, "^%W", ""), "GAME") then return true end
-end
 
 local function soundCreate(self, entity, index, time, path, fade)
 	if path:match('["?]') then return end
 
-	if not soundExists(path) then return end
+	if not WireLib.SoundExists(path) then return end
 	local data = self.data.sound_data
 	if not isAllowed( self ) then return end
 

--- a/lua/entities/gmod_wire_soundemitter.lua
+++ b/lua/entities/gmod_wire_soundemitter.lua
@@ -133,7 +133,6 @@ end
 
 function ENT:UpdateSound()
 	if self.NeedsRefresh or self.sound ~= self.ActiveSample then
-		if not WireLib.SoundExists(self.sound) then return end
 
 		self.NeedsRefresh = nil
 		local filter = RecipientFilter()
@@ -167,15 +166,15 @@ end
 function ENT:SetSound(soundName)
 	self:StopSounds()
 
-	soundName = string.Trim(string.sub(soundName, 1, 260))
-	if soundName:match('["?]') then return end
-	util.PrecacheSound(soundName)
+	soundName = WireLib.SoundExists(soundName)
+	if not soundName then return end
 
+	util.PrecacheSound(soundName)
 	self.sound = soundName
 
-	self.SoundProperties = sound.GetProperties(self.sound)
+	self.SoundProperties = sound.GetProperties(soundName)
 	if self.SoundProperties then
-		WireLib.TriggerOutput(self, "Duration", SoundDuration(self.sound))
+		WireLib.TriggerOutput(self, "Duration", SoundDuration(soundName))
 		WireLib.TriggerOutput(self, "Property Sound", 1)
 		WireLib.TriggerOutput(self, "Properties", self.SoundProperties)
 	else
@@ -183,7 +182,7 @@ function ENT:SetSound(soundName)
 		WireLib.TriggerOutput(self, "Properties", {})
 	end
 
-	self:SetOverlayText( soundName:gsub("[/\\]+","/") )
+	self:SetOverlayText(soundName)
 end
 
 function ENT:StartSounds()

--- a/lua/entities/gmod_wire_soundemitter.lua
+++ b/lua/entities/gmod_wire_soundemitter.lua
@@ -133,7 +133,7 @@ end
 
 function ENT:UpdateSound()
 	if self.NeedsRefresh or self.sound ~= self.ActiveSample then
-		if not file.Exists("sound/" .. self.sound, "GAME") then return end
+		if not WireLib.SoundExists(self.sound) then return end
 
 		self.NeedsRefresh = nil
 		local filter = RecipientFilter()

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1537,8 +1537,10 @@ if not WireLib.PatchedDuplicator then
 end
 
 function WireLib.SoundExists(path)
-	if istable(sound.GetProperties(path)) then return true end
-	if file.Exists("sound/" .. string.gsub(path, "^%W*", ""), "GAME") then return true end
+	path = string.GetNormalizedFilepath(string.gsub(string.sub(path, 1, 260), '["?]', ''))
+	if istable(sound.GetProperties(path)) or file.Exists("sound/" .. path, "GAME") then
+		return path
+	end
 end
 
 -- Notify --

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1536,6 +1536,11 @@ if not WireLib.PatchedDuplicator then
 	end
 end
 
+function WireLib.SoundExists(path)
+	if istable(sound.GetProperties(path)) then return true end
+	if file.Exists("sound/" .. string.gsub(path, "^%W", ""), "GAME") then return true end
+end
+
 -- Notify --
 
 local triv_start = WireLib.Net.Trivial.Start

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1538,7 +1538,7 @@ end
 
 function WireLib.SoundExists(path)
 	if istable(sound.GetProperties(path)) then return true end
-	if file.Exists("sound/" .. string.gsub(path, "^%W", ""), "GAME") then return true end
+	if file.Exists("sound/" .. string.gsub(path, "^%W*", ""), "GAME") then return true end
 end
 
 -- Notify --


### PR DESCRIPTION
Fixes a design oversight introduced by #3122 not accounting for soundscripts & sound paths with sound characters in them.