### PR TITLE
Improve wire_holograms_display_owners

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/cl_hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_hologram.lua
@@ -45,9 +45,30 @@ local function WireHologramsShowOwners()
 		local vec = ent:GetPos():ToScreen()
 
 		if vec.visible then
-			local text = names[ent:GetPlayer()] .. "\n" .. ent.steamid
-			draw.DrawText(text, "DermaDefaultBold", vec.x + 1, vec.y + 1, color_black, TEXT_ALIGN_CENTER)
-			draw.DrawText(text, "DermaDefaultBold", vec.x, vec.y, color_white, TEXT_ALIGN_CENTER)
+			surface.SetFont("DermaDefaultBold")
+			local text = names[ent:GetPlayer()]
+			local w, h = surface.GetTextSize(text)
+			--Draw nick shadow
+			surface.SetTextColor(0, 0, 0)
+			surface.SetTextPos(vec.x - w / 2 + 1, vec.y - h / 2 + 1)
+			surface.DrawText(text)
+
+			--Draw nick
+			surface.SetTextColor(255, 255, 255)
+			surface.SetTextPos(vec.x - w / 2, vec.y - h / 2)
+			surface.DrawText(text)
+
+			local text2 = ent.steamid
+			local w2, h2 = surface.GetTextSize(text2)
+			--Draw steamid shadow
+			surface.SetTextColor(0, 0, 0)
+			surface.SetTextPos(vec.x - w2 / 2 + 1, vec.y + h / 2 + 1)
+			surface.DrawText(text2)
+			
+			--Draw steamid
+			surface.SetTextColor(255, 255, 255)
+			surface.SetTextPos(vec.x - w2 / 2, vec.y + h / 2)
+			surface.DrawText(text2)
 		end
 	end
 end

--- a/lua/entities/gmod_wire_expression2/core/cl_hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_hologram.lua
@@ -1,14 +1,9 @@
 -- Replicated from serverside, same function as the one below except this takes precedence
 local holoDisplayCVar = CreateConVar("wire_holograms_display_owners_maxdist", "-1", {FCVAR_REPLICATED})
-
 local holoDisplayCVarCL = CreateClientConVar( "wire_holograms_display_owners_maxdist_cl" , "-1", true, false,
 "The maximum distance that wire_holograms_display_owners will allow names to be seen. -1 for original function.", -1, 32768)
 
 local function WireHologramsShowOwners()
-	local eye = EyePos()
-	local entList = ents.FindByClass( "gmod_wire_hologram" )
-	local finalEntList = {}
-
 	local finalCVar = 0
 	-- Both cvars, server-replicated and clientside
 	local cva = holoDisplayCVar:GetInt()
@@ -18,43 +13,53 @@ local function WireHologramsShowOwners()
 		finalCVar = cvb
 	else
 		if cvb >= 0 then -- Use whichever value is lower, as long as the client isn't trying to get mapwide visibility of names while the server prevents it
-			finalCVar = math.min( cva, cvb)
+			finalCVar = math.min(cva, cvb)
 		else -- If all else fails, settle with what the server is using
 			finalCVar = cva
 		end
 	end
 
-	local holoDisplayDist = finalCVar ^ 2
+	local entList = {}
 
 	if finalCVar > 0 then -- Can't check for -1 from the above variable since it is squared, and it needs to be squared for performance reasons comparing distances
-		for _,ent in pairs( entList ) do
-			local distToEye = eye:DistToSqr( ent:GetPos() )
-			if distToEye < holoDisplayDist then finalEntList[ #finalEntList + 1 ] = ent end
+		local holoDisplayDist = finalCVar ^ 2
+		local eyePos = EyePos()
+
+		for _, ent in ipairs(ents.FindByClass("gmod_wire_hologram")) do
+			if eyePos:DistToSqr(ent:GetPos()) < holoDisplayDist then entList[#entList + 1] = ent end
 		end
-	else -- Default to the original function of showing ALL holograms
+	elseif finalCVar == -1 then
+		-- Default to the original function of showing ALL holograms
 		-- if, in the end, both are 0, why even bother trying to do it at all (and why is this running?)
-		if finalCVar == -1 then finalEntList = entList end
+		entList = ents.FindByClass("gmod_wire_hologram")
 	end
 
-	local names = setmetatable({},{__index=function(t, ply)
-		local name = ply:IsValid() and ply:GetName() or "(disconnected)"
+	local names = setmetatable({}, {__index = function(t, ply)
+		local name = ply:IsValid() and ply:Nick() or "(disconnected)"
 		t[ply] = name
+
 		return name
 	end})
-	for _, ent in pairs( finalEntList ) do
+
+	for _, ent in ipairs(entList) do
 		local vec = ent:GetPos():ToScreen()
+
 		if vec.visible then
-			draw.DrawText( names[ent:GetPlayer()] .. "\n" .. ent.steamid, "DermaDefault", vec.x, vec.y, Color(255,0,0,255), 1 )
+			local text = names[ent:GetPlayer()] .. "\n" .. ent.steamid
+			draw.DrawText(text, "DermaDefaultBold", vec.x + 1, vec.y + 1, color_black, TEXT_ALIGN_CENTER)
+			draw.DrawText(text, "DermaDefaultBold", vec.x, vec.y, color_white, TEXT_ALIGN_CENTER)
 		end
 	end
 end
 
 local display_owners = false
-concommand.Add( "wire_holograms_display_owners", function()
+
+concommand.Add("wire_holograms_display_owners", function()
 	display_owners = not display_owners
+
 	if display_owners then
-		hook.Add( "HUDPaint", "wire_holograms_showowners", WireHologramsShowOwners)
+		hook.Add("HUDPaint", "wire_holograms_showowners", WireHologramsShowOwners)
 	else
 		hook.Remove("HUDPaint", "wire_holograms_showowners")
 	end
-end )
+end)

--- a/lua/entities/gmod_wire_expression2/core/cl_hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_hologram.lua
@@ -41,7 +41,7 @@ local function WireHologramsShowOwners()
 		return name
 	end})
 
-	surface.SetFont("DermaDefaultBold")
+	surface.SetFont("DebugOverlay")
 
 	for _, ent in ipairs(entList) do
 		local vec = ent:GetPos():ToScreen()
@@ -49,11 +49,6 @@ local function WireHologramsShowOwners()
 		if vec.visible then
 			local text = names[ent:GetPlayer()]
 			local w, h = surface.GetTextSize(text)
-			--Draw nick shadow
-			surface.SetTextColor(0, 0, 0)
-			surface.SetTextPos(vec.x - w / 2 + 1, vec.y - h / 2 + 1)
-			surface.DrawText(text)
-
 			--Draw nick
 			surface.SetTextColor(255, 255, 255)
 			surface.SetTextPos(vec.x - w / 2, vec.y - h / 2)
@@ -61,11 +56,6 @@ local function WireHologramsShowOwners()
 
 			local text2 = ent.steamid
 			local w2, h2 = surface.GetTextSize(text2)
-			--Draw steamid shadow
-			surface.SetTextColor(0, 0, 0)
-			surface.SetTextPos(vec.x - w2 / 2 + 1, vec.y + h / 2 + 1)
-			surface.DrawText(text2)
-			
 			--Draw steamid
 			surface.SetTextColor(255, 255, 255)
 			surface.SetTextPos(vec.x - w2 / 2, vec.y + h / 2)

--- a/lua/entities/gmod_wire_expression2/core/cl_hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_hologram.lua
@@ -41,11 +41,12 @@ local function WireHologramsShowOwners()
 		return name
 	end})
 
+	surface.SetFont("DermaDefaultBold")
+
 	for _, ent in ipairs(entList) do
 		local vec = ent:GetPos():ToScreen()
 
 		if vec.visible then
-			surface.SetFont("DermaDefaultBold")
 			local text = names[ent:GetPlayer()]
 			local w, h = surface.GetTextSize(text)
 			--Draw nick shadow


### PR DESCRIPTION
Improves code performance and enhances text/code readability. Red color may be hard to see in certain situations, whereas white text with a black shadow remains clear in all conditions.
![image](https://github.com/user-attachments/assets/453622c8-7fe0-48e5-be78-b3e48507a5c8)