### PR TITLE
Network EGP data only to connected players

### DIFF
--- a/lua/entities/gmod_wire_egp/lib/egplib/transmitreceive.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/transmitreceive.lua
@@ -42,7 +42,7 @@ if (SERVER) then
 		if not EGP.umsg.Start( "EGP_Transmit_Data", ply ) then return end
 			net.WriteEntity( Ent )
 			net.WriteString( "ClearScreen" )
-		EGP.umsg.End()
+		EGP.umsg.End( Ent )
 
 		EGP:SendQueueItem( ply )
 	end
@@ -61,7 +61,7 @@ if (SERVER) then
 			net.WriteString( "SaveFrame" )
 			net.WriteEntity( ply )
 			net.WriteString( FrameName )
-		EGP.umsg.End()
+		EGP.umsg.End( Ent )
 
 		EGP:SendQueueItem( ply )
 	end
@@ -82,7 +82,7 @@ if (SERVER) then
 			net.WriteString( "LoadFrame" )
 			net.WriteEntity( ply )
 			net.WriteString( FrameName )
-		EGP.umsg.End()
+		EGP.umsg.End( Ent )
 
 		EGP:SendQueueItem( ply )
 	end
@@ -112,7 +112,7 @@ if (SERVER) then
 						net.WriteFloat( vert.v or 0 )
 					end
 				end
-			EGP.umsg.End()
+			EGP.umsg.End( Ent )
 		end
 
 		EGP:SendQueueItem( ply )
@@ -144,7 +144,7 @@ if (SERVER) then
 						net.WriteFloat( vert.v or 0 )
 					end
 				end
-			EGP.umsg.End()
+			EGP.umsg.End( Ent )
 		end
 
 		EGP:SendQueueItem( ply )
@@ -165,7 +165,7 @@ if (SERVER) then
 				net.WriteString( "AddText" )
 				net.WriteInt( index, 16 )
 				net.WriteString( text )
-			EGP.umsg.End()
+			EGP.umsg.End( Ent )
 		end
 
 		EGP:SendQueueItem( ply )
@@ -186,7 +186,7 @@ if (SERVER) then
 				net.WriteString( "SetText" )
 				net.WriteInt( index, 16 )
 				net.WriteString( text )
-			EGP.umsg.End()
+			EGP.umsg.End( Ent )
 		end
 
 		EGP:SendQueueItem( ply )
@@ -213,7 +213,7 @@ if (SERVER) then
 			net.WriteEntity( Ent )
 			net.WriteString( "EditFiltering" )
 			net.WriteUInt( filtering, 2 )
-		EGP.umsg.End()
+		EGP.umsg.End( Ent )
 
 		EGP:SendQueueItem( ply )
 	end
@@ -278,7 +278,7 @@ if (SERVER) then
 					v:Transmit( Ent, ply )
 				end
 			end
-		EGP.umsg.End()
+		EGP.umsg.End( Ent )
 
 		-- Change order now
 		if order_was_changed then
@@ -574,7 +574,7 @@ if (SERVER) then
 		end
 	end)
 
-	function EGP:SendDataStream( ply, entid )
+	function EGP:SendDataStream( ply, entid, silent )
 		if not ply or not ply:IsValid() then return false, "ERROR: Invalid ply." end
 		local targets
 		if (entid) then
@@ -620,12 +620,17 @@ if (SERVER) then
 				end
 
 				timer.Simple( k, function() -- send 1 second apart
+					local isLastScreen = ((k == #targets) and #targets or nil)
+					if silent then
+						isLastScreen = nil
+					end
+
 					net.Start("EGP_Request_Transmit")
 						net.WriteTable({
 							Ent = v,
 							Objects = DataToSend,
 							Filtering = v.GPU_texture_filtering,
-							IsLastScreen = (k == #targets) and #targets or nil -- Doubles as notifying the client that no more data will arrive, and tells them how many did arrive
+							IsLastScreen = isLastScreen -- Doubles as notifying the client that no more data will arrive, and tells them how many did arrive
 						})
 					net.Send(ply)
 				end)

--- a/lua/entities/gmod_wire_egp/lib/egplib/umsgsystem.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/umsgsystem.lua
@@ -39,7 +39,7 @@ function EGP.umsg.Start( name, sender )
 	return true
 end
 
-function EGP.umsg.End()
+function EGP.umsg.End( ent )
 	if CurSender:IsValid() then
 		if not EGP.IntervalCheck[CurSender] then EGP.IntervalCheck[CurSender] = { bytes = 0, time = 0 } end
 		local bytes = net.BytesWritten()
@@ -48,8 +48,19 @@ function EGP.umsg.End()
 		else
 			ErrorNoHalt("Tried to end EGP net message outside of net context?")
 		end
-		net.Broadcast()
 
+		if ent.Users then
+			local sendTbl = {}
+			for ply, _ in pairs(ent.Users) do
+				if ply:IsValid() then
+					table.insert(sendTbl, ply)
+				end
+			end
+
+			net.Send(sendTbl)
+		else
+			net.Broadcast()
+		end
 	else
 		net.Send(NULL)
 	end

--- a/lua/entities/gmod_wire_egp_hud/huddraw.lua
+++ b/lua/entities/gmod_wire_egp_hud/huddraw.lua
@@ -145,6 +145,7 @@ else -- SERVER
 
 	local function EGPHudConnect(ent, state, ply)
 		if state then
+			EGP:SendDataStream(ply, ent:EntIndex(), true)
 			if not ent.Users then ent.Users = {} end
 
 			if not ent.Users[ply] then


### PR DESCRIPTION
This change makes EGPs only network to players that are connected to the EGP, should reduce network usage massively and especially help larger servers.

It seems to work in my tests but i haven't been able to throughly make sure nothing is backwards broken. Making this a draft for now for feedback.