### PR TITLE
Verify player is in vehicle before adding player to vehicle

### DIFF
--- a/lua/entities/gmod_wire_pod.lua
+++ b/lua/entities/gmod_wire_pod.lua
@@ -637,7 +637,8 @@ end
 
 function Wire_Pod_EnterVehicle(ply, vehicle)
 	for _, v in ipairs(pods) do
-		if v:GetPod() == vehicle and ply:InVehicle() then
+		local pod = v:GetPod()
+		if pod == vehicle and ply:GetVehicle() == pod then
 			v:PlayerEntered(ply)
 		end
 	end

--- a/lua/entities/gmod_wire_pod.lua
+++ b/lua/entities/gmod_wire_pod.lua
@@ -637,8 +637,7 @@ end
 
 function Wire_Pod_EnterVehicle(ply, vehicle)
 	for _, v in ipairs(pods) do
-		local pod = v:GetPod()
-		if pod and pod == vehicle then
+		if v:GetPod() == vehicle and ply:InVehicle() then
 			v:PlayerEntered(ply)
 		end
 	end


### PR DESCRIPTION
The hook order here makes it so that `EnterVehicle` continues to execute even after finishing a `ExitVehicle` hook. This checks if the player is still in the same vehicle for the current `PlayerEnter` hook.

- Fix pod controller would stay active after the player exits or changes seat on the same tick.

Fixes #3150