### PR TITLE
Add new E2 hash functions

### DIFF
--- a/data/expression2/tests/runtime/libraries/string.txt
+++ b/data/expression2/tests/runtime/libraries/string.txt
@@ -27,5 +27,7 @@ assert(Threw)
 assert(format("%s %d", "foo", 232) == "foo 232")
 assert(format("%u", 232) == "232")
 
+assert(hashCRC(Str) == "3957769958")
 assert(hashMD5(Str) == "6cd3556deb0da54bca060b4c39479839")
+assert(hashSHA1(Str) == "943a702d06f34599aee1f8da8ef9f7296031d699")
 assert(hashSHA256(Str) == "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3")

--- a/data/expression2/tests/runtime/libraries/string.txt
+++ b/data/expression2/tests/runtime/libraries/string.txt
@@ -26,3 +26,6 @@ assert(Threw)
 
 assert(format("%s %d", "foo", 232) == "foo 232")
 assert(format("%u", 232) == "232")
+
+assert(hashMD5(Str) == "6cd3556deb0da54bca060b4c39479839")
+assert(hashSHA256(Str) == "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3")

--- a/lua/entities/gmod_wire_expression2/core/selfaware.lua
+++ b/lua/entities/gmod_wire_expression2/core/selfaware.lua
@@ -362,7 +362,7 @@ e2function number hashNoComments()
 	return getHash( self, self.entity.buffer )
 end
 
-[nodiscard]
+[nodiscard, deprecated = "Use hashMD5 or hashSHA256"]
 e2function number hash( string str )
 	return getHash( self, str )
 end

--- a/lua/entities/gmod_wire_expression2/core/selfaware.lua
+++ b/lua/entities/gmod_wire_expression2/core/selfaware.lua
@@ -362,7 +362,7 @@ e2function number hashNoComments()
 	return getHash( self, self.entity.buffer )
 end
 
-[nodiscard, deprecated = "Use hashMD5 or hashSHA256"]
+[nodiscard, deprecated]
 e2function number hash( string str )
 	return getHash( self, str )
 end

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -526,7 +526,7 @@ end
 
 local function hash_generic(self, text, func)
 	local len = #text
-	if len > 65536 then return self:throw("Input string is too long!", "") end
+	if len > 131072 then return self:throw("Input string is too long!", "") end
 	self.prf = self.prf + len * 0.01
 	return func(text)
 end
@@ -534,8 +534,18 @@ end
 __e2setcost(5)
 
 [nodiscard]
+e2function string hashCRC(string text)
+	return hash_generic(self, text, util.CRC)
+end
+
+[nodiscard]
 e2function string hashMD5(string text)
 	return hash_generic(self, text, util.MD5)
+end
+
+[nodiscard]
+e2function string hashSHA1(string text)
+	return hash_generic(self, text, util.SHA1)
 end
 
 [nodiscard]

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -526,7 +526,7 @@ end
 
 local function hash_generic(self, text, func)
 	local len = #text
-	if len > 131072 then return self:forceThrow("Input string is too long!") end
+	if len > 131072 then self:forceThrow("Input string is too long!") end
 	self.prf = self.prf + len * 0.01
 	return func(text)
 end

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -520,3 +520,25 @@ e2function string decompress(string compressed)
 	self.prf = self.prf + len * 0.5
 	return decompress(compressed) or self:throw("Invalid input for decompression!", "")
 end
+
+--[[******************************************************************************]]--
+-- Hash functions
+
+local function hash_generic(self, text, func)
+	local len = #text
+	if len > 65536 then return self:throw("Input string is too long!", "") end
+	self.prf = self.prf + len * 0.01
+	return func(text)
+end
+
+__e2setcost(5)
+
+[nodiscard]
+e2function string hashMD5(string text)
+	return hash_generic(self, text, util.MD5)
+end
+
+[nodiscard]
+e2function string hashSHA256(string text)
+	return hash_generic(self, text, util.SHA256)
+end

--- a/lua/entities/gmod_wire_expression2/core/string.lua
+++ b/lua/entities/gmod_wire_expression2/core/string.lua
@@ -526,7 +526,7 @@ end
 
 local function hash_generic(self, text, func)
 	local len = #text
-	if len > 131072 then return self:throw("Input string is too long!", "") end
+	if len > 131072 then return self:forceThrow("Input string is too long!") end
 	self.prf = self.prf + len * 0.01
 	return func(text)
 end

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -176,6 +176,8 @@ E2Helper.Descriptions["gmatch(s:s)"] = "runs string.gmatch(S, S2) and returns th
 E2Helper.Descriptions["gmatch(s:sn)"] = "runs string.gmatch(S, S2, N) and returns the captures in arrays in a table"
 E2Helper.Descriptions["compress(s)"] = "Compresses the input string using LZMA compression. See decompress(string)"
 E2Helper.Descriptions["decompress(s)"] = "Decompresses an LZMA-compressed string. See compress(string)"
+E2Helper.Descriptions["hashMD5(s)"] = "Returns the MD5 hash of the input string. This is not a secure hash function; see hashSHA256"
+E2Helper.Descriptions["hashSHA256(s)"] = "Returns the SHA256 hash of the input string"
 
 -- Entity/Player
 E2Helper.Descriptions["entity(n)"] = "Gets the entity associated with the id"
@@ -937,7 +939,7 @@ E2Helper.Descriptions["remoteSetCode(e:st)"] = "Sets the E2's code with main fil
 E2Helper.Descriptions["remoteUpload(e:s)"] = "Uploads the code from your computer to the server"
 E2Helper.Descriptions["getCodeIncludes()"] = "Returns a table where indices (keys) are names of included files and entries are their codes"
 E2Helper.Descriptions["hash()"] = "Returns a numerical hash using the code of the E2 itself (Including comments)"
-E2Helper.Descriptions["hash(s)"] = "Returns a numerical hash using the string specified"
+E2Helper.Descriptions["hash(s)"] = "Returns the CRC-32 of the string specified. This should not be used as a legitimate hash function"
 E2Helper.Descriptions["hashNoComments()"] = "Returns a numerical hash using the code of the E2 itself (Excluding comments)"
 E2Helper.Descriptions["concmd(s)"] = "Takes a string and executes it in console. Returns 1 if it succeeded and 0 if it failed.The client must enable this in the console with \"wire_expression2_concmd 1\". \"wire_expression2_concmd_whitelist\" allows you to choose which commands can be used.[http://www.wiremod.com/forum/151800-post12.html]"
 E2Helper.Descriptions["ioInputEntity(s)"] = "Returns the entity the input S is wired to"

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -176,7 +176,9 @@ E2Helper.Descriptions["gmatch(s:s)"] = "runs string.gmatch(S, S2) and returns th
 E2Helper.Descriptions["gmatch(s:sn)"] = "runs string.gmatch(S, S2, N) and returns the captures in arrays in a table"
 E2Helper.Descriptions["compress(s)"] = "Compresses the input string using LZMA compression. See decompress(string)"
 E2Helper.Descriptions["decompress(s)"] = "Decompresses an LZMA-compressed string. See compress(string)"
+E2Helper.Descriptions["hashCRC(s)"] = "Returns a the CRC checksum of the input string. This is not a secure hash function"
 E2Helper.Descriptions["hashMD5(s)"] = "Returns the MD5 hash of the input string. This is not a secure hash function; see hashSHA256"
+E2Helper.Descriptions["hashSHA1(s)"] = "Returns the SHA1 hash of the input string. This is not a secure hash function; see hashSHA256"
 E2Helper.Descriptions["hashSHA256(s)"] = "Returns the SHA256 hash of the input string"
 
 -- Entity/Player


### PR DESCRIPTION
- Adds `hashCRC(string)` to get the CRC checksum of a string
- Adds `hashMD5(string)` to get the MD5 hash of a string
- Adds `hashSHA1(string)` to get the SHA1 hash of a string
- Adds `hashSHA256(string)` to get the SHA256 of a string
- Update test file to include hash functions
- Update `hash(string)` description
- Deprecates `hash(string)`

I think the size limit could be higher without much concern. Please advise.

Also doing this as a test of the linter since for some reason it's using the old one on the other PR.