### PR TITLE
e:propNoDupe(n)

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/cl_prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cl_prop.lua
@@ -2,9 +2,9 @@ language.Add("Undone_e2_spawned_prop", "Undone E2 Spawned Prop")
 language.Add("Undone_e2_spawned_seat", "Undone E2 Spawned Seat")
 language.Add("Undone_e2_spawned_sent", "Undone E2 Spawned SENT")
 E2Helper.Descriptions["propManipulate(e:vannn)"] = "Allows to do any single prop core function in one term (position, rotation, freeze, gravity, notsolid)"
-E2Helper.Descriptions["e:propIsDupeable()"] = "Returns 1, if the prop can be duplicated with the duplicator/advdupe2 tool, 0 otherwise."
-E2Helper.Descriptions["e:propCanSetNoDupe()"] = "Returns 1, if you can make passed entity non-dupeable, 0 otherwise."
-E2Helper.Descriptions["e:propNoDupe(n)"] = "Set to 1 to prevent the prop from being duplicated with the duplicator/advdupe2 tool. Set to 0 to allow duplication. (Default: 0)"
+E2Helper.Descriptions["e:propIsDupeable()"] = "Returns 1, if the prop can be duplicated with the duplicator/advdupe2/similar tool, 0 otherwise."
+E2Helper.Descriptions["e:propCanSetDupeable()"] = "Returns 1, if you can change entity dupeable state, 0 otherwise. (If you can make it either dupeable or non-dupeable)"
+E2Helper.Descriptions["e:propNoDupe(n)"] = "Set to 1 to prevent the prop from being duplicated with the duplicator/advdupe2 tool. Set to 0 to allow duplication. (You will not be able to make already non-dupeable prop as dupeable)"
 E2Helper.Descriptions["propSpawn(sn)"] = "Use the model string or a template entity to spawn a prop. You can set the position and/or the rotation as well. The last number indicates frozen/unfrozen."
 E2Helper.Descriptions["propSpawn(en)"] = "Entity template, Frozen Spawns a prop with the model of the template entity. If frozen is 0, then it will spawn unfrozen."
 E2Helper.Descriptions["propSpawn(svn)"] = "Model path, Position, Frozen Spawns a prop with the model denoted by the string filepath at the position denoted by the vector. If frozen is 0, then it will spawn unfrozen."

--- a/lua/entities/gmod_wire_expression2/core/custom/cl_prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cl_prop.lua
@@ -2,6 +2,8 @@ language.Add("Undone_e2_spawned_prop", "Undone E2 Spawned Prop")
 language.Add("Undone_e2_spawned_seat", "Undone E2 Spawned Seat")
 language.Add("Undone_e2_spawned_sent", "Undone E2 Spawned SENT")
 E2Helper.Descriptions["propManipulate(e:vannn)"] = "Allows to do any single prop core function in one term (position, rotation, freeze, gravity, notsolid)"
+E2Helper.Descriptions["e:propIsDupeable()"] = "Returns 1, if the prop can be duplicated with the duplicator/advdupe2 tool, 0 otherwise."
+E2Helper.Descriptions["e:propCanSetNoDupe()"] = "Returns 1, if you can make passed entity non-dupeable, 0 otherwise."
 E2Helper.Descriptions["e:propNoDupe(n)"] = "Set to 1 to prevent the prop from being duplicated with the duplicator/advdupe2 tool. Set to 0 to allow duplication. (Default: 0)"
 E2Helper.Descriptions["propSpawn(sn)"] = "Use the model string or a template entity to spawn a prop. You can set the position and/or the rotation as well. The last number indicates frozen/unfrozen."
 E2Helper.Descriptions["propSpawn(en)"] = "Entity template, Frozen Spawns a prop with the model of the template entity. If frozen is 0, then it will spawn unfrozen."

--- a/lua/entities/gmod_wire_expression2/core/custom/cl_prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cl_prop.lua
@@ -2,6 +2,7 @@ language.Add("Undone_e2_spawned_prop", "Undone E2 Spawned Prop")
 language.Add("Undone_e2_spawned_seat", "Undone E2 Spawned Seat")
 language.Add("Undone_e2_spawned_sent", "Undone E2 Spawned SENT")
 E2Helper.Descriptions["propManipulate(e:vannn)"] = "Allows to do any single prop core function in one term (position, rotation, freeze, gravity, notsolid)"
+E2Helper.Descriptions["e:propNoDupe(n)"] = "Set to 1 to prevent the prop from being duplicated with the duplicator/advdupe2 tool. Set to 0 to allow duplication. (Default: 0)"
 E2Helper.Descriptions["propSpawn(sn)"] = "Use the model string or a template entity to spawn a prop. You can set the position and/or the rotation as well. The last number indicates frozen/unfrozen."
 E2Helper.Descriptions["propSpawn(en)"] = "Entity template, Frozen Spawns a prop with the model of the template entity. If frozen is 0, then it will spawn unfrozen."
 E2Helper.Descriptions["propSpawn(svn)"] = "Model path, Position, Frozen Spawns a prop with the model denoted by the string filepath at the position denoted by the vector. If frozen is 0, then it will spawn unfrozen."

--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -61,7 +61,7 @@ local ValidSpawn = PropCore.ValidSpawn
 local canHaveInvalidPhysics = {
 	delete=true, parent=true, deparent=true, solid=true,
 	shadow=true, draw=true, use=true, pos=true, ang=true,
-	manipulate=true
+	manipulate=true, noDupe=true
 }
 
 function PropCore.ValidAction(self, entity, cmd, bone)
@@ -772,10 +772,15 @@ e2function void propDeleteAll()
 	self.data.spawnedProps = {}
 end
 
+--------------------------------------------------------------------------------
+
+__e2setcost(1)
+e2function void entity:propNoDupe(number noDupe)
+	if not ValidAction(self, this, "noDupe") then return end
+	this.DoNotDuplicate = noDupe ~= 0
+end
 
 __e2setcost(10)
-
---------------------------------------------------------------------------------
 e2function void entity:propManipulate(vector pos, angle rot, number freeze, number gravity, number notsolid)
 	if not ValidAction(self, this, "manipulate") then return end
 	PhysManipulate(this, pos, rot, freeze, gravity, notsolid)


### PR DESCRIPTION
Makes a silly function that lets you mark props as nodupe, to prevent from duping over. Useful for making pre-spawned prop projectiles non-dupeable