### PR TITLE
Remove bone-keyed caches in bone extension

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/bone.lua
+++ b/lua/entities/gmod_wire_expression2/core/bone.lua
@@ -52,7 +52,7 @@ local function isValidBone(b)
 	if type(b) ~= "PhysObj" or not IsValid(b) then return nil, 0 end
 	local ent = b:GetEntity()
 	if not ent:IsValid() then
-		return nil, 0
+		return nil
 	end
 	return ent
 end

--- a/lua/entities/gmod_wire_expression2/core/bone.lua
+++ b/lua/entities/gmod_wire_expression2/core/bone.lua
@@ -8,15 +8,12 @@ registerCallback("e2lib_replace_function", function(funcname, func, oldfunc)
 	end
 end)
 
-local bone2index = {}
 local entity2bone = {}
 
 hook.Add("EntityRemoved", "wire_expression2_bone", function(ent)
-	if not entity2bone[ent] then return end
-	for index,bone in pairs(entity2bone[ent]) do
-		bone2index[bone] = nil
+	if entity2bone[ent] then
+		entity2bone[ent] = nil
 	end
-	entity2bone[ent] = nil
 end)
 
 -- faster access to some math library functions
@@ -35,8 +32,6 @@ local function getBone(entity, index)
 		bone = entity:GetPhysicsObjectNum(index)
 		if not bone then return nil end
 		entity2bone[entity][index] = bone
-
-		bone2index[bone] = index
 	end
 
 	return IsValid(bone) and bone or nil
@@ -52,19 +47,14 @@ local function GetBones(entity)
 end
 E2Lib.GetBones = GetBones
 
-local function removeBone(bone)
-	bone2index[bone] = nil
-end
-
--- checks whether the bone is valid. if yes, returns the bone's entity and bone index; otherwise, returns nil.
+-- checks whether the bone is valid. if yes, returns the bone's entity; otherwise, returns nil.
 local function isValidBone(b)
 	if type(b) ~= "PhysObj" or not IsValid(b) then return nil, 0 end
 	local ent = b:GetEntity()
 	if not ent:IsValid() then
-		removeBone(b)
 		return nil, 0
 	end
-	return ent, bone2index[b]
+	return ent
 end
 E2Lib.isValidBone = isValidBone
 
@@ -125,15 +115,13 @@ end
 
 --- Returns <this>'s index in the entity it belongs to. Returns -1 if the bone is invalid or an error occured.
 e2function number bone:index()
-	if not isValidBone(this) then return -1 end
-	--[[local ent = this:GetEntity()
-	if not IsValid(ent) then return -1 end
-	local maxn = ent:GetPhysicsObjectCount()-1
-	for i = 0,maxn do
+	local ent = isValidBone(this)
+	if not ent then return -1 end
+	local n = ent:GetPhysicsObjectCount() - 1
+	for i = 0, n do
 		if this == ent:GetPhysicsObjectNum(i) then return i end
 	end
-	return -1]]
-	return bone2index[this] or -1
+	return -1
 end
 
 --[[************************************************************************]]--
@@ -400,15 +388,13 @@ end
 -- helper function for invert(T) in table.lua
 function e2_tostring_bone(b)
 	local ent = isValidBone(b)
-	if not ent then return "(null)" end
-	return string.format("%s:bone(%d)", tostring(ent), bone2index[b])
+	if not ent then return "(null bone)" end
+	return string.format("bone [%s][Entity %d]", b:GetName(), ent:EntIndex())
 end
+local e2_tostring_bone = e2_tostring_bone
 
---- Returns <b> formatted as a string. Returns "<code>(null)</code>" for invalid bones.
 e2function string toString(bone b)
-	local ent = isValidBone(b)
-	if not ent then return "(null)" end
-	return string.format("%s:bone(%d)", tostring(ent), bone2index[b])
+	return e2_tostring_bone(b)
 end
 
 WireLib.registerDebuggerFormat("BONE", e2_tostring_bone)

--- a/lua/entities/gmod_wire_expression2/core/bone.lua
+++ b/lua/entities/gmod_wire_expression2/core/bone.lua
@@ -8,14 +8,12 @@ registerCallback("e2lib_replace_function", function(funcname, func, oldfunc)
 	end
 end)
 
-local bone2entity = {}
 local bone2index = {}
 local entity2bone = {}
 
 hook.Add("EntityRemoved", "wire_expression2_bone", function(ent)
 	if not entity2bone[ent] then return end
 	for index,bone in pairs(entity2bone[ent]) do
-		bone2entity[bone] = nil
 		bone2index[bone] = nil
 	end
 	entity2bone[ent] = nil
@@ -38,7 +36,6 @@ local function getBone(entity, index)
 		if not bone then return nil end
 		entity2bone[entity][index] = bone
 
-		bone2entity[bone] = entity
 		bone2index[bone] = index
 	end
 
@@ -56,15 +53,14 @@ end
 E2Lib.GetBones = GetBones
 
 local function removeBone(bone)
-	bone2entity[bone] = nil
 	bone2index[bone] = nil
 end
 
 -- checks whether the bone is valid. if yes, returns the bone's entity and bone index; otherwise, returns nil.
 local function isValidBone(b)
 	if type(b) ~= "PhysObj" or not IsValid(b) then return nil, 0 end
-	local ent = bone2entity[b]
-	if not IsValid(ent) then
+	local ent = b:GetEntity()
+	if not ent:IsValid() then
 		removeBone(b)
 		return nil, 0
 	end


### PR DESCRIPTION
- Removes `bone2index`
- Removes `bone2entity`
- Reformatted `tostring(bone)` function. Now operates similarly to Gmod's physobject tostring.
- Revert `bone:index()` function
- Change signature of `E2Lib.getBone` to return only an entity now

`entity2bone` still exists because it might be more efficient. Worst case, it'll recache it and that's not that bad.

Fixes #3018 

I miss being able to show the index in printing :(