### PR TITLE
Add Vehicle Inputs To Cam Controllers And EGP Huds

### DIFF
--- a/lua/entities/gmod_wire_cameracontroller.lua
+++ b/lua/entities/gmod_wire_cameracontroller.lua
@@ -388,7 +388,6 @@ function ENT:Initialize()
 		"FLIR",
 		"FOV",
 		"Vehicles (Links all vehicles of passed array to this cam controller) [ARRAY]",
-		"Vehicle [ENTITY]"
 	})
 
 	self.Activated = false -- Whether or not to activate the cam controller for all players sitting in linked vehicles, or as soon as a player sits in a linked vehicle
@@ -865,12 +864,6 @@ function ENT:TriggerInput( name, value )
 			if( not IsValid(v) ) then continue end
 			self:LinkEnt( v )
 		end
-	elseif name == "Vehicle" then
-		if not IsValid(value) then return end -- Only link if the input is valid. That way, it won't be unlinked if the wire is disconnected
-		if value:IsPlayer() then return end
-		if value:IsNPC() then return end
-
-		self:LinkEnt(value)
 	else
 		self:LocalizePositions(false)
 

--- a/lua/entities/gmod_wire_cameracontroller.lua
+++ b/lua/entities/gmod_wire_cameracontroller.lua
@@ -388,6 +388,7 @@ function ENT:Initialize()
 		"FLIR",
 		"FOV",
 		"Vehicles (Links all vehicles of passed array to this cam controller) [ARRAY]",
+		"Vehicle [ENTITY]"
 	})
 
 	self.Activated = false -- Whether or not to activate the cam controller for all players sitting in linked vehicles, or as soon as a player sits in a linked vehicle
@@ -864,6 +865,12 @@ function ENT:TriggerInput( name, value )
 			if( not IsValid(v) ) then continue end
 			self:LinkEnt( v )
 		end
+	elseif name == "Vehicle" then
+		if not IsValid(value) then return end -- Only link if the input is valid. That way, it won't be unlinked if the wire is disconnected
+		if value:IsPlayer() then return end
+		if value:IsNPC() then return end
+
+		self:LinkEnt(value)
 	else
 		self:LocalizePositions(false)
 

--- a/lua/entities/gmod_wire_egp_hud/init.lua
+++ b/lua/entities/gmod_wire_egp_hud/init.lua
@@ -25,7 +25,8 @@ function ENT:Initialize()
 	self:AddEFlags( EFL_FORCE_CHECK_TRANSMIT )
 
 	WireLib.CreateInputs(self, {
-		"0 to 512 (If enabled, changes the resolution of the egp hud to be between 0 and 512 instead of the user's monitor's resolution.\nWill cause objects to look stretched out on most screens, so your UI will need to be designed with this in mind.\nIt's recommended to use the egpScrW, egpScrH, and egpScrSize functions instead.)"
+		"0 to 512 (If enabled, changes the resolution of the egp hud to be between 0 and 512 instead of the user's monitor's resolution.\nWill cause objects to look stretched out on most screens, so your UI will need to be designed with this in mind.\nIt's recommended to use the egpScrW, egpScrH, and egpScrSize functions instead.)",
+		"Vehicle [ENTITY]"
 	})
 
 	WireLib.CreateOutputs(self, { "wirelink [WIRELINK]" })
@@ -42,6 +43,12 @@ end
 function ENT:TriggerInput( name, value )
 	if (name == "0 to 512") then
 		self:SetResolution(value ~= 0)
+	elseif name == "Vehicle" then
+		if not IsValid(value) then return end -- Only link if the input is valid. That way, it won't be unlinked if the wire is disconnected
+		if value:IsPlayer() then return end
+		if value:IsNPC() then return end
+
+		self:LinkEnt(value)
 	end
 end
 

--- a/lua/entities/gmod_wire_egp_hud/init.lua
+++ b/lua/entities/gmod_wire_egp_hud/init.lua
@@ -26,7 +26,7 @@ function ENT:Initialize()
 
 	WireLib.CreateInputs(self, {
 		"0 to 512 (If enabled, changes the resolution of the egp hud to be between 0 and 512 instead of the user's monitor's resolution.\nWill cause objects to look stretched out on most screens, so your UI will need to be designed with this in mind.\nIt's recommended to use the egpScrW, egpScrH, and egpScrSize functions instead.)",
-		"Vehicle [ENTITY]"
+		"Vehicles (Links all vehicles of passed array to this egp HUD) [ARRAY]",
 	})
 
 	WireLib.CreateOutputs(self, { "wirelink [WIRELINK]" })
@@ -43,12 +43,12 @@ end
 function ENT:TriggerInput( name, value )
 	if (name == "0 to 512") then
 		self:SetResolution(value ~= 0)
-	elseif name == "Vehicle" then
-		if not IsValid(value) then return end -- Only link if the input is valid. That way, it won't be unlinked if the wire is disconnected
-		if value:IsPlayer() then return end
-		if value:IsNPC() then return end
-
-		self:LinkEnt(value)
+	elseif name == "Vehicles" then
+		for k, v in ipairs( value ) do
+			if( TypeID(v) ~= TYPE_ENTITY ) then continue end
+			if( not IsValid(v) ) then continue end
+			self:LinkEnt( v )
+		end
 	end
 end
 

--- a/lua/entities/gmod_wire_pod.lua
+++ b/lua/entities/gmod_wire_pod.lua
@@ -163,7 +163,8 @@ function ENT:Initialize()
 		"Disable", "Crosshairs", "Brake", "Allow Buttons",
 		"Relative (If this is non-zero, the 'Bearing' and 'Elevation' outputs will be relative to the vehicle.)",
 		"Damage Health (Damages the driver's health.)", "Damage Armor (Damages the driver's armor.)", "Hide Player", "Hide HUD", "Show Cursor",
-		"Vehicle [ENTITY]"
+		"Vehicle [ENTITY]",
+		"Vehicles (Links all vehicles of passed array to this pod controller) [ARRAY]",
 	}
 
 	self.Inputs = WireLib.CreateInputs(self, inputs)
@@ -471,6 +472,12 @@ function ENT:TriggerInput(name, value)
 		if value:IsNPC() then return end
 
 		self:LinkEnt(value)
+	elseif name == "Vehicles" then
+		for k, v in ipairs( value ) do
+			if( TypeID(v) ~= TYPE_ENTITY ) then continue end
+			if( not IsValid(v) ) then continue end
+			self:LinkEnt( v )
+		end
 	end
 end
 

--- a/lua/entities/gmod_wire_pod.lua
+++ b/lua/entities/gmod_wire_pod.lua
@@ -467,7 +467,6 @@ function ENT:TriggerInput(name, value)
 	elseif name == "Show Cursor" then
 		self:SetShowCursor(value)
 	elseif name == "Vehicle" then
-		if not IsValid(value) then return end -- Only link if the input is valid. That way, it won't be unlinked if the wire is disconnected
 		if( TypeID(value) ~= TYPE_ENTITY ) then return end
 		if( not IsValid(value) ) then return end
 

--- a/lua/entities/gmod_wire_pod.lua
+++ b/lua/entities/gmod_wire_pod.lua
@@ -468,8 +468,8 @@ function ENT:TriggerInput(name, value)
 		self:SetShowCursor(value)
 	elseif name == "Vehicle" then
 		if not IsValid(value) then return end -- Only link if the input is valid. That way, it won't be unlinked if the wire is disconnected
-		if value:IsPlayer() then return end
-		if value:IsNPC() then return end
+		if( TypeID(value) ~= TYPE_ENTITY ) then return end
+		if( not IsValid(value) ) then return end
 
 		self:LinkEnt(value)
 	elseif name == "Vehicles" then


### PR DESCRIPTION
Adds a "Vehicle" input to Cam Controllers and EGP Huds, inline with Pod Controllers.

I understand this is somewhat redundant for Cam Controllers but I feel it's relevant.

I am working on some addon stuff where a seat may not exist on spawn (generated by another entity). In this case, wire I/O is a reliable way to persist linkages through dupes.