### PR TITLE
Switch E2Helper & Wire's Text Editor to a partly modular/mode system

### DIFF
--- a/lua/wire/client/e2helper.lua
+++ b/lua/wire/client/e2helper.lua
@@ -108,40 +108,36 @@ local function getdesc(name, args)
 	return CurrentDescs()[string.format("%s(%s)", name, args)] or CurrentDescs()[name]
 end
 
--- Register the E2 mode after it has at least been created.
-
-delayed(1,function()
-	local E2Mode = E2Helper:RegisterMode("E2")
-	if E2Mode then
-		local E2ModeMetatable = {
-			__index = function(self,key)
-				if key == "Items" then return wire_expression2_funcs end
-				if key == "Descriptions" then return E2Helper.Descriptions end
-				return nil
-			end
-		}
-		E2Mode.Items = nil
-		E2Mode.Descriptions = nil
-		-- The metatable is needed because storing a ref to wire_expression2_funcs
-		-- and then causing e2 to reload (like changing extensions) doesn't update the ref
-		-- or something like that, it causes e2helper to access nil values.
-		setmetatable(E2Mode,E2ModeMetatable)
-		E2Mode.ModeSetup = function(E2HelperPanel)
-			E2HelperPanel.FunctionColumn:SetName("Function")
-			E2HelperPanel.FunctionColumn:SetWidth(126)
-			E2HelperPanel.FromColumn:SetName("From")
-			E2HelperPanel.FromColumn:SetWidth(80)
-			E2HelperPanel.TakesColumn:SetName("Takes")
-			E2HelperPanel.TakesColumn:SetWidth(60)
-			E2HelperPanel.ReturnsColumn:SetName("Returns")
-			E2HelperPanel.ReturnsColumn:SetWidth(60)
-			E2HelperPanel.CostColumn:SetName("Cost")
-			E2HelperPanel.CostColumn:SetWidth(40)
+-- Register the E2 mode, this shouldn't need be done twice because it indexes global for its info
+local E2Mode = E2Helper:RegisterMode("E2")
+if E2Mode then
+	local E2ModeMetatable = {
+		__index = function(self,key)
+			if key == "Items" then return wire_expression2_funcs end
+			if key == "Descriptions" then return E2Helper.Descriptions end
+			return nil
 		end
-
+	}
+	E2Mode.Items = nil
+	E2Mode.Descriptions = nil
+	-- The metatable is needed because storing a ref to wire_expression2_funcs
+	-- and then causing e2 to reload (like changing extensions) doesn't update the ref
+	-- or something like that, it causes e2helper to access nil values.
+	setmetatable(E2Mode,E2ModeMetatable)
+	E2Mode.ModeSetup = function(E2HelperPanel)
+		E2HelperPanel.FunctionColumn:SetName("Function")
+		E2HelperPanel.FunctionColumn:SetWidth(126)
+		E2HelperPanel.FromColumn:SetName("From")
+		E2HelperPanel.FromColumn:SetWidth(80)
+		E2HelperPanel.TakesColumn:SetName("Takes")
+		E2HelperPanel.TakesColumn:SetWidth(60)
+		E2HelperPanel.ReturnsColumn:SetName("Returns")
+		E2HelperPanel.ReturnsColumn:SetWidth(60)
+		E2HelperPanel.CostColumn:SetName("Cost")
+		E2HelperPanel.CostColumn:SetWidth(40)
 	end
+
 end
-)()
 
 function E2Helper.Create(reset)
 

--- a/lua/wire/client/e2helper.lua
+++ b/lua/wire/client/e2helper.lua
@@ -1,7 +1,7 @@
 --[[
   Expression 2 Helper for Expression 2
   -HP- (and tomylobo, though he breaks a lot ^^)
-  Divran made CPU support
+  Divran made the original CPU support
   Fasteroid made the "from" column
 ]] --
 
@@ -12,50 +12,45 @@ E2Helper.Descriptions = {}
 include("e2descriptions.lua")
 
 -------------------------------
----- CPU support
-E2Helper.CPUDescriptions = {}
-E2Helper.CPUTable = {}
-E2Helper.CurrentMode = true -- E2/CPU. True = E2, false = CPU
+---- Extension / Mode Switching Support
+E2Helper.Modes = {}
+E2Helper.CurrentMode = "E2" -- Key for accessing mode.
 
-local function AddCPUDesc(FuncName, Args, Desc, Platform, Type)
-	table.insert(E2Helper.CPUTable, { [1] = FuncName, [2] = Args, [3] = Platform, [4] = Type })
-	E2Helper.CPUDescriptions[FuncName] = Desc
-end
-
-if CPULib then
-	-- Add help on all opcodes
-	for _, instruction in ipairs(CPULib.InstructionTable) do
-		if (instruction.Mnemonic ~= "RESERVED") and
-			(not instruction.Obsolete) then
-			local instructionArgs = instruction.Operand1
-			if instruction.Operand2 ~= "" then
-				instructionArgs = instructionArgs .. ", " .. instruction.Operand2
-			end
-
-			AddCPUDesc(instruction.Mnemonic,
-				instructionArgs,
-				instruction.Reference,
-				instruction.Set,
-				instruction.Opcode)
-		end
+function E2Helper:RegisterMode(name)
+	if self.Modes[name] then
+		-- Don't overwrite a previously existing mode if possible
+		-- If an addon really wants to do so, they have access to the E2Helper mode table.
+		return false
+	else
+		-- Name is available, return a table to be set up by caller.
+		local ModeTable = {
+			Descriptions = {}, -- Item descriptions
+			Items = {}, -- Items
+			-- There should be a ModeSetup function here taking the E2Helper table as an argument.
+		}
+		self.Modes[name] = ModeTable
+		return ModeTable
 	end
 end
 
 -- Which tables are we going to use?
 local function CurrentDescs()
-	if E2Helper.CurrentMode == true then
-		return E2Helper.Descriptions
-	else
-		return E2Helper.CPUDescriptions
-	end
+	return E2Helper.Modes[E2Helper.CurrentMode].Descriptions
 end
 
 local function CurrentTable()
-	if E2Helper.CurrentMode == true then
-		return wire_expression2_funcs
-	else
-		return E2Helper.CPUTable
+	return E2Helper.Modes[E2Helper.CurrentMode].Items
+end
+
+function E2Helper:SetMode(key)
+	local mode = E2Helper.Modes[key or false]
+	if mode then
+		E2Helper.CurrentMode = key
+		mode.ModeSetup(E2Helper)
+		E2Helper.Update()
+		return true
 	end
+	return false -- No mode.
 end
 
 -------------------------------
@@ -105,6 +100,30 @@ local function getdesc(name, args)
 	return CurrentDescs()[string.format("%s(%s)", name, args)] or CurrentDescs()[name]
 end
 
+-- Register the E2 mode after it has at least been created.
+
+delayed(1,function()
+	local E2Mode = E2Helper:RegisterMode("E2")
+	if E2Mode then
+		E2Mode.Descriptions = E2Helper.Descriptions
+		E2Mode.Items = wire_expression2_funcs -- May be worth replacing this with a metatable to fetch the table from global.
+		E2Mode.ModeSetup = function(E2HelperPanel)
+			E2HelperPanel.FunctionColumn:SetName("Function")
+			E2HelperPanel.FunctionColumn:SetWidth(126)
+			E2HelperPanel.FromColumn:SetName("From")
+			E2HelperPanel.FromColumn:SetWidth(80)
+			E2HelperPanel.TakesColumn:SetName("Takes")
+			E2HelperPanel.TakesColumn:SetWidth(60)
+			E2HelperPanel.ReturnsColumn:SetName("Returns")
+			E2HelperPanel.ReturnsColumn:SetWidth(60)
+			E2HelperPanel.CostColumn:SetName("Cost")
+			E2HelperPanel.CostColumn:SetWidth(40)
+		end
+
+	end
+end
+)()
+
 function E2Helper.Create(reset)
 
 	E2Helper.Frame = vgui.Create("DFrame")
@@ -139,14 +158,25 @@ function E2Helper.Create(reset)
 	E2Helper.ResultFrame:SetPos(5, 60)
 	E2Helper.ResultFrame:SetSize(330, 240)
 	E2Helper.ResultFrame:SetMultiSelect(false)
-	E2Helper.ResultFrame:AddColumn("Function"):SetWidth(126)
-	E2Helper.FromColumn = E2Helper.ResultFrame:AddColumn("From")
-	E2Helper.FromColumn:SetWidth(80)
-	E2Helper.ResultFrame:AddColumn("Takes"):SetWidth(60)
-	E2Helper.ReturnsColumn = E2Helper.ResultFrame:AddColumn("Returns")
-	E2Helper.ReturnsColumn:SetWidth(60)
-	E2Helper.CostColumn = E2Helper.ResultFrame:AddColumn("Cost")
-	E2Helper.CostColumn:SetWidth(40)
+	-- Default 5 columns, accessable by index here for more modularity.
+	E2Helper.Columns = {
+		E2Helper.ResultFrame:AddColumn("Function"),
+		E2Helper.ResultFrame:AddColumn("From"),
+		E2Helper.ResultFrame:AddColumn("Takes"),
+		E2Helper.ResultFrame:AddColumn("Returns"),
+		E2Helper.ResultFrame:AddColumn("Cost"),
+	}
+	E2Helper.Columns[1]:SetWidth(126)
+	E2Helper.Columns[2]:SetWidth(80)
+	E2Helper.Columns[3]:SetWidth(60)
+	E2Helper.Columns[4]:SetWidth(60)
+	E2Helper.Columns[5]:SetWidth(40)
+	-- Name keys for backwards compatibility
+	E2Helper.FunctionColumn = E2Helper.Columns[1]
+	E2Helper.FromColumn = E2Helper.Columns[2]
+	E2Helper.TakesColumn = E2Helper.Columns[3]
+	E2Helper.ReturnsColumn = E2Helper.Columns[4]
+	E2Helper.CostColumn = E2Helper.Columns[5]
 
 	function E2Helper.ResultFrame:OnClickLine(line)
 		self:ClearSelection()
@@ -239,33 +269,38 @@ function E2Helper.Create(reset)
 	E2Helper.MaxLabel:SetText("Max results:")
 	E2Helper.MaxLabel:SizeToContents()
 
-	E2Helper.E2Mode = vgui.Create("DCheckBoxLabel", E2Helper.Frame)
-	E2Helper.E2Mode:SetPos(90, 384)
-	E2Helper.E2Mode:SetText("E2")
-	E2Helper.E2Mode:SetValue(true)
-	E2Helper.E2Mode:SizeToContents()
-	function E2Helper.E2Mode.Button:Toggle()
-		self:SetValue(true)
-		E2Helper.CurrentMode = true
-		E2Helper.CPUMode:SetValue(false)
-		E2Helper.CostColumn:SetName("Cost")
-		E2Helper.ReturnsColumn:SetName("Returns")
-		E2Helper.Update()
+	E2Helper.ModeSelect = vgui.Create("DComboBox", E2Helper.Frame)
+	E2Helper.ModeSelect:SetPos(90, 384)
+	-- E2Helper.ModeSelect:SetText("E2")
+	-- E2Helper.ModeSelect:SetValue(true)
+	-- E2Helper.ModeSelect:SizeToContents()
+	local modecount = 0
+	for k,_ in pairs(E2Helper.Modes) do
+		modecount = modecount + 1
+		E2Helper.ModeSelect:AddChoice(k)
 	end
-
-	E2Helper.CPUMode = vgui.Create("DCheckBoxLabel", E2Helper.Frame)
-	E2Helper.CPUMode:SetPos(90, 404)
-	E2Helper.CPUMode:SetText("CPU/GPU")
-	E2Helper.CPUMode:SetValue(false)
-	E2Helper.CPUMode:SizeToContents()
-	function E2Helper.CPUMode.Button:Toggle()
-		self:SetValue(true)
-		E2Helper.CurrentMode = false
-		E2Helper.E2Mode:SetValue(false)
-		E2Helper.CostColumn:SetName("Opcode")
-		E2Helper.ReturnsColumn:SetName("Platform")
-		E2Helper.Update()
+	if modecount < 2 then
+		-- If we don't have enough modes it's pointless to display this I think.
+		E2Helper.ModeSelect:Hide()
+	else
+		E2Helper.ModeSelect:Show()
 	end
+	function E2Helper.ModeSelect:OnSelect(ind,value,data)
+		E2Helper:SetMode(value)
+	end
+	-- E2Helper.CPUMode = vgui.Create("DCheckBoxLabel", E2Helper.Frame)
+	-- E2Helper.CPUMode:SetPos(90, 404)
+	-- E2Helper.CPUMode:SetText("CPU/GPU")
+	-- E2Helper.CPUMode:SetValue(false)
+	-- E2Helper.CPUMode:SizeToContents()
+	-- function E2Helper.CPUMode.Button:Toggle()
+	-- 	self:SetValue(true)
+	-- 	E2Helper.CurrentMode = false
+	-- 	E2Helper.E2Mode:SetValue(false)
+	-- 	E2Helper.CostColumn:SetName("Opcode")
+	-- 	E2Helper.ReturnsColumn:SetName("Platform")
+	-- 	E2Helper.Update()
+	-- end
 
 	E2Helper.NameEntry.OnTextChanged = delayed(0.1, E2Helper.Update)
 	E2Helper.FromEntry.OnTextChanged = delayed(0.1, E2Helper.Update)
@@ -293,7 +328,7 @@ function E2Helper.Create(reset)
 end
 
 function E2Helper.GetFunctionSyntax(func, args, rets)
-	if E2Helper.CurrentMode == true then
+	if E2Helper.CurrentMode == "E2" then
 		local signature = func .. "(" .. args .. ")"
 		local ret = E2Lib.generate_signature(signature, rets, wire_expression2_funcs[signature].argnames)
 		if rets ~= "" then ret = ret:sub(1, 1):upper() .. ret:sub(2) end
@@ -309,6 +344,7 @@ function E2Helper.Update()
 	cookie_update()
 
 	E2Helper.ResultFrame:Clear()
+	E2Helper.ModeSelect:SetValue(E2Helper.CurrentMode)
 
 	local search_name, search_from, search_args, search_rets = E2Helper.NameEntry:GetValue():lower(), E2Helper.FromEntry:GetValue():lower(), E2Helper.ParamEntry:GetValue():lower(), E2Helper.ReturnEntry:GetValue():lower()
 	local count = 0
@@ -317,7 +353,7 @@ function E2Helper.Update()
 
 	-- add E2 constants
 	E2Helper.constants = {}
-	if E2Helper.CurrentMode == true then
+	if E2Helper.CurrentMode == "E2" then
 		for k, v in pairs(wire_expression2_constants) do
 			-- constants have no arguments and no cost
 			local name, args, rets, cost = k, nil, v.type, 0
@@ -332,7 +368,7 @@ function E2Helper.Update()
 
 	if count < maxcount then
 		for _, v in pairs(CurrentTable()) do
-			if E2Helper.CurrentMode == true then
+			if E2Helper.CurrentMode == "E2" then
 				local from, signature, rets, cost = v.extension, v[1], v[2], v[4]
 				local name, args = string.match(signature, "^([^(]+)%(([^)]*)%)$")
 
@@ -347,11 +383,12 @@ function E2Helper.Update()
 					if count >= maxcount then break end
 				end
 			else
-				local funcname, args, forwhat, functype = unpack(v)
-				if (funcname:lower():find(search_name, 1, true) and
+				local funcname, extension, args, forwhat, functype = unpack(v)
+				if funcname:lower():find(search_name, 1, true) and
+						extension:lower():find(search_from, 1, true) and
 						args:lower():find(search_args, 1, true) and
-						forwhat:lower():find(search_rets, 1, true)) then
-					local line = E2Helper.ResultFrame:AddLine(funcname, "", args, forwhat, functype) -- TODO: make this column useful for CPU/GPU
+						forwhat:lower():find(search_rets, 1, true) then
+					local line = E2Helper.ResultFrame:AddLine(funcname, extension, args, forwhat, functype)
 					if tooltip then line:SetTooltip(funcname .. " " .. args) end
 					count = count + 1
 					if count >= maxcount then break end
@@ -379,22 +416,22 @@ function E2Helper.Show(searchtext)
 	end
 end
 
-function E2Helper.UseE2(nEditorType)
-	E2Helper.CurrentMode = false
-	E2Helper.E2Mode:Toggle()
-	local val = E2Helper.ReturnEntry:GetValue()
-	if val and (val == "CPU" or val == "GPU") then E2Helper.ReturnEntry:SetText("") end
-	E2Helper.CostColumn:SetName("Cost")
-	E2Helper.ReturnsColumn:SetName("Returns")
-end
+-- function E2Helper.UseE2(nEditorType)
+-- 	E2Helper.CurrentMode = false
+-- 	E2Helper.E2Mode:Toggle()
+-- 	local val = E2Helper.ReturnEntry:GetValue()
+-- 	if val and (val == "CPU" or val == "GPU") then E2Helper.ReturnEntry:SetText("") end
+-- 	E2Helper.CostColumn:SetName("Cost")
+-- 	E2Helper.ReturnsColumn:SetName("Returns")
+-- end
 
-function E2Helper.UseCPU(nEditorType)
-	E2Helper.CurrentMode = true
-	E2Helper.CPUMode:Toggle()
-	E2Helper.CostColumn:SetName("Type")
-	E2Helper.ReturnsColumn:SetName("For What")
-	E2Helper.ReturnEntry:SetText(nEditorType)
-end
+-- function E2Helper.UseCPU(nEditorType)
+-- 	E2Helper.CurrentMode = true
+-- 	E2Helper.CPUMode:Toggle()
+-- 	E2Helper.CostColumn:SetName("Type")
+-- 	E2Helper.ReturnsColumn:SetName("For What")
+-- 	E2Helper.ReturnEntry:SetText(nEditorType)
+-- end
 
 local delayed_cookie_update = delayed(1, cookie_update)
 
@@ -417,8 +454,9 @@ function E2Helper.Resize()
 	E2Helper.DescriptionEntry:SetPos(orig.DescriptionEntry[1], orig.DescriptionEntry[2] + changeh)
 	E2Helper.DescriptionEntry:SetSize(orig.DescriptionEntry[3] + changew, orig.DescriptionEntry[4])
 	E2Helper.ResultFrame:SetSize(orig.ResultFrame[3] + changew, orig.ResultFrame[4] + changeh)
-	E2Helper.E2Mode:SetPos(orig.E2Mode[1], orig.E2Mode[2] + changeh)
-	E2Helper.CPUMode:SetPos(orig.CPUMode[1], orig.CPUMode[2] + changeh)
+	-- E2Helper.E2Mode:SetPos(orig.E2Mode[1], orig.E2Mode[2] + changeh)
+	-- E2Helper.CPUMode:SetPos(orig.CPUMode[1], orig.CPUMode[2] + changeh)
+	E2Helper.ModeSelect:SetPos(orig.ModeSelect[1] + changew, orig.ModeSelect[2] + changeh)
 
 	E2Helper.NameEntry:SetSize(orig.NameEntry[3] + changew * 0.25, orig.NameEntry[4])
 	E2Helper.FromEntry:SetPos(orig.FromEntry[1] + changew * 0.25, orig.FromEntry[2])

--- a/lua/wire/client/e2helper.lua
+++ b/lua/wire/client/e2helper.lua
@@ -43,11 +43,11 @@ local function CurrentTable()
 end
 
 function E2Helper:SetMode(key)
-	local mode = E2Helper.Modes[key or false]
+	local mode = self.Modes[key or false]
 	if mode then
-		E2Helper.CurrentMode = key
-		mode.ModeSetup(E2Helper)
-		E2Helper.Update()
+		self.CurrentMode = key
+		mode.ModeSetup(self)
+		self.Update()
 		return true
 	end
 	return false -- No mode.

--- a/lua/wire/client/e2helper.lua
+++ b/lua/wire/client/e2helper.lua
@@ -113,8 +113,19 @@ end
 delayed(1,function()
 	local E2Mode = E2Helper:RegisterMode("E2")
 	if E2Mode then
-		E2Mode.Descriptions = E2Helper.Descriptions
-		E2Mode.Items = wire_expression2_funcs -- May be worth replacing this with a metatable to fetch the table from global.
+		local E2ModeMetatable = {
+			__index = function(self,key)
+				if key == "Items" then return wire_expression2_funcs end
+				if key == "Descriptions" then return E2Helper.Descriptions end
+				return nil
+			end
+		}
+		E2Mode.Items = nil
+		E2Mode.Descriptions = nil
+		-- The metatable is needed because storing a ref to wire_expression2_funcs
+		-- and then causing e2 to reload (like changing extensions) doesn't update the ref
+		-- or something like that, it causes e2helper to access nil values.
+		setmetatable(E2Mode,E2ModeMetatable)
 		E2Mode.ModeSetup = function(E2HelperPanel)
 			E2HelperPanel.FunctionColumn:SetName("Function")
 			E2HelperPanel.FunctionColumn:SetWidth(126)

--- a/lua/wire/client/e2helper.lua
+++ b/lua/wire/client/e2helper.lua
@@ -271,9 +271,6 @@ function E2Helper.Create(reset)
 
 	E2Helper.ModeSelect = vgui.Create("DComboBox", E2Helper.Frame)
 	E2Helper.ModeSelect:SetPos(90, 384)
-	-- E2Helper.ModeSelect:SetText("E2")
-	-- E2Helper.ModeSelect:SetValue(true)
-	-- E2Helper.ModeSelect:SizeToContents()
 	local modecount = 0
 	for k,_ in pairs(E2Helper.Modes) do
 		modecount = modecount + 1
@@ -288,19 +285,6 @@ function E2Helper.Create(reset)
 	function E2Helper.ModeSelect:OnSelect(ind,value,data)
 		E2Helper:SetMode(value)
 	end
-	-- E2Helper.CPUMode = vgui.Create("DCheckBoxLabel", E2Helper.Frame)
-	-- E2Helper.CPUMode:SetPos(90, 404)
-	-- E2Helper.CPUMode:SetText("CPU/GPU")
-	-- E2Helper.CPUMode:SetValue(false)
-	-- E2Helper.CPUMode:SizeToContents()
-	-- function E2Helper.CPUMode.Button:Toggle()
-	-- 	self:SetValue(true)
-	-- 	E2Helper.CurrentMode = false
-	-- 	E2Helper.E2Mode:SetValue(false)
-	-- 	E2Helper.CostColumn:SetName("Opcode")
-	-- 	E2Helper.ReturnsColumn:SetName("Platform")
-	-- 	E2Helper.Update()
-	-- end
 
 	E2Helper.NameEntry.OnTextChanged = delayed(0.1, E2Helper.Update)
 	E2Helper.FromEntry.OnTextChanged = delayed(0.1, E2Helper.Update)
@@ -416,23 +400,6 @@ function E2Helper.Show(searchtext)
 	end
 end
 
--- function E2Helper.UseE2(nEditorType)
--- 	E2Helper.CurrentMode = false
--- 	E2Helper.E2Mode:Toggle()
--- 	local val = E2Helper.ReturnEntry:GetValue()
--- 	if val and (val == "CPU" or val == "GPU") then E2Helper.ReturnEntry:SetText("") end
--- 	E2Helper.CostColumn:SetName("Cost")
--- 	E2Helper.ReturnsColumn:SetName("Returns")
--- end
-
--- function E2Helper.UseCPU(nEditorType)
--- 	E2Helper.CurrentMode = true
--- 	E2Helper.CPUMode:Toggle()
--- 	E2Helper.CostColumn:SetName("Type")
--- 	E2Helper.ReturnsColumn:SetName("For What")
--- 	E2Helper.ReturnEntry:SetText(nEditorType)
--- end
-
 local delayed_cookie_update = delayed(1, cookie_update)
 
 local lastw, lasth
@@ -454,8 +421,6 @@ function E2Helper.Resize()
 	E2Helper.DescriptionEntry:SetPos(orig.DescriptionEntry[1], orig.DescriptionEntry[2] + changeh)
 	E2Helper.DescriptionEntry:SetSize(orig.DescriptionEntry[3] + changew, orig.DescriptionEntry[4])
 	E2Helper.ResultFrame:SetSize(orig.ResultFrame[3] + changew, orig.ResultFrame[4] + changeh)
-	-- E2Helper.E2Mode:SetPos(orig.E2Mode[1], orig.E2Mode[2] + changeh)
-	-- E2Helper.CPUMode:SetPos(orig.CPUMode[1], orig.CPUMode[2] + changeh)
 	E2Helper.ModeSelect:SetPos(orig.ModeSelect[1] + changew, orig.ModeSelect[2] + changeh)
 
 	E2Helper.NameEntry:SetSize(orig.NameEntry[3] + changew * 0.25, orig.NameEntry[4])

--- a/lua/wire/client/e2helper.lua
+++ b/lua/wire/client/e2helper.lua
@@ -27,6 +27,8 @@ function E2Helper:RegisterMode(name)
 			Descriptions = {}, -- Item descriptions
 			Items = {}, -- Items
 			-- There should be a ModeSetup function here taking the E2Helper table as an argument.
+			-- Optionally, as well, a ModeSwitch function, taking the E2Helper as an argument.
+			-- Will be called on switch, before the new mode's ModeSetup, used for teardown if necessary.
 		}
 		self.Modes[name] = ModeTable
 		return ModeTable
@@ -44,9 +46,15 @@ end
 
 function E2Helper:SetMode(key)
 	local mode = self.Modes[key or false]
+	local curMode = self.Modes[self.CurrentMode]
 	if mode then
+		if curMode.ModeSwitch then
+			curMode.ModeSwitch(self) -- For teardown of previous setup if needed.
+		end
 		self.CurrentMode = key
-		mode.ModeSetup(self)
+		if mode.ModeSetup then
+			mode.ModeSetup(self)
+		end
 		self.Update()
 		return true
 	end

--- a/lua/wire/client/text_editor/modes/e2.lua
+++ b/lua/wire/client/text_editor/modes/e2.lua
@@ -3,7 +3,13 @@ local string_sub = string.sub
 local string_gmatch = string.gmatch
 local string_gsub = string.gsub
 
-local EDITOR = {}
+local EDITOR = {
+	UseValidator = true,
+	Validator = function(editor,source,file)
+		return E2Lib.Validate(source)
+	end,
+	UseSoundBrowser = true,
+}
 
 local function istype(tp)
 	return wire_expression_types[tp:upper()] or tp == "number"

--- a/lua/wire/client/text_editor/wire_expression2_editor.lua
+++ b/lua/wire/client/text_editor/wire_expression2_editor.lua
@@ -2035,11 +2035,7 @@ function Editor:Setup(nTitle, nLocation, nEditorType)
 		E2Help:SetText("E2Helper")
 		E2Help.DoClick = function()
 			E2Helper.Show()
-			if editorMode.E2HelperCategory then
-				E2Helper:SetMode(editorMode.E2HelperCategory)
-			else
-				E2Helper:SetMode(nEditorType)
-			end
+			E2Helper:SetMode(editorMode.E2HelperCategory or nEditorType)
 		end
 		self.C.E2Help = E2Help
 	end

--- a/lua/wire/client/text_editor/wire_expression2_editor.lua
+++ b/lua/wire/client/text_editor/wire_expression2_editor.lua
@@ -2027,7 +2027,7 @@ function Editor:Setup(nTitle, nLocation, nEditorType)
 	self:SetEditorMode(nEditorType or "Default")
 	local editorMode = WireTextEditor.Modes[self:GetEditorMode() or "Default"]
 
-	local helpMode = E2Helper.Modes[nEditorType or ""] or E2Helper.Modes[editorMode.E2HelperCategory or ""]
+	local helpMode = E2Helper.Modes[nEditorType or ""] or E2Helper.Modes[(editorMode and editorMode.E2HelperCategory) or ""]
 	if helpMode then -- Add "E2Helper" button
 		local E2Help = vgui.Create("Button", self.C.Menu)
 		E2Help:SetSize(58, 20)
@@ -2035,7 +2035,11 @@ function Editor:Setup(nTitle, nLocation, nEditorType)
 		E2Help:SetText("E2Helper")
 		E2Help.DoClick = function()
 			E2Helper.Show()
-			E2Helper:SetMode(editorMode.E2HelperCategory or nEditorType)
+			if editorMode and editorMode.E2HelperCategory then
+				E2Helper:SetMode(editorMode.E2HelperCategory)
+			else
+				E2Helper:SetMode(nEditorType)
+			end
 		end
 		self.C.E2Help = E2Help
 	end


### PR DESCRIPTION
Removes the hardcoded support for the CPU, GPU, and SPU (their functionality has been reimplemented as part of an upcoming wire-cpu PR) and replaces it with a partly modular system.

## E2Helper

Replaces the CPU/GPU and E2 checkboxes with a slick new dropdown which should be populated by all the registered e2helper modules
![gmod_gWLD4vsYD4](https://github.com/user-attachments/assets/b792e3cd-a4ed-4585-b135-7ff28b4a5df7)
Will be hidden if there's less than 2 modules to pick from to avoid visual clutter
(E2Helper will look like this for people with no modules other than E2)
![gmod_6BPmZaYl2N](https://github.com/user-attachments/assets/c52e5f8c-76b0-4a42-949c-0096ec18e495)

Allows descriptions and items to be updated easily without need for globals by the addon that registered this mode, which will update on next refresh. (Helps support extensions for other addons by letting them dynamically change the list as their own extensions get loaded and unloaded)

Opens more of the columns to be accessed by key on E2Helper, or via an array so you don't have to memorize the names and order, and allows E2Helper to call a "Setup" function for modes, allowing them to change column names or do what they need to with the editor on mode change (E2 and ZCPU's modes change column names primarily)

## Text Editor

Looks exactly the same to the user for the pre-existing cases.

Allows per-editor replacement of the E2Lib compile / CPULib compile functions with an addon provided "Validator" taking Editor, Code, File as arguments.

Sound browser and validator for the text editor are now controlled via settings on the editor mode, rather than hardcoded by their name.


Neither are fully decoupled fully from hardcoded E2 cases, but this makes a good stepping stone I think to opening up the use of the text editor and E2helper by other addons.

For an example of how to support or use these changes, see: https://github.com/wiremod/wire-cpu/pull/63