### PR TITLE
Fix NULL error

### DIFF
--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -262,7 +262,7 @@ if CLIENT then
 			looked_at:BeingLookedAtByLocalPlayer()
 		end
 
-		if cur_ent.IsWire and cur_ent:BeingLookedAtByLocalPlayer() then
+		if IsValid(cur_ent) and cur_ent.IsWire and cur_ent:BeingLookedAtByLocalPlayer() then
 			looked_at = cur_ent
 		else
 			looked_at = nil


### PR DESCRIPTION
It seems that a simple check against the table is not enough, so the entity is sometimes NULL
```
[wire-master] gamemodes/sandbox/entities/entities/base_gmodentity.lua:20: Tried to use a NULL entity!
1. GetPos - [C]:-1
 2. BeingLookedAtByLocalPlayer - gamemodes/sandbox/entities/entities/base_gmodentity.lua:20
  3. BeingLookedAtByLocalPlayer - addons/wire-master/lua/entities/base_wire_entity.lua:230
   4. fn - addons/wire-master/lua/entities/base_wire_entity.lua:265
    5. unknown - addons/ulib-master/lua/ulib/shared/hook.lua:109
```