### PR TITLE
Fix rare lua error

### DIFF
--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -711,7 +711,7 @@ end)
 
 hook.Add("PlayerAuthed", "Wire_Expression2_Player_Authed", function(ply, sid, uid)
 	for _, ent in ipairs(ents.FindByClass("gmod_wire_expression2")) do
-		if (ent.uid == uid) then
+		if ent.uid == uid and ent.context then
 			ent.context.player = ply
 			ent.player = ply
 			ent:SetNWEntity("player", ply)


### PR DESCRIPTION
I have noticed this error from time to time after enabling `wire_expression2_pause_on_disconnect`
```
[wire-master] addons/wire-master/lua/entities/gmod_wire_expression2/init.lua:713: attempt to index field 'context' (a nil value)
1. unknown - addons/wire-master/lua/entities/gmod_wire_expression2/init.lua:713
 2. unknown - addons/hook-library-master/lua/includes/modules/hook.lua:313
  3. UniqueID - [C]:-1
   4. echoToAdmins - addons/ulx-master/lua/ulx/log.lua:164
    5. old_func - addons/ulx-master/lua/ulx/log.lua:202
     6. unknown - addons/hook-library-master/lua/includes/modules/hook.lua:208
      7. unknown - addons/hook-library-master/lua/includes/modules/hook.lua:313
```