### PR TITLE
Remove dead COLOSSAL_SANDBOX checks

### DIFF
--- a/lua/entities/gmod_wire_gps.lua
+++ b/lua/entities/gmod_wire_gps.lua
@@ -8,7 +8,6 @@ if CLIENT then
 		BaseClass.Think(self)
 
 		local pos = self:GetPos()
-		if (COLOSSAL_SANDBOX) then pos = pos * 6.25 end
 		local txt = string.format( "Position = %0.3f, %0.3f, %0.3f", math.Round(pos.x,3),math.Round(pos.y,3),math.Round(pos.z,3) )
 
 		self:SetOverlayText( txt )
@@ -54,13 +53,13 @@ function ENT:Think()
 	BaseClass.Think(self)
 
 	local pos = self:GetPos()
-	if (COLOSSAL_SANDBOX) then pos = pos * 6.25 end
 
 	Wire_TriggerOutput(self, "X", pos.x)
 	Wire_TriggerOutput(self, "Y", pos.y)
 	Wire_TriggerOutput(self, "Z", pos.z)
 	Wire_TriggerOutput(self, "Vector", pos)
 	Wire_TriggerOutput(self, "Current Memory", self.arrayindex)
+	
 	if self.arrayindex > 0 then
 		Wire_TriggerOutput(self, "Recall X", self.storedpositions[self.arrayindex].x)
 		Wire_TriggerOutput(self, "Recall Y", self.storedpositions[self.arrayindex].y)

--- a/lua/entities/gmod_wire_gps.lua
+++ b/lua/entities/gmod_wire_gps.lua
@@ -37,7 +37,7 @@ function ENT:Setup()
 	self.Value = 0
 	self.PrevOutput = nil
 
-	//self:ShowOutput(0, 0, 0)
+	--self:ShowOutput(0, 0, 0)
 	Wire_TriggerOutput(self, "X", 0)
 	Wire_TriggerOutput(self, "Y", 0)
 	Wire_TriggerOutput(self, "Z", 0)
@@ -59,7 +59,7 @@ function ENT:Think()
 	Wire_TriggerOutput(self, "Z", pos.z)
 	Wire_TriggerOutput(self, "Vector", pos)
 	Wire_TriggerOutput(self, "Current Memory", self.arrayindex)
-	
+
 	if self.arrayindex > 0 then
 		Wire_TriggerOutput(self, "Recall X", self.storedpositions[self.arrayindex].x)
 		Wire_TriggerOutput(self, "Recall Y", self.storedpositions[self.arrayindex].y)
@@ -86,7 +86,7 @@ function ENT:TriggerInput(iname, value)
 	elseif (iname == "Next") then
 		if (value ~= 0) then
 			if # self.storedpositions > 0 then
-				if not (self.arrayindex >= # self.storedpositions) then
+				if self.arrayindex > #self.storedpositions then
 					self.arrayindex = self.arrayindex+1;
 				else
 					self.arrayindex = 1; --loop back

--- a/lua/entities/gmod_wire_gps.lua
+++ b/lua/entities/gmod_wire_gps.lua
@@ -86,7 +86,7 @@ function ENT:TriggerInput(iname, value)
 	elseif (iname == "Next") then
 		if (value ~= 0) then
 			if # self.storedpositions > 0 then
-				if self.arrayindex > #self.storedpositions then
+				if self.arrayindex < #self.storedpositions then
 					self.arrayindex = self.arrayindex+1;
 				else
 					self.arrayindex = 1; --loop back

--- a/lua/entities/gmod_wire_ranger.lua
+++ b/lua/entities/gmod_wire_ranger.lua
@@ -206,12 +206,6 @@ function ENT:Think()
 		end
 	end
 
-	if (COLOSSAL_SANDBOX) then
-		vel = vel * 6.25
-		pos = pos * 6.25
-		dist = dist * 6.25
-	end
-
 	self:TriggerOutput(dist, pos, vel, ang, col, val, sid, uid, ent, hnrm, trace)
 	self:ShowOutput(dist, pos, vel, ang, col, val, sid, uid, ent, hnrm, trace)
 


### PR DESCRIPTION
I don't see the point in these checks, considering that this is some old gamemode and this check is only in 2 entities. So it won't work anyway