### PR TITLE
Limit egp font amount

### DIFF
--- a/lua/entities/gmod_wire_egp/lib/egplib/materials.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/materials.lua
@@ -3,15 +3,17 @@
 --------------------------------------------------------
 local EGP = EGP
 
+if SERVER then
+	EGP.PlayerFontCount = EGP.PlayerFontCount or {}
+end
+
 if CLIENT then
 	-- Valid fonts table
-	local MAX_EGP_FONTS = 150
 	EGP.ValidFonts_Lookup = EGP.ValidFonts_Lookup or {}
-	EGP.ValidFonts_Count = EGP.ValidFonts_Count or 0
 
 	function EGP.CreateFont( font, size )
 		local fontName = "WireEGP_" .. size .. "_" .. font
-		if not EGP.ValidFonts_Lookup[fontName] and EGP.ValidFonts_Count < MAX_EGP_FONTS then
+		if not EGP.ValidFonts_Lookup[fontName] then
 			local fontTable =
 			{
 				font=font,
@@ -22,9 +24,6 @@ if CLIENT then
 			}
 			surface.CreateFont( fontName, fontTable )
 			EGP.ValidFonts_Lookup[fontName] = true
-			EGP.ValidFonts_Count = EGP.ValidFonts_Count + 1
-		else
-			fontName = "WireEGP_18_WireGPU_ConsoleFont"
 		end
 
 		return fontName

--- a/lua/entities/gmod_wire_egp/lib/egplib/materials.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/materials.lua
@@ -3,9 +3,32 @@
 --------------------------------------------------------
 local EGP = EGP
 
--- Valid fonts table
-EGP.ValidFonts_Lookup = {}
-if (CLIENT) then
+if CLIENT then
+	-- Valid fonts table
+	local MAX_EGP_FONTS = 150
+	EGP.ValidFonts_Lookup = EGP.ValidFonts_Lookup or {}
+	EGP.ValidFonts_Count = EGP.ValidFonts_Count or 0
+
+	function EGP.CreateFont( font, size )
+		local fontName = "WireEGP_" .. size .. "_" .. font
+		if not EGP.ValidFonts_Lookup[fontName] and EGP.ValidFonts_Count < MAX_EGP_FONTS then
+			local fontTable =
+			{
+				font=font,
+				size = size,
+				weight = 800,
+				antialias = true,
+				additive = false
+			}
+			surface.CreateFont( fontName, fontTable )
+			EGP.ValidFonts_Lookup[fontName] = true
+			EGP.ValidFonts_Count = EGP.ValidFonts_Count + 1
+		else
+			fontName = "WireEGP_18_WireGPU_ConsoleFont"
+		end
+
+		return fontName
+	end
 
 	local type = type
 	local SetMaterial = surface.SetMaterial

--- a/lua/entities/gmod_wire_egp/lib/objects/text.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/text.lua
@@ -10,7 +10,6 @@ Obj.halign = 0
 local surface_SetTextPos
 local surface_DrawText
 local surface_SetTextColor
-local surface_CreateFont
 local surface_SetFont
 local surface_GetTextSize
 local cam_PushModelMatrix
@@ -38,19 +37,7 @@ function Obj:Draw(ent, drawMat)
 	if (self.text and #self.text>0) then
 		surface_SetTextColor( self.r, self.g, self.b, self.a )
 
-		local font = "WireEGP_" .. self.size .. "_" .. self.font
-		if (not EGP.ValidFonts_Lookup[font]) then
-			local fontTable =
-			{
-				font=self.font,
-				size = self.size,
-				weight = 800,
-				antialias = true,
-				additive = false
-			}
-			surface_CreateFont( font, fontTable )
-			EGP.ValidFonts_Lookup[font] = true
-		end
+		local font = EGP.CreateFont( self.font, self.size )
 		surface_SetFont( font )
 
 		if self.angle == 0 then

--- a/lua/entities/gmod_wire_egp/lib/objects/textlayout.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/textlayout.lua
@@ -23,19 +23,7 @@ function Obj:Draw(ent, drawMat)
 	if (self.text and #self.text>0) then
 		surface.SetTextColor( self.r, self.g, self.b, self.a )
 
-		local font = "WireEGP_" .. self.size .. "_" .. self.font
-		if (not EGP.ValidFonts_Lookup[font]) then
-			local fontTable =
-			{
-				font=self.font,
-				size = self.size,
-				weight = 800,
-				antialias = true,
-				additive = false
-			}
-			surface.CreateFont( font, fontTable )
-			EGP.ValidFonts_Lookup[font] = true
-		end
+		local font = EGP.CreateFont( self.font, self.size )
 		surface.SetFont( font )
 
 		--if (not self.layouter) then self.layouter = EGP:MakeTextLayouter() end -- Trying to make my own layouter...

--- a/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
@@ -252,9 +252,28 @@ end
 ----------------------------
 -- Font
 ----------------------------
+local function canCreateFont( ply, font, size )
+	size = size or 18
+
+	EGP.PlayerFontCount[ply:SteamID64()] = EGP.PlayerFontCount[ply:SteamID64()] or { fonts = {}, count = 0 }
+	local fontTable = EGP.PlayerFontCount[ply:SteamID64()] 
+
+	if fontTable.count >= 50 then return false end
+
+	local fontName = font .. size
+	if fontTable.fonts[fontName] then return true end
+
+	fontTable.count = fontTable.count + 1
+	fontTable.fonts[fontName] = true
+
+	return true
+end
+
 e2function void wirelink:egpFont( number index, string font )
 	if (!EGP:IsAllowed( self, this )) then return end
 	if #font > 30 then return self:throw("Font string is too long!", nil) end
+	if not canCreateFont( self.player, font ) then return self:throw("You have reached the maximum amount of fonts!", nil) end
+
 	local bool, k, v = hasObject(this, index)
 	if (bool) then
 		if v:EditObject({ font = font }) then EGP:DoAction( this, self, "SendObject", v ) Update(self,this) end
@@ -264,6 +283,8 @@ end
 e2function void wirelink:egpFont( number index, string font, number size )
 	if (!EGP:IsAllowed( self, this )) then return end
 	if #font > 30 then return self:throw("Font string is too long!", nil) end
+	if not canCreateFont( self.player, font, size ) then return self:throw("You have reached the maximum amount of fonts!", nil) end
+
 	local bool, k, v = hasObject(this, index)
 	if (bool) then
 		if v:EditObject({ font = font, size = size }) then EGP:DoAction( this, self, "SendObject", v ) Update(self,this) end


### PR DESCRIPTION
Limits the amount of fonts a player can make as gmod doesn't clean them up.
Also adds `EGP.CreateFont` to reduce duplicate code