### PR TITLE
entityRemoved event

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -1306,6 +1306,14 @@ E2Lib.registerEvent("entityCreated", {
 	{ "Entity", "e" }
 })
 
+hook.Add("EntityRemoved", "E2_entityRemoved", function(ent)
+	E2Lib.triggerEvent("entityRemoved", { ent })
+end)
+
+E2Lib.registerEvent("entityRemoved", {
+	{ "Entity", "e" }
+})
+
 local function upperfirst( word )
 	return word:Left(1):upper() .. word:Right(-2):lower()
 end


### PR DESCRIPTION
Adds a simple hook that, for example, allows you to track the deletion of an entity or something similar