### PR TITLE
Add E2 function entity:propKeepFrozen(number)

### DIFF
--- a/lua/entities/gmod_wire_cameracontroller.lua
+++ b/lua/entities/gmod_wire_cameracontroller.lua
@@ -56,7 +56,6 @@ if CLIENT then
 	local curdistance = 0
 	local oldcurdistance = 0
 	local smoothdistance = 0
-	local maxdistance = 16000
 
 	local zoomdistance = 0
 	local zoombind = 0
@@ -155,7 +154,7 @@ if CLIENT then
 
 			if AllowZoom then
 				if zoombind ~= 0 then
-					zoomdistance = math.Clamp(zoomdistance + zoombind * FrameTime() * 100 * max((abs(curdistance) + abs(zoomdistance))/10,10),0,math.min(16000-curdistance, maxdistance))
+					zoomdistance = math.Clamp(zoomdistance + zoombind * FrameTime() * 100 * max((abs(curdistance) + abs(zoomdistance))/10,10),0,16000-curdistance)
 					zoombind = 0
 				end
 				curdistance = curdistance + zoomdistance
@@ -269,7 +268,6 @@ if CLIENT then
 
 		-- distance
 		distance = math.Clamp(net.ReadFloat(),-16000,16000)
-		maxdistance = net.ReadFloat()
 
 		-- Parent
 		WaitingForID = net.ReadInt(32)
@@ -376,7 +374,6 @@ function ENT:Initialize()
 		"Angle (Sets the direction of the camera, in angle form.\nIf clientside movement is enabled, this is ignored.) [ANGLE]",
 		"Position (Sets the position of the camera.\nIf clientside movement is enabled, this specifies the center of the camera's orbit.) [VECTOR]",
 		"Distance (Sets the 'distance' of the camera.\nIn other words, the camera will be moved away from the specified position by this amount.\nIf clientside zooming is enabled, this is the farthest you can zoom in.)",
-		"MaxDistance (Sets the max distance the camera can zoom out to.\n Needs clientside movement and clientside zooming to be enabled.)",
 		"UnRoll (If free movement is enabled, this resets the roll back to zero.)",
 		"Parent (Parents the camera to this entity.) [ENTITY]",
 		"FilterEntities (In addition to ignoring the contraption of the 'Parent' entity, or the cam controller itself\nif parent isn't used, entities in this list will be ignored by the 'HitPos' and 'Trace' outputs) [ARRAY]",
@@ -393,7 +390,6 @@ function ENT:Initialize()
 	self.Position = Vector(0,0,0)
 	self.Angle = Angle(0,0,0)
 	self.Distance = 0
-	self.MaxDistance = 16000
 	self.UnRoll = false
 
 	self.Players = {}
@@ -460,7 +456,7 @@ end
 -- Data sending
 --------------------------------------------------
 
-local function SendPositions( pos, ang, dist, parent, unroll, maxdist )
+local function SendPositions( pos, ang, dist, parent, unroll )
 	-- pos/ang
 	net.WriteFloat( pos.x )
 	net.WriteFloat( pos.y )
@@ -473,7 +469,6 @@ local function SendPositions( pos, ang, dist, parent, unroll, maxdist )
 
 	-- distance
 	net.WriteFloat( dist )
-	net.WriteFloat( maxdist )
 
 	-- parent
 	local id = IsValid( parent ) and parent:EntIndex() or -1
@@ -497,7 +492,7 @@ function ENT:SyncSettings( ply, active )
 			net.WriteBit( self.AutoUnclip_IgnoreWater )
 			net.WriteBit( self.DrawPlayer )
 			net.WriteBit( self.DrawParent )
-			SendPositions( self.Position, self.Angle, self.Distance, self.Parent, self.UnRoll, self.MaxDistance )
+			SendPositions( self.Position, self.Angle, self.Distance, self.Parent, self.UnRoll )
 		end
 	net.Send( ply )
 end
@@ -508,7 +503,7 @@ function ENT:SyncPositions( ply )
 	if not IsValid(ply) then ply = self.Players end
 	net.Start( "wire_camera_controller_sync" )
 		net.WriteEntity( self )
-		SendPositions( self.Position, self.Angle, self.Distance, self.Parent, self.UnRoll, self.MaxDistance )
+		SendPositions( self.Position, self.Angle, self.Distance, self.Parent, self.UnRoll )
 	net.Send( ply )
 end
 
@@ -868,8 +863,6 @@ function ENT:TriggerInput( name, value )
 			self.Position = value
 		elseif name == "Distance" then
 			self.Distance = value
-		elseif name == "MaxDistance" then
-			self.MaxDistance = value
 		elseif name == "UnRoll" then
 			self.UnRoll = tobool(value)
 		elseif name == "Direction" then

--- a/lua/entities/gmod_wire_cameracontroller.lua
+++ b/lua/entities/gmod_wire_cameracontroller.lua
@@ -56,6 +56,7 @@ if CLIENT then
 	local curdistance = 0
 	local oldcurdistance = 0
 	local smoothdistance = 0
+	local maxdistance = 16000
 
 	local zoomdistance = 0
 	local zoombind = 0
@@ -154,7 +155,7 @@ if CLIENT then
 
 			if AllowZoom then
 				if zoombind ~= 0 then
-					zoomdistance = math.Clamp(zoomdistance + zoombind * FrameTime() * 100 * max((abs(curdistance) + abs(zoomdistance))/10,10),0,16000-curdistance)
+					zoomdistance = math.Clamp(zoomdistance + zoombind * FrameTime() * 100 * max((abs(curdistance) + abs(zoomdistance))/10,10),0,math.min(16000-curdistance, maxdistance))
 					zoombind = 0
 				end
 				curdistance = curdistance + zoomdistance
@@ -268,6 +269,7 @@ if CLIENT then
 
 		-- distance
 		distance = math.Clamp(net.ReadFloat(),-16000,16000)
+		maxdistance = net.ReadFloat()
 
 		-- Parent
 		WaitingForID = net.ReadInt(32)
@@ -374,6 +376,7 @@ function ENT:Initialize()
 		"Angle (Sets the direction of the camera, in angle form.\nIf clientside movement is enabled, this is ignored.) [ANGLE]",
 		"Position (Sets the position of the camera.\nIf clientside movement is enabled, this specifies the center of the camera's orbit.) [VECTOR]",
 		"Distance (Sets the 'distance' of the camera.\nIn other words, the camera will be moved away from the specified position by this amount.\nIf clientside zooming is enabled, this is the farthest you can zoom in.)",
+		"MaxDistance (Sets the max distance the camera can zoom out to.\n Needs clientside movement and clientside zooming to be enabled.)",
 		"UnRoll (If free movement is enabled, this resets the roll back to zero.)",
 		"Parent (Parents the camera to this entity.) [ENTITY]",
 		"FilterEntities (In addition to ignoring the contraption of the 'Parent' entity, or the cam controller itself\nif parent isn't used, entities in this list will be ignored by the 'HitPos' and 'Trace' outputs) [ARRAY]",
@@ -390,6 +393,7 @@ function ENT:Initialize()
 	self.Position = Vector(0,0,0)
 	self.Angle = Angle(0,0,0)
 	self.Distance = 0
+	self.MaxDistance = 16000
 	self.UnRoll = false
 
 	self.Players = {}
@@ -456,7 +460,7 @@ end
 -- Data sending
 --------------------------------------------------
 
-local function SendPositions( pos, ang, dist, parent, unroll )
+local function SendPositions( pos, ang, dist, parent, unroll, maxdist )
 	-- pos/ang
 	net.WriteFloat( pos.x )
 	net.WriteFloat( pos.y )
@@ -469,6 +473,7 @@ local function SendPositions( pos, ang, dist, parent, unroll )
 
 	-- distance
 	net.WriteFloat( dist )
+	net.WriteFloat( maxdist )
 
 	-- parent
 	local id = IsValid( parent ) and parent:EntIndex() or -1
@@ -492,7 +497,7 @@ function ENT:SyncSettings( ply, active )
 			net.WriteBit( self.AutoUnclip_IgnoreWater )
 			net.WriteBit( self.DrawPlayer )
 			net.WriteBit( self.DrawParent )
-			SendPositions( self.Position, self.Angle, self.Distance, self.Parent, self.UnRoll )
+			SendPositions( self.Position, self.Angle, self.Distance, self.Parent, self.UnRoll, self.MaxDistance )
 		end
 	net.Send( ply )
 end
@@ -503,7 +508,7 @@ function ENT:SyncPositions( ply )
 	if not IsValid(ply) then ply = self.Players end
 	net.Start( "wire_camera_controller_sync" )
 		net.WriteEntity( self )
-		SendPositions( self.Position, self.Angle, self.Distance, self.Parent, self.UnRoll )
+		SendPositions( self.Position, self.Angle, self.Distance, self.Parent, self.UnRoll, self.MaxDistance )
 	net.Send( ply )
 end
 
@@ -863,6 +868,8 @@ function ENT:TriggerInput( name, value )
 			self.Position = value
 		elseif name == "Distance" then
 			self.Distance = value
+		elseif name == "MaxDistance" then
+			self.MaxDistance = value
 		elseif name == "UnRoll" then
 			self.UnRoll = tobool(value)
 		elseif name == "Direction" then

--- a/lua/entities/gmod_wire_cameracontroller.lua
+++ b/lua/entities/gmod_wire_cameracontroller.lua
@@ -271,6 +271,10 @@ if CLIENT then
 		distance = math.Clamp(net.ReadFloat(),-16000,16000)
 		maxdistance = net.ReadFloat()
 
+		if AutoMove and AllowZoom then
+			zoombind = 1
+		end
+
 		-- Parent
 		WaitingForID = net.ReadInt(32)
 

--- a/lua/entities/gmod_wire_cameracontroller.lua
+++ b/lua/entities/gmod_wire_cameracontroller.lua
@@ -271,10 +271,6 @@ if CLIENT then
 		distance = math.Clamp(net.ReadFloat(),-16000,16000)
 		maxdistance = net.ReadFloat()
 
-		if AutoMove and AllowZoom then
-			zoombind = 1
-		end
-
 		-- Parent
 		WaitingForID = net.ReadInt(32)
 

--- a/lua/entities/gmod_wire_expression2/core/custom/cl_prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cl_prop.lua
@@ -40,6 +40,7 @@ E2Helper.Descriptions["propSpawnEffect(n)"] = "Set to 1 to enable prop spawn eff
 E2Helper.Descriptions["propDelete(e:)"] = "Deletes the specified prop."
 E2Helper.Descriptions["propDelete(t:)"] = "Deletes all the props in the given table, returns the amount of props deleted."
 E2Helper.Descriptions["propDelete(r:)"] = "Deletes all the props in the given array, returns the amount of props deleted."
+E2Helper.Descriptions["propKeepFrozen(e:n)"] = "if set to non-zero, prevents the entity from being unfrozen by physgun reload, can be unfrozen otherwise."
 E2Helper.Descriptions["propFreeze(e:n)"] = "Passing 0 unfreezes the entity, everything else freezes it."
 E2Helper.Descriptions["propNotSolid(e:n)"] = "Passing 0 makes the entity solid, everything else makes it non-solid."
 E2Helper.Descriptions["propGravity(e:n)"] = "Passing 0 makes the entity weightless, everything else makes it weighty."

--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -61,7 +61,7 @@ local ValidSpawn = PropCore.ValidSpawn
 local canHaveInvalidPhysics = {
 	delete=true, parent=true, deparent=true, solid=true,
 	shadow=true, draw=true, use=true, pos=true, ang=true,
-	manipulate=true, noDupe=true
+	manipulate=true, noDupe=true, keepFrozen=true
 }
 
 function PropCore.ValidAction(self, entity, cmd, bone)
@@ -814,6 +814,15 @@ e2function void entity:propFreeze(number freeze)
 	if not ValidAction(self, this, "freeze") then return end
 	PhysManipulate(this, nil, nil, freeze, nil, nil)
 end
+
+e2function void entity:propKeepFrozen(number keepFrozen)
+	if not ValidAction(self, this, "keepFrozen") then return end
+	this.PropcoreKeepFrozen = keepFrozen ~= 0 or nil
+end
+
+hook.Add("CanPlayerUnfreeze", "E2_PropcoreKeepFrozen", function(_, Ent)
+	if Ent.PropcoreKeepFrozen then return false end
+end)
 
 e2function void entity:propNotSolid(number notsolid)
 	if not ValidAction(self, this, "solid") then return end


### PR DESCRIPTION
If the number is non-zero then the prop will not be unfreezeable by physgun reloads, other unfreezing methods should be unaffected.

I figured that since e2 has physgun pickup/drop events now that would help with keeping setang plates frozen without checking it every tick that there should also be a way to prevent props being unfrozen with physgun reload.
