### PR TITLE
Check isentity on owner in DrawWorldTip

### DIFF
--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -159,7 +159,7 @@ if CLIENT then
 		local name
 		if CPPI then
 			local owner = self:CPPIGetOwner()
-			name = string.format("(%s)", (owner and owner:IsPlayer()) and owner:GetName() or "World")
+			name = string.format("(%s)", (isentity(owner) and owner:IsPlayer()) and owner:GetName() or "World")
 		else
 			name = "(" .. self:GetPlayerName() .. ")"
 		end


### PR DESCRIPTION
PatchProtect returns a number (CPPI.CPPI_DEFER) when waiting to receive the owner over the network