### PR TITLE
Fix bad EGPObject invalid function

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/egpobjects.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpobjects.lua
@@ -9,6 +9,7 @@ local isValid = EGP.EGPObject.IsValid
 local hasObject = EGP.HasObject
 local egp_create = EGP.Create
 local isAllowed = EGP.IsAllowed
+local isEGPObject = EGP.IsEGPObject
 
 -- Table of allowed arguments and their types
 local EGP_ALLOWED_ARGS =
@@ -46,7 +47,7 @@ registerType("egpobject", "xeo", NULL_EGPOBJECT,
 	nil,
 	nil,
 	function(v)
-		return not isValid(v)
+		return not isEGPObject(v)
 	end
 )
 


### PR DESCRIPTION
Before this PR, the NULL EGPObject would be duplicated each time it was pulled from a table, since it would be deemed invalid.