### PR TITLE
Fix for trackCollision(e), can now be done on first execution

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -1580,7 +1580,7 @@ end
 
 e2function number trackCollision( entity ent )
 	-- If it's not registered, collisions will just stack up infinitely and not be flushed.
-	if not registered_chips[self.entity] then
+	if not self.entity.registered_events["entityCollision"] then
 		self:forceThrow("event entityCollision(eexcd) is needed to use trackCollision(e)!")
 	end
 	if IsValid(ent) then


### PR DESCRIPTION
Switches check for `registered_chips[self.entity]` (which is reliant on the constructor running) to `self.entity.registered_events["entityCollision"]` which appears to be populated by the compiler / e2 upload, and is available before first execution of chip (before constructors are run).

Not extensively tested, but upon initial inspection, fixes code like
```typescript
interval(500)
if( first() ){
    E = entity():isWeldedTo()
    trackCollision(E) // Runtime error - event entityCollision is needed
}

print( isTrackingCollision(E) )

event entityCollision(Entity:entity, HitEntity:entity, CollisionData:collision) {
    print("event", Entity)
}
```