### PR TITLE
Add printCaption e2functions

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/cl_debug.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_debug.lua
@@ -52,3 +52,7 @@ CreateClientConVar("wire_expression2_clipboard_allow", 0, true, true, "Allow E2 
 net.Receive("wire_expression2_set_clipboard_text", function(len, ply)
 	SetClipboardText(net.ReadString())
 end)
+
+net.Receive("wire_expression2_caption", function()
+	gui.AddCaption(net.ReadData(net.ReadUInt(16)), net.ReadDouble(), net.ReadBool())
+end)

--- a/lua/entities/gmod_wire_expression2/core/debug.lua
+++ b/lua/entities/gmod_wire_expression2/core/debug.lua
@@ -515,3 +515,43 @@ e2function void setClipboardText(string text)
 		net.WriteString(text)
 	net.Send(self.player)
 end
+
+
+-- Closed Captions
+
+util.AddNetworkString("wire_expression2_caption")
+
+-- Maximum seconds a caption can be displayed for
+local MAX_CAPTION_DURATION = 7
+
+local function send_caption(self, text, duration, fromPlayer)
+	if duration < 0 then return end -- <0 duration doesn't display normally
+	local ply = self.player
+	if not checkDelay(ply) then return end
+
+	local max_len = math.min(maxLength:GetInt(), ply:GetInfoNum("wire_expression2_print_max_length", defaultMaxLength))
+
+	text = string.sub(text, 1, max_len)
+	duration = math.min(duration, MAX_CAPTION_DURATION)
+
+	local len = #text
+
+	self.prf = self.prf + len
+
+	net.Start("wire_expression2_caption")
+		net.WriteUInt(len, 16)
+		net.WriteData(text)
+		net.WriteDouble(duration)
+		net.WriteBool(fromPlayer)
+	net.Send(ply)
+end
+
+__e2setcost(100)
+
+e2function void addCaption(string text, number duration, number fromPlayer)
+	send_caption(self, text, duration, fromPlayer)
+end
+
+e2function void addCaption(string text, number duration)
+	send_caption(self, text, duration, false)
+end

--- a/lua/entities/gmod_wire_expression2/core/debug.lua
+++ b/lua/entities/gmod_wire_expression2/core/debug.lua
@@ -548,10 +548,10 @@ end
 
 __e2setcost(100)
 
-e2function void addCaption(string text, number duration, number fromPlayer)
+e2function void printCaption(string text, number duration, number fromPlayer)
 	send_caption(self, text, duration, fromPlayer)
 end
 
-e2function void addCaption(string text, number duration)
+e2function void printCaption(string text, number duration)
 	send_caption(self, text, duration, false)
 end

--- a/lua/entities/gmod_wire_expression2/core/debug.lua
+++ b/lua/entities/gmod_wire_expression2/core/debug.lua
@@ -536,7 +536,7 @@ local function send_caption(self, text, duration, fromPlayer)
 
 	local len = #text
 
-	self.prf = self.prf + len
+	self.prf = self.prf + len / 8
 
 	net.Start("wire_expression2_caption")
 		net.WriteUInt(len, 16)

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -960,6 +960,8 @@ E2Helper.Descriptions["printColorDriver(e:r)"] = "Like printColorDriver but take
 E2Helper.Descriptions["printTable(t)"] = "Prints a table like the lua function PrintTable does, except to the chat area"
 E2Helper.Descriptions["printTable(r)"] = "Prints an array like the lua function PrintTable does, except to the chat area"
 E2Helper.Descriptions["setClipboardText(s)"] = "Adds the given string to the chip owners clipboard"
+E2Helper.Descriptions["printCaption(snn)"] = "Emits a closed caption with the provided text and duration in seconds. The last argument is used to control the playerclr code"
+E2Helper.Descriptions["printCaption(sn)"] = "Emits a closed caption with the provided text and duration in seconds"
 
 -- Time
 E2Helper.Descriptions["tickClk()"] = "DEPRECATED. Use 'event tick()' instead! Returns 1 if the current execution was caused by \"runOnTick\""


### PR DESCRIPTION
Implements `gui.AddCaption` for the E2 owner. I wasn't sure where to put this, but I thought lumping it in with the other printing functions made some sort of sense.

These have a hard-coded duration limit of 7 seconds, equal to hints.

- Adds function `printCaption(string text, number duration, number fromPlayer)`
- Adds function `printCaption(string text, number duration)`