### PR TITLE
entities() E2 function

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -123,6 +123,15 @@ e2function entity entity:owner()
 	return getOwner(self, this)
 end
 
+__e2setcost(100)
+
+e2function array entities()
+	local entities = ents.GetAll()
+	self.prf = self.prf + #entities / 2
+
+	return entities
+end
+
 __e2setcost(20)
 
 e2function table entity:keyvalues()

--- a/lua/wire/client/e2descriptions.lua
+++ b/lua/wire/client/e2descriptions.lua
@@ -184,6 +184,7 @@ E2Helper.Descriptions["hashSHA256(s)"] = "Returns the SHA256 hash of the input s
 
 -- Entity/Player
 E2Helper.Descriptions["entity(n)"] = "Gets the entity associated with the id"
+E2Helper.Descriptions["entities()"] = "Returns an array containing all entities on the map"
 E2Helper.Descriptions["owner()"] = "Gets the owner of the expression ( same as entity():owner() )"
 E2Helper.Descriptions["id(e:)"] = "Gets the numeric id of an entity"
 E2Helper.Descriptions["noentity()"] = "Returns an invalid entity"


### PR DESCRIPTION
Adds a function to get an array of all entities on the map. Of course we have ```findByClass("*")```, but it works many times slower and is not an obvious way to get all entities.