### PR TITLE
Dont run player methods if player is NULL

### DIFF
--- a/lua/weapons/remotecontroller.lua
+++ b/lua/weapons/remotecontroller.lua
@@ -57,9 +57,7 @@ function SWEP:OnDrop()
 	self.Linked = nil
 end
 
-function SWEP:On()
-	local ply = self:GetOwner()
-
+function SWEP:On(ply)
 	if IsValid(self.Linked) and self.Linked.HasPly and self.Linked:HasPly() then
 		if WireLib.CanTool(ply, self.Linked, "remotecontroller") then
 			if self.Linked.RC then
@@ -85,20 +83,16 @@ function SWEP:On()
 	end
 end
 
-function SWEP:Off()
-	local ply = self:GetOwner()
-	local validPly = IsValid(ply)
-
-	if validPly and self.Active then
+function SWEP:Off(ply)
+	if self.Active then
 		ply:SetMoveType(self.OldMoveType or MOVETYPE_WALK)
 	end
 
 	self.Active = nil
 	self.OldMoveType = nil
-	if validPly then
-		ply:DrawViewModel(true)
-		ply.using_wire_remote_control = false
-	end
+
+	ply:DrawViewModel(true)
+	ply.using_wire_remote_control = false
 
 	if IsValid(self.Linked) and self.Linked:GetPly() == ply then
 		self.Linked:PlayerExited()
@@ -107,12 +101,14 @@ end
 
 function SWEP:Think()
 	if not self.Linked then return end
+	local ply = self:GetOwner()
+	if not IsValid(ply) then return end
 
-	if self:GetOwner():KeyPressed(IN_USE) then
+	if ply:KeyPressed(IN_USE) then
 		if not self.Active then
-			self:On()
+			self:On(ply)
 		else
-			self:Off()
+			self:Off(ply)
 		end
 	end
 end

--- a/lua/weapons/remotecontroller.lua
+++ b/lua/weapons/remotecontroller.lua
@@ -39,21 +39,18 @@ function SWEP:PrimaryAttack()
 end
 
 function SWEP:Holster()
-	if self.Linked then
-		self:Off()
+	local ply = self:GetOwner()
+	if IsValid(ply) and self.Linked then
+		self:Off(ply)
 	end
-
-	return true
-end
-
-function SWEP:Deploy()
 	return true
 end
 
 function SWEP:OnDrop()
-	if not self.Linked then return end
-
-	self:Off()
+	local ply = self:GetOwner()
+	if IsValid(ply) and self.Linked then
+		self:Off(ply)
+	end
 	self.Linked = nil
 end
 

--- a/lua/weapons/remotecontroller.lua
+++ b/lua/weapons/remotecontroller.lua
@@ -87,15 +87,18 @@ end
 
 function SWEP:Off()
 	local ply = self:GetOwner()
+	local validPly = IsValid(ply)
 
-	if self.Active then
+	if validPly and self.Active then
 		ply:SetMoveType(self.OldMoveType or MOVETYPE_WALK)
 	end
 
 	self.Active = nil
 	self.OldMoveType = nil
-	ply:DrawViewModel(true)
-	ply.using_wire_remote_control = false
+	if validPly then
+		ply:DrawViewModel(true)
+		ply.using_wire_remote_control = false
+	end
 
 	if IsValid(self.Linked) and self.Linked:GetPly() == ply then
 		self.Linked:PlayerExited()


### PR DESCRIPTION
`self:GetOwner` returns `NULL` during `SWEP:OnDrop`

Fixes:
```
addons/wire/lua/weapons/remotecontroller.lua:97: attempt to call method 'DrawViewModel' (a nil value)
   1.  DrawViewModel - [C]:-1
    2.  Off - addons/wire/lua/weapons/remotecontroller.lua:97
     3.  unknown - addons/wire/lua/weapons/remotecontroller.lua:56
      4.  DropWeapon - [C]:-1
       5.  func - addons/loose-scripts/lua/autorun/server/weapon_drop.lua:13
        6.  Run - addons/ulib/lua/includes/modules/hook.lua:260
         7.  func - addons/gmod-custom-chat/lua/custom_chat/server/net_messages.lua:56
          8.  unknown - lua/includes/extensions/net.lua:38
```