### PR TITLE
Fix logic in #3155

### DIFF
--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1545,7 +1545,7 @@ function WireLib.SoundExists(path, ply)
 
 	-- Extract sound flags. See https://developer.valvesoftware.com/wiki/Soundscripts#Sound_characters
 	local flags, checkpath = string.match(path, "^([^%w_/%.]*)(.*)")
-	if #flags > 2 or string.find(flags, "[^#@<>%^%)}]") then
+	if #flags > 2 or string.match(flags, "[^#@<>%^%)}]") then
 		path = checkpath
 	end
 

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1543,9 +1543,9 @@ function WireLib.SoundExists(path, ply)
 	-- Limit length and remove invalid chars
 	path = string.GetNormalizedFilepath(string.gsub(string.sub(path, 1, 260), "[\"?']", ""))
 
-	-- Extract sound flags. Only allowed flags are '<', '>', '^', ')'
+	-- Extract sound flags. See https://developer.valvesoftware.com/wiki/Soundscripts#Sound_characters
 	local flags, checkpath = string.match(path, "^([^%w_/%.]*)(.*)")
-	if #flags>2 or string.match(flags, "[#@^<>%^%)}]") then
+	if #flags > 2 or string.find(flags, "[^#@<>%^%)}]") then
 		path = checkpath
 	end
 


### PR DESCRIPTION
Misread `^` as a sound character... also replaced to `string.find` since `match` isn't needed here.