### PR TITLE
Add bonemerging and model bone parenting to holos

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -1159,6 +1159,41 @@ e2function array entity:getFlexes()
 end
 
 --[[******************************************************************************]]
+-- Model bones
+
+__e2setcost(5)
+
+e2function number entity:getModelBoneCount()
+	if not IsValid(this) then return self:throw("Invalid entity!", 0) end
+
+	return this:GetBoneCount()
+end
+
+e2function number entity:getModelBoneIndex(string bone_name)
+	if not IsValid(this) then return self:throw("Invalid entity!", 0) end
+
+	return this:LookupBone(bone_name) or -1
+end
+
+e2function number entity:getModelBoneName(bone_index)
+	if not IsValid(this) then return self:throw("Invalid entity!", "") end
+
+	return this:GetBoneName(bone_index) or ""
+end
+
+__e2setcost(50)
+
+e2function array entity:getModelBones()
+	if not IsValid(this) then return self:throw("Invalid entity!", {}) end
+	local ret = {}
+	for i = 0, this:GetBoneCount() - 1 do
+		ret[i] = this:GetBoneName(i)
+	end
+	self.prf = self.prf + (#ret + 1) * 5
+	return ret
+end
+
+--[[******************************************************************************]]
 -- End e2functions
 
 hook.Add("OnEntityCreated", "E2_entityCreated", function(ent)

--- a/lua/entities/gmod_wire_expression2/core/hologram.lua
+++ b/lua/entities/gmod_wire_expression2/core/hologram.lua
@@ -1243,12 +1243,29 @@ e2function void holoParentAttachment(index, entity ent, string attachmentName)
 	Parent_Hologram(Holo, ent, attachmentName)
 end
 
+-- Combination of EF_BONEMERGE and EF_BONEMERGE_FASTCULL, to avoid performance complaints.
+local BONEMERGE_FLAGS = bit.bor(EF_BONEMERGE, EF_BONEMERGE_FASTCULL)
+
 e2function void holoUnparent(index)
 	local Holo = CheckIndex(self, index)
 	if not Holo then return end
 
+	Holo.ent:RemoveEffects(BONEMERGE_FLAGS)
 	Holo.ent:SetParent(nil)
 	Holo.ent:SetParentPhysNum(0)
+end
+
+__e2setcost(10)
+
+e2function void holoBonemerge(index, state)
+	local Holo = CheckIndex(self, index)
+	if not Holo then return end
+
+	if state ~= 0 then
+		Holo.ent:AddEffects(BONEMERGE_FLAGS)
+	else
+		Holo.ent:RemoveEffects(BONEMERGE_FLAGS)
+	end
 end
 
 -- -----------------------------------------------------------------------------

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -1299,6 +1299,7 @@ E2Helper.Descriptions["holoRemainingSpawns()"] = "Returns how many holograms can
 E2Helper.Descriptions["holoReset(nsvvs)"] = "Similar to holoCreate, but reusing the old entity"
 E2Helper.Descriptions["holoScale(n)"] = "Returns the scale of the given hologram"
 E2Helper.Descriptions["holoScale(nv)"] = "Sets the scale of the given hologram, as a multiplier"
+E2Helper.Descriptions["holoBoneMerge(nn)"] = "Enables bonemerge behavior on the hologram when the second argument is not 0"
 E2Helper.Descriptions["holoBoneScale(nn)"] = "Returns the scale of the given hologram bone"
 E2Helper.Descriptions["holoBoneScale(nnv)"] = "Sets the scale of the given hologram bone, as a multiplier"
 E2Helper.Descriptions["holoBoneScale(ns)"] = "Returns the scale of the given hologram named bone"

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -428,6 +428,12 @@ E2Helper.Descriptions["getFlexWeight"] = "Gets the weight of the flex"
 E2Helper.Descriptions["getFlexes(e:)"] = "Gets a 0-indexed array of all flexes and their names"
 E2Helper.Descriptions["hasFlexes(e:)"] = "Returns 1 if the entity has flexes"
 
+-- Model bones
+E2Helper.Descriptions["getModelBoneCount(e:)"] = "Gets the number of bones on the entity's model. Note these are different from E2 bones"
+E2Helper.Descriptions["getModelBoneIndex(e:s)"] = "Gets the bone index of the given name or -1 if it doesn't exist"
+E2Helper.Descriptions["getModelBoneName(e:n)"] = "Gets the name of the bone"
+E2Helper.Descriptions["getModelBones(e:)"] = "Gets a 0-indexed array of all bones and their names. Note these are different from E2 bones"
+
 -- Vector
 E2Helper.Descriptions["vec2(n)"] = "Makes a 2D vector"
 E2Helper.Descriptions["vec2(nn)"] = "Makes a 2D vector"
@@ -1292,6 +1298,9 @@ E2Helper.Descriptions["holoModelList()"] = "Returns the list of valid models\nSe
 E2Helper.Descriptions["holoParent(ne)"] = "Parents the hologram to an entity"
 E2Helper.Descriptions["holoParent(nn)"] = "Parents the hologram to another hologram"
 E2Helper.Descriptions["holoParentAttachment(nes)"] = "Parents the hologram to an entity's bone by its attachment name"
+E2Helper.Descriptions["holoParentAttachment(nns)"] = "Parents the hologram to another hologram's attachment by its attachment name"
+E2Helper.Descriptions["holoParentBone(nen)"] = "Parents the hologram to an entity's bone by its bone index. Note this is completely different from E2 (physics) bones"
+E2Helper.Descriptions["holoParentBone(nnn)"] = "Parents the hologram to another hologram's bone by its bone index. Note this is completely different from E2 (physics) bones"
 E2Helper.Descriptions["holoUnparent(n)"] = "Un-parents the hologram"
 E2Helper.Descriptions["holoPos(nv)"] = "Sets the position of the hologram"
 E2Helper.Descriptions["holoPos(n)"] = "Gets the position of the hologram"
@@ -1299,7 +1308,7 @@ E2Helper.Descriptions["holoRemainingSpawns()"] = "Returns how many holograms can
 E2Helper.Descriptions["holoReset(nsvvs)"] = "Similar to holoCreate, but reusing the old entity"
 E2Helper.Descriptions["holoScale(n)"] = "Returns the scale of the given hologram"
 E2Helper.Descriptions["holoScale(nv)"] = "Sets the scale of the given hologram, as a multiplier"
-E2Helper.Descriptions["holoBoneMerge(nn)"] = "Enables bonemerge behavior on the hologram when the second argument is not 0"
+E2Helper.Descriptions["holoBonemerge(nn)"] = "Enables bonemerge behavior on the hologram when the second argument is not 0"
 E2Helper.Descriptions["holoBoneScale(nn)"] = "Returns the scale of the given hologram bone"
 E2Helper.Descriptions["holoBoneScale(nnv)"] = "Sets the scale of the given hologram bone, as a multiplier"
 E2Helper.Descriptions["holoBoneScale(ns)"] = "Returns the scale of the given hologram named bone"


### PR DESCRIPTION
1. Allows holos to bonemerge to their parents
   - This allows players to bonemerge, for example, a hat to their head
   - `holoBonemerge(number, number)` - Simple switch function with second argument controlling state. Does not operate if holo is not parented.
3. Allows holos to parent to model bones (followbone)
   - This is roughly equivalent to bonemerging, but less convenient
   - Lets users do PAC3 stuff with holos, basically
   - `holoParentBone(number, entity, number)`
   - `holoParentBone(number, number, number)` - Direct parent to another holo
4. Adds some model bone accessor functions to get model bone information via E2
    - These were added so users do not need to rely on external methods to comfortably use holo bone parenting
   - `entity:getModelBoneCount()`
   - `entity:getModelBoneIndex(string)`
   - `entity:getModelBoneName(number)`
   - `entity:getModelBones()`
5. Added `holoParentAttachment(number, number, string)` as a direct holo-to-holo attachment parent
   - This is superfluous and probably is handled better by using the Holo entity directly, but for some reason I thought the functional symmetry with `holoParent` was especially important here.