### PR TITLE
Limit `@autoupdate` directive executions

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/preprocessor.lua
+++ b/lua/entities/gmod_wire_expression2/base/preprocessor.lua
@@ -234,6 +234,7 @@ local function handleIO(name)
 	end
 end
 
+---@type fun(PreProcessor, string, Trace):string?[]
 local directive_handlers = {
 	["name"] = function(self, value)
 		if not self.ignorestuff then
@@ -293,8 +294,28 @@ local directive_handlers = {
 		end
 	end,
 
-	["autoupdate"] = function(self)
-		if CLIENT then return "" end
+	["autoupdate"] = function(self, value, trace)
+		if not self.directives.autoupdate then
+			self.directives.autoupdate = true
+		else
+			if CLIENT then -- Only warn on client
+				trace.end_line = trace.start_line + 1 -- Modify this trace to avoid creating new ones. Hacky but resourceful(?)
+				trace.end_col = 1
+				self:Warning("Directive (@autoupdate) is already defined", trace, { { at = trace, replace = "" } })
+			end
+			return ""
+		end
+
+		if CLIENT then
+			if #string.Trim(value) > 0 then
+				trace.start_col = trace.end_col + 1
+				trace.end_line = trace.start_line + 1
+				trace.end_col = 1
+				self:Warning("Directive (@autoupdate) takes no parameters", trace, { { at = trace, replace = "\n" } })
+			end
+			return ""
+		end
+
 		if not IsValid( self.ent ) or not self.ent.duped or not self.ent.filepath or self.ent.filepath == "" then return "" end
 		WireLib.Expression2Upload( self.ent:GetPlayer(), self.ent, self.ent.filepath )
 	end,
@@ -350,7 +371,7 @@ end
 
 
 ---@alias IODirective { [1]: string[], [2]: TypeSignature[], [3]: table<string, TypeSignature>, [4]: table<string, string>, [5]: table<string, Trace>  }
----@alias PPDirectives { inputs: IODirective, outputs: IODirective, persist: IODirective, name: string?, model: string?, trigger: { [1]: boolean?, [2]: table<string, boolean> }, strict: boolean? }
+---@alias PPDirectives { inputs: IODirective, outputs: IODirective, persist: IODirective, name: string?, model: string?, trigger: { [1]: boolean?, [2]: table<string, boolean> }, strict: boolean?, autoupdate: true? }
 
 ---@param buffer string
 ---@param directives PPDirectives

--- a/lua/entities/gmod_wire_expression2/base/preprocessor.lua
+++ b/lua/entities/gmod_wire_expression2/base/preprocessor.lua
@@ -294,24 +294,28 @@ local directive_handlers = {
 		end
 	end,
 
-	["autoupdate"] = function(self, value, trace)
+	["autoupdate"] = function(self, arg, trace)
 		if not self.directives.autoupdate then
 			self.directives.autoupdate = true
 		else
-			if CLIENT then -- Only warn on client
-				trace.end_line = trace.start_line + 1 -- Modify this trace to avoid creating new ones. Hacky but resourceful(?)
-				trace.end_col = 1
-				self:Warning("Directive (@autoupdate) is already defined", trace, { { at = trace, replace = "" } })
+			if not self.ignorestuff then -- Assume includes are in good faith and ignore them
+				local quickfix
+				if CLIENT then -- Only do quickfix on the client for optimization
+					trace.end_line = trace.start_line + 1 -- Modify this trace to avoid creating new ones. Hacky but resourceful(?)
+					trace.end_col = 1
+					quickfix = { { at = trace, replace = "" } }
+				end
+				self:Error("Directive (@autoupdate) cannot be defined twice", trace, quickfix)
 			end
 			return ""
 		end
 
 		if CLIENT then
-			if #string.Trim(value) > 0 then
+			if #string.Trim(arg) > 0 then
 				trace.start_col = trace.end_col + 1
 				trace.end_line = trace.start_line + 1
 				trace.end_col = 1
-				self:Warning("Directive (@autoupdate) takes no parameters", trace, { { at = trace, replace = "\n" } })
+				self:Warning("Directive (@autoupdate) takes no arguments", trace, { { at = trace, replace = "\n" } })
 			end
 			return ""
 		end

--- a/lua/wire/client/text_editor/wire_expression2_editor.lua
+++ b/lua/wire/client/text_editor/wire_expression2_editor.lua
@@ -2006,14 +2006,28 @@ end
 
 function Editor:Close()
 	timer.Stop("e2autosave")
-	self:AutoSave()
+	local ok, err = pcall(self.AutoSave, self)
+	if not ok then
+		WireLib.Notify(nil, "Failed to autosave file while closing E2 editor.\n" .. err, 3)
+	end
 
-	self:Validate()
-	self:ExtractName()
+	ok = pcall(self.Validate, self)
+	if not ok then
+		WireLib.Notify(nil, "Failed to validate file while closing E2 editor.\n", 2)
+	end
+
+	ok, err = pcall(self.ExtractName, self)
+	if not ok then
+		WireLib.Notify(nil, "Failed to extract name while closing E2 editor.\n" .. err, 3)
+	end
+
 	self:SetV(false)
 	self.chip = false
 
-	self:SaveEditorSettings()
+	ok, err = pcall(self.SaveEditorSettings, self)
+	if not ok then
+		WireLib.Notify(nil, "Failed to save editor settings while closing E2 editor.\n" .. err, 3)
+	end
 
 	hook.Run("WireEditorClose", self)
 end


### PR DESCRIPTION
This PR fixes #3190. In addition, I made this directive a little more informative. Unrelated to the linked issue, I also included some wrapping into the E2 editor to avoid the editor from failing to close (such failures are rare but extremely annoying).

Relevant changes:
- Limited `@autoupdate` directive to only ever run once
- Added error when `@autoupdate` is defined twice in the same file
  - An error is not ran, but the directive is still ignored, if the directive is in an include

Miscellaneous changes:
- Add warning when `@autoupdate` is passed any arguments
- Tried to prevent the E2 editor from ever failing to close
  - Normally the editor only fails on `Validate`, but I wrapped a few other functions to be on the safe side
- Updated some annotations