### PR TITLE
Fix downloads when reloading file extension

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/files.lua
+++ b/lua/entities/gmod_wire_expression2/core/files.lua
@@ -352,11 +352,7 @@ flushFileBuffer = function()
 						table.remove(queue, 1)
 
 						if #queue ~= 0 then -- Queue the next file
-							if timer.Exists("wire_expression2_flush_file_buffer") then
-								timer.Adjust("wire_expression2_flush_file_buffer", 0.2, 2)
-							else
-								timer.Create("wire_expression2_flush_file_buffer", 0.2, 2, flushFileBuffer)
-							end
+							timer.Create("wire_expression2_flush_file_buffer", 0.2, 2, flushFileBuffer)
 						end
 					end)
 				net.Send(ply)

--- a/lua/entities/gmod_wire_expression2/core/files.lua
+++ b/lua/entities/gmod_wire_expression2/core/files.lua
@@ -325,6 +325,7 @@ util.AddNetworkString("wire_expression2_file_download")
 -- 2 - Upload
 -- 3 - End
 
+timer.Remove("wire_expression2_flush_file_buffer") -- Remove this timer in case it exists from reloading
 flushFileBuffer = function()
 	for ply, queue in pairs(downloads) do
 		if ent_IsValid(ply) then
@@ -350,8 +351,12 @@ flushFileBuffer = function()
 
 						table.remove(queue, 1)
 
-						if #queue ~= 0 and not timer.Exists("wire_expression2_flush_file_buffer") then -- Queue the next file
-							timer.Create("wire_expression2_flush_file_buffer", 0.2, 0, flushFileBuffer)
+						if #queue ~= 0 then -- Queue the next file
+							if timer.Exists("wire_expression2_flush_file_buffer") then
+								timer.Adjust("wire_expression2_flush_file_buffer", 0.2, 2)
+							else
+								timer.Create("wire_expression2_flush_file_buffer", 0.2, 2, flushFileBuffer)
+							end
 						end
 					end)
 				net.Send(ply)


### PR DESCRIPTION
Downloads would break when reloading the file extension because it depended on a timer that never gets removed.