### PR TITLE
Fix notification spam

### DIFF
--- a/lua/wire/stools/eyepod.lua
+++ b/lua/wire/stools/eyepod.lua
@@ -53,7 +53,7 @@ if SERVER then
 				ClampY = 0
 			end
 		else
-			WireLib.AddNotify(ply, "Invalid Clamping of Wire EyePod Values!", NOTIFY_ERROR, 5, NOTIFYSOUND_DRIP1)
+			WireLib.AddNotify(self:GetOwner(), "Invalid Clamping of Wire EyePod Values!", NOTIFY_ERROR, 5, NOTIFYSOUND_DRIP1)
 			return 1, 0, 0, 0, 0, 0, 0, 0
 		end
 		return DefaultToZero, ShowRateOfChange, ClampXMin, ClampXMax, ClampYMin, ClampYMax, ClampX, ClampY


### PR DESCRIPTION
As in this [pull request](https://github.com/wiremod/wire-extras/pull/132), the notification is sent to all players instead of the owner, which can spam the entire screen
![1](https://github.com/user-attachments/assets/94dea4a9-9fb1-4388-ac58-c5c45fb49576)
