### PR TITLE
Changed E2 spawn behavior to only run once ever

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/core.lua
+++ b/lua/entities/gmod_wire_expression2/core/core.lua
@@ -73,6 +73,7 @@ local function dupefinished( TimedPasteData, TimedPasteDataCurrent )
 			v.dupefinished = true
 			v:Execute()
 			v.dupefinished = nil
+			v.duped = nil
 		end
 	end
 end


### PR DESCRIPTION
If `AdvDupe2` is undefined, `duped()` will always run,
else, `duped()` will only run if the chip is not strict.

This also changes `duped()` and `dupefinished()` to be synonymous when AdvDupe2 is installed. Both will be `1` when the `dupefinished()` case is ran. Although it's not equivalent (because `duped()` is ran before constraints are created), you can now use `duped()` to flag both post-AdvDupe2 and regular post-dupe.

I'm not sure if this is the best solution, but AdvDupe2 is the only addon that provides a hook to run after all of pasting is finished for both the normal and alternate duplicator.