### PR TITLE
Add e2 timer limit convar

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/timer.lua
+++ b/lua/entities/gmod_wire_expression2/core/timer.lua
@@ -2,6 +2,7 @@
   Timer support
 \******************************************************************************/
 
+local wire_expression2_timers_limit = CreateConVar("wire_expression2_timers_limit", 100, FCVAR_ARCHIVE, "The maximum number of timers that can be created by an E2 chip")
 local timerid = 0
 
 local function Execute(self, name)
@@ -85,6 +86,11 @@ local function luaTimerCreate(self, name, delay, repetitions, callback)
 		luaTimers[entIndex] = {}
 	elseif luaTimerExists(self, name) then
 		return self:throw("Timer with name " .. name .. " already exists", nil)
+	end
+
+	local timerLimit = wire_expression2_timers_limit:GetInt()
+	if table.Count(luaTimers[entIndex]) >= timerLimit then
+		return self:throw("Timer limit reached (" .. timerLimit .. ")", nil)
 	end
 
 	local internalName = luaTimerGetInternalName(self.entity:EntIndex(), name)


### PR DESCRIPTION
Currently players can make an infinite amount of timers causing severe lag
```
@persist A

if (first()){
    A = 0
}

interval(100)
while(perf())
{
    timer("Logic" + A,10000000,0,function(){
    })
    
    A = A + 1
}
```