### PR TITLE
Fix try/catch would not pop excess scopes

### DIFF
--- a/data/expression2/tests/regressions/3080.txt
+++ b/data/expression2/tests/regressions/3080.txt
@@ -1,0 +1,40 @@
+## SHOULD_PASS:EXECUTE
+@strict
+
+try {
+    error("A")
+} catch(A:string) {
+    assert(A == "A")
+}
+
+try {
+    if(1) {
+        error("B")
+    }
+} catch(B:string) {
+    assert(B == "B")
+}
+
+if(1) {
+    try {
+        error("C")
+    } catch(C:string) {
+        assert(C == "C")
+    }
+    
+    try {
+        if(1) {
+            error("D")
+        }
+    } catch(D:string) {
+        assert(D == "D")
+    }
+    
+    let Fn = function() { error("F") }
+    
+    try {
+        Fn()
+    } catch(F:string) {
+        assert(F == "F")
+    }
+}

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -621,9 +621,12 @@ local CompileVisitors = {
 		self.scope.data.ops = self.scope.data.ops + 5
 
 		return function(state) ---@param state RuntimeContext
+			local depth = state.ScopeID
 			state:PushScope()
 				local ok, err = pcall(try_block, state)
-			state:PopScope()
+			while state.ScopeID > depth do -- Dump all scopes that may have been created in between
+				state:PopScope()
+			end
 			if not ok then
 				local catchable, msg = E2Lib.unpackException(err)
 				if catchable then

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -621,13 +621,13 @@ local CompileVisitors = {
 		self.scope.data.ops = self.scope.data.ops + 5
 
 		return function(state) ---@param state RuntimeContext
-			local depth = state.ScopeID
+			local scope, scope_id = state.Scope, state.ScopeID
 			state:PushScope()
 				local ok, err = pcall(try_block, state)
-			while state.ScopeID > depth do -- Dump all scopes that may have been created in between
+			if ok then
 				state:PopScope()
-			end
-			if not ok then
+			else
+				state.Scope, state.ScopeID = scope, scope_id -- Skip back any scopes that may have been created in try_block
 				local catchable, msg = E2Lib.unpackException(err)
 				if catchable then
 					state:PushScope()


### PR DESCRIPTION
Scopes could be pushed in try/catch that were never popped (causing a misalignment or something). This resolves that.

Fixes #3080