### PR TITLE
Fix egp datastreams

### DIFF
--- a/lua/entities/gmod_wire_egp/lib/egplib/objects.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/objects.lua
@@ -85,7 +85,11 @@ function baseObj:EditObject(args)
 	end
 	for k, v in pairs(args) do
 		if self[k] ~= nil and self[k] ~= v then
-			self[k] = v
+			if CLIENT and k == "material" and isstring(v) then
+				self[k] = Material(v)
+			else
+				self[k] = v
+			end
 			ret = true
 		end
 	end

--- a/lua/entities/gmod_wire_egp/lib/objects/poly.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/poly.lua
@@ -53,7 +53,7 @@ Obj.Receive = function( self )
 	return tbl
 end
 Obj.DataStreamInfo = function( self )
-	return { material = self.material, r = self.r, g = self.g, b = self.b, a = self.a, filtering = self.filtering, parent = self.parent, x = self.x, y = self.y, angle = self.angle }
+	return { material = self.material, r = self.r, g = self.g, b = self.b, a = self.a, filtering = self.filtering, parent = self.parent, x = self.x, y = self.y, angle = self.angle, vertices = self.vertices }
 end
 
 function Obj:Contains(x, y)

--- a/lua/entities/gmod_wire_egp_hud/huddraw.lua
+++ b/lua/entities/gmod_wire_egp_hud/huddraw.lua
@@ -145,12 +145,13 @@ else -- SERVER
 
 	local function EGPHudConnect(ent, state, ply)
 		if state then
-			EGP:SendDataStream(ply, ent:EntIndex(), true)
 			if not ent.Users then ent.Users = {} end
 
 			if not ent.Users[ply] then
 				ent.Users[ply] = true
 			end
+
+			EGP:SendDataStream(ply, ent:EntIndex(), true)
 		elseif ent.Users and ent.Users[ply] then
 			ent.Users[ply] = nil
 


### PR DESCRIPTION
- Properly networks poly and poly derived vertices, before this wasn't networked at all so they simply didn't work, this has been a bug for 11 years.
- Fixes materials being strings on client, before a datastream would just set the key to a string which would then later be ignored, now it actually turns it into a IMaterial
- Call EGP:SendDataStream a little later, not that it changes anything functionally but it makes more sense to call it after the user being set

# Examples:

## A hud using a lot of different poly derived objects:
Before:
![image](https://github.com/user-attachments/assets/9ab60ab6-be73-426d-a9ac-51e176cb03e4)

After:
![image](https://github.com/user-attachments/assets/93f61349-adce-488f-ab99-4fd0925cf760)

## A overview of all objects
@deltamolfar made this E2 to show the issue

Before:
![image](https://github.com/user-attachments/assets/9a8f481c-ab69-41dc-b9af-b2047182841e)

After:
![image](https://github.com/user-attachments/assets/ecfebbe0-9abb-4118-a526-2b7f91e23b0c)
