### PR TITLE
Fix nil error

### DIFF
--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -262,7 +262,7 @@ if CLIENT then
 			looked_at:BeingLookedAtByLocalPlayer()
 		end
 
-		if cur_ent.IsWire and cur_ent:BeingLookedAtByLocalPlayer() then
+		if IsValid(cur_ent) and cur_ent.IsWire and cur_ent:BeingLookedAtByLocalPlayer() then
 			looked_at = cur_ent
 		else
 			looked_at = nil

--- a/lua/wire/stools/hydraulic.lua
+++ b/lua/wire/stools/hydraulic.lua
@@ -178,7 +178,7 @@ function TOOL:RightClick( trace )
 	end
 	local trace2 = util.TraceLine( tr )
 
-	if not WireLib.CanTool(self:GetOwner(), trace2.Entity, "wire_hydraulic") then return false end
+	if SERVER and not WireLib.CanTool(self:GetOwner(), trace2.Entity, "wire_hydraulic") then return false end
 
 	return self:LeftClick(trace) and self:LeftClick(trace2)
 end

--- a/lua/wire/stools/hydraulic.lua
+++ b/lua/wire/stools/hydraulic.lua
@@ -178,7 +178,7 @@ function TOOL:RightClick( trace )
 	end
 	local trace2 = util.TraceLine( tr )
 
-	if SERVER and not WireLib.CanTool(self:GetOwner(), trace2.Entity, "wire_hydraulic") then return false end
+	if CLIENT or not WireLib.CanTool(self:GetOwner(), trace2.Entity, "wire_hydraulic") then return false end
 
 	return self:LeftClick(trace) and self:LeftClick(trace2)
 end


### PR DESCRIPTION
Fixes:
```
[wire-master] addons/wire-master/lua/wire/stools/hydraulic.lua:181: attempt to call field 'CanTool' (a nil value)
1. RightClick - addons/wire-master/lua/wire/stools/hydraulic.lua:181
 2. unknown - gamemodes/sandbox/entities/weapons/gmod_tool/shared.lua:264
```
WireLib.CanTool does not exist on the client