### PR TITLE
Fix for error in lambda for tracking collisions + safe external lambda errors.

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -1547,7 +1547,7 @@ local function E2CollisionEventHandler()
 				for _,i in ipairs(ctx.data.E2QueuedCollisions) do
 					if i.cb then
 						-- Arguments for this were checked when we set it up, no need to typecheck
-						i.cb:UnsafeCall({i.us,i.xcd.HitEntity,i.xcd})
+						i.cb:UnsafeExtCall({i.us,i.xcd.HitEntity,i.xcd},ctx)
 						if chip.error then break end
 					end
 					-- It's okay to ExecuteEvent regardless, it'll just return when it fails to find the registered event


### PR DESCRIPTION
Adds UnsafeExtCall and ExtCall functions to the lambda type.
(UnsafeExtCall is "Unsafe" because it doesn't check args, it mimicks UnsafeCall)

These will pcall the lambda function and instead of throwing (which will trigger a lua error) will instead return nil and error the E2 chip.

Fixes collisions no longer being tracked after having an error occur in the lambda's callback, now properly produces errors on chip.
![image](https://github.com/user-attachments/assets/d65c5670-f8d9-46b0-992b-009265fc2613)
