### PR TITLE
Fix lambda timers timerSetDelay not accounting for repetitions.

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/timer.lua
+++ b/lua/entities/gmod_wire_expression2/core/timer.lua
@@ -244,18 +244,9 @@ e2function void timerSetDelay(string name, number delay)
 	end
 
 	local entIndex = self.entity:EntIndex()
-	local internalName = luaTimerGetInternalName(entIndex, name)
 	luaTimers[entIndex][name].delay = delay
 
-	if luaTimers[entIndex][name].repetitions > 0 then
-		local repsLeft = timer.RepsLeft(internalName)
-		if repsLeft == 0 then return end
-
-		luaTimers[entIndex][name].repetitions = repsLeft
-		timer.Adjust(internalName, delay, repsLeft)
-		return
-	end
-	timer.Adjust(internalName, delay, 0)
+	timer.Adjust(luaTimerGetInternalName(entIndex, name), delay)
 end
 
 e2function number timerSetReps(string name, number repetitions)

--- a/lua/entities/gmod_wire_expression2/core/timer.lua
+++ b/lua/entities/gmod_wire_expression2/core/timer.lua
@@ -58,7 +58,7 @@ local luaTimers = {
 			delay = 1,
 			repetitions = 1
 		}
-	} 
+	}
 	*/
 }
 
@@ -244,8 +244,18 @@ e2function void timerSetDelay(string name, number delay)
 	end
 
 	local entIndex = self.entity:EntIndex()
+	local internalName = luaTimerGetInternalName(entIndex, name)
 	luaTimers[entIndex][name].delay = delay
-	timer.Adjust(luaTimerGetInternalName(entIndex, name), delay, 0)
+
+	if luaTimers[entIndex][name].repetitions > 0 then
+		local repsLeft = timer.RepsLeft(internalName)
+		if repsLeft == 0 then return end
+
+		luaTimers[entIndex][name].repetitions = repsLeft
+		timer.Adjust(internalName, delay, repsLeft)
+		return
+	end
+	timer.Adjust(internalName, delay, 0)
 end
 
 e2function number timerSetReps(string name, number repetitions)


### PR DESCRIPTION
Lambda timers used to make all timers infinitely repeat upon using timerSetDelay, now it accounts for timers with limited repetitions.