### PR TITLE
Stricter sentSpawn

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -226,7 +226,7 @@ function PropCore.CreateSent(self, class, pos, angles, freeze, data)
 
 	local isWhitelist = wire_expression2_propcore_sents_whitelist:GetBool()
 	if isWhitelist and not registered_sent and sent then
-		return self:throw("Spawning entity '" .. class .. "' is not allowed! wire_expression2_propcore_sents_whitelist is enabled", NULL)
+		return self:throw("Spawning entity '" .. class .. "' is not allowed! wire_expression2_propcore_sents_whitelist is enabled.", NULL)
 	elseif not registered_sent and not sent then
 		return self:throw("Sent class '" .. class .. "' is not registered nor in entity tab!", NULL)
 	end
@@ -247,7 +247,7 @@ function PropCore.CreateSent(self, class, pos, angles, freeze, data)
 		-- ( Although I'm not sure that compiler would allow injection(I couldn't make it), some smart lads could still find a workaround, so it's better to be safe than sorry :) )
 		-- ( On a second thought, having this check is a good thing, as misspelled parameters will be caught, and nerves will be saved :D )
 		for k, v in pairs(data) do
-			if not sentParams[k] then return self:throw("Invalid parameter name '" .. tostring(k).."'", NULL) end
+			if not sentParams[k] then return self:throw("Invalid parameter name '" .. tostring(k).."'. You can use sentGetData(\""..class.."\") to get list of valid parameters.", NULL) end
 			if k=="_preFactory" or k=="_postFactory" then return self:throw("'"..k.."' is reserved parameter name. You can't assign value to it!", NULL) end
 		end
 

--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -243,15 +243,13 @@ function PropCore.CreateSent(self, class, pos, angles, freeze, data)
 		end
 
 		-- Not sure if we should check for invalid parameters, as it's not really a problem if the user provides more parameters than needed (they will be ignored), but the check
-		-- against pre/post factories injections is still required. If you want to validate that all parameters are valid, uncomment the following code instead.
+		-- against pre/post factories injections is still required.
 		-- ( Although I'm not sure that compiler would allow injection(I couldn't make it), some smart lads could still find a workaround, so it's better to be safe than sorry :) )
-		--for k, v in pairs(data) do
-			--if not sentParams[k] then return self:throw("Invalid parameter name '" .. tostring(k).."'", NULL) end
-		--end
-
-		-- And comment that instead to save cpu time.
-		if data._preFactory then return self:throw("Invalid parameter name '_preFactory'", NULL) end
-		if data._postFactory then return self:throw("Invalid parameter name '_postFactory'", NULL) end
+		-- ( On a second thought, having this check is a good thing, as misspelled parameters will be caught, and nerves will be saved :D )
+		for k, v in pairs(data) do
+			if not sentParams[k] then return self:throw("Invalid parameter name '" .. tostring(k).."'", NULL) end
+			if k=="_preFactory" or k=="_postFactory" then return self:throw("'"..k.."' is reserved parameter name. You can't assign value to it!", NULL) end
+		end
 
 		local entityData = {}
 

--- a/lua/wire/server/sents_registry.lua
+++ b/lua/wire/server/sents_registry.lua
@@ -27,6 +27,8 @@
 -- WARNING: You have to validate table structures by yourself!
 -- (Either you expect numerical table, ranger data, or any other kind of table.)
 
+-- WARNING: sentSpawn will stop any sent from being spawned, if user passed parameter that isn't registered (or if _pre/postFactory is attempted to be set)!
+
 -- TIP: If you want to stop an entity from being able to be spawned, either return false on Expression2_CanSpawnSent hook, or statically append a classname + true at
 -- 		lua/entities/gmod_wire_expression2/core/custom/prop.lua:201 (local blacklistedSents table).
 -- 		(Or comment out a register function call in this file, or use WireLib.Unregister, but that possibly can break thirdparty addon support. Use only if you know what you're doing.)


### PR DESCRIPTION
I've changed my mind regarding should sentSpawn throw a soft exception if invalid parameter is passed (it already made me waste quite some time debugging to only find out I've misspelled a param name, or passed an array instead of table).

It does breaks backward compability a bit on, as now E2 will stop sentSpawn from going further, if wrong parameter name is being passed, but I think I should've done that in a first place (also I doubt it will break a lot or big projects, as I doubt people leave wrong parameters for fun)