### PR TITLE
Dont use net.WriteTable for EGP

### DIFF
--- a/lua/entities/gmod_wire_egp/lib/egplib/transmitreceive.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/transmitreceive.lua
@@ -632,8 +632,8 @@ if (SERVER) then
 						IsLastScreen = isLastScreen -- Doubles as notifying the client that no more data will arrive, and tells them how many did arrive
 					}
 
-					local json = WireLib.von.serialize(data)
-					local compressed = util.Compress(json)
+					local von = WireLib.von.serialize(data)
+					local compressed = util.Compress(von)
 					net.Start("EGP_Request_Transmit")
 					net.WriteUInt( #compressed, 16 )
 					net.WriteData( compressed, #compressed )

--- a/lua/entities/gmod_wire_egp/lib/egplib/transmitreceive.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/transmitreceive.lua
@@ -633,9 +633,8 @@ if (SERVER) then
 					}
 
 					local von = WireLib.von.serialize(data)
-					local vonLen = #von
-					if vonLen > 60000 then
-						ply:ChatPrint("[EGP] Error: Data too large to send to client. (" .. math.Round( vonLen / 1024, 2 ) .. " kb)")
+					if #von > 60000 then
+						ply:ChatPrint("[EGP] Error: Data too large to send to client. (" .. math.Round( #von / 1024, 2 ) .. " kb)")
 						return
 					end
 
@@ -648,7 +647,6 @@ if (SERVER) then
 					end
 
 					net.Start("EGP_Request_Transmit")
-					net.WriteUInt( vonLen, 16 )
 					net.WriteUInt( compressedLength, 16 )
 					net.WriteData( compressed, compressedLength )
 					net.Send(ply)
@@ -691,10 +689,9 @@ else
 	end
 
 	net.Receive("EGP_Request_Transmit", function(len,ply)
-		local vonLen = net.ReadUInt(16)
 		local amount = net.ReadUInt(16)
 		local data = net.ReadData(amount)
-		local tbl = WireLib.von.deserialize(util.Decompress(data, vonLen))
+		local tbl = WireLib.von.deserialize(util.Decompress(data, 60000))
 		EGP:ReceiveDataStream(tbl)
 	end)
 end

--- a/lua/entities/gmod_wire_egp/lib/egplib/transmitreceive.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/transmitreceive.lua
@@ -619,7 +619,7 @@ if (SERVER) then
 					DataToSend[#DataToSend+1] = { ID = obj.ID, index = obj.index, Settings = obj:DataStreamInfo() }
 				end
 
-				timer.Simple( k, function() -- send 1 second apart
+				timer.Simple( k - 1, function() -- send 1 second apart, send the first one instantly
 					local isLastScreen = ((k == #targets) and #targets or nil)
 					if silent then
 						isLastScreen = nil

--- a/lua/entities/gmod_wire_egp/lib/egplib/transmitreceive.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/transmitreceive.lua
@@ -632,7 +632,7 @@ if (SERVER) then
 						IsLastScreen = isLastScreen -- Doubles as notifying the client that no more data will arrive, and tells them how many did arrive
 					}
 
-					local json = util.TableToJSON(data)
+					local json = WireLib.von.serialize(data)
 					local compressed = util.Compress(json)
 					net.Start("EGP_Request_Transmit")
 					net.WriteUInt( #compressed, 16 )
@@ -679,7 +679,7 @@ else
 	net.Receive("EGP_Request_Transmit", function(len,ply)
 		local amount = net.ReadUInt(16)
 		local data = net.ReadData(amount)
-		local tbl = util.JSONToTable(util.Decompress(data))
+		local tbl = WireLib.von.deserialize(util.Decompress(data))
 		EGP:ReceiveDataStream(tbl)
 	end)
 end

--- a/lua/entities/gmod_wire_egp/lib/egplib/transmitreceive.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/transmitreceive.lua
@@ -634,9 +634,16 @@ if (SERVER) then
 
 					local von = WireLib.von.serialize(data)
 					local compressed = util.Compress(von)
+					local compressedLength = #compressed
+
+					if compressedLength > 60000 then
+						ply:ChatPrint("[EGP] Error: Data too large to send to client. (" .. math.Round( compressedLength / 1024, 2 ) .. " kb)")
+						return
+					end
+
 					net.Start("EGP_Request_Transmit")
-					net.WriteUInt( #compressed, 16 )
-					net.WriteData( compressed, #compressed )
+					net.WriteUInt( compressedLength, 16 )
+					net.WriteData( compressed, compressedLength )
 					net.Send(ply)
 				end)
 				sent = true


### PR DESCRIPTION
Massively saves on EGP networking,

Just as a simple example:
This took `113616` bits before
![image](https://github.com/user-attachments/assets/99ff0718-c855-45ff-b584-a680e26cfb2d)

After the pr this took ~`4840` bits
