### PR TITLE
Add input strings limit for string_explode gate action

### DIFF
--- a/lua/wire/gates/string.lua
+++ b/lua/wire/gates/string.lua
@@ -113,6 +113,11 @@ GateActions["string_explode"] = {
 	output = function(gate, A, B)
 		if not A then A = "" end
 		if not B then B = "" end
+		if  (A and #A or 0)
+		  + (B and #B or 0)  > MAX_LEN
+		then
+			return false
+		end
 		return string.Explode(B,A)
 	end,
 	label = function(Out, A, B)


### PR DESCRIPTION
Large maliciously formed strings when fed into string_explode gate can overflow the server RAM.

![Screenshot 2025-03-27 025934](https://github.com/user-attachments/assets/0cdb07f6-dddf-47c1-b92e-5bead446f30b)

There is MAX_LEN constant that has been used for string_concat, string_replace and string_repeat but not for string_replace, which is an oversight. Large strings can be fed into the string_explode to easily fill up more than 4GB of server RAM. They can be generated either via expression2, or using wire constant values in pair with maliciously formed (adv)dupe to crash the server.

Limiting input string length by MAX_LEN fixes the issue.