### PR TITLE
Fix startup syntax error

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -1146,16 +1146,15 @@ e2function void entity:ragdollFreeze(isFrozen)
 end
 
 __e2setcost(5)
-
 e2function angle entity:ragdollGetAng()
 	if not ValidAction(self, this) then return end
 
 	local phys = this:GetPhysicsObject()
 
 	return phys:IsValid() and phys:GetAngles() or self:throw("Tried to use entity without physics", Angle())
+end
 
 __e2setcost(150)
-
 e2function void entity:ragdollSetPos(vector pos)
 	if not ValidAction(self, this, "pos") then return end
 


### PR DESCRIPTION
Fixes the syntax error introduced in https://github.com/wiremod/wire/pull/3180
```
[wire] entities/gmod_wire_expression2/core/custom/prop.lua:1157: 'end' expected (to close 'function' at line 1150) near '__e2setcost'
  1. unknown - addons/wire/lua/entities/gmod_wire_expression2/core/extloader.lua:97
   2. pcall - [C]:-1
    3. e2_include_finalize - addons/wire/lua/entities/gmod_wire_expression2/core/extloader.lua:112
     4. unknown - addons/wire/lua/entities/gmod_wire_expression2/core/extloader.lua:185
      5. include - [C]:-1
       6. unknown - addons/wire/lua/entities/gmod_wire_expression2/core/init.lua:320
        7. include - [C]:-1
         8. unknown - addons/wire/lua/entities/gmod_wire_expression2/shared.lua:24
          9. include - [C]:-1
           10. unknown - addons/wire/lua/entities/gmod_wire_expression2/init.lua:3

There was an error loading the custom/prop.lua extension. Please report this to its developer.
attempt to call a nil value
```