### PR TITLE
Fix lua error

### DIFF
--- a/lua/entities/gmod_wire_colorer.lua
+++ b/lua/entities/gmod_wire_colorer.lua
@@ -49,7 +49,6 @@ if CLIENT then
 		-- get colors
 		local data = self:GetOverlayData()
 		local inColor = data and Color(data.r or 255,data.g or 255,data.b or 255,data.a or 255) or Color(255, 255, 255)
-		local inColor = data and Color(data.r or 255,data.g or 255,data.b or 255,data.a or 255) or Color(255, 255, 255)
 
 		local trace = util.TraceLine( { start = self:GetPos(), endpos = self:GetPos() + self:GetUp() * self:GetBeamLength(), filter = {self} } )
 

--- a/lua/entities/gmod_wire_colorer.lua
+++ b/lua/entities/gmod_wire_colorer.lua
@@ -48,7 +48,7 @@ if CLIENT then
 	function ENT:DrawWorldTipBody( pos )
 		-- get colors
 		local data = self:GetOverlayData()
-		local inColor = Color(data.r or 255,data.g or 255,data.b or 255,data.a or 255)
+		local inColor = data and Color(data.r or 255,data.g or 255,data.b or 255,data.a or 255) or Color(255, 255, 255)
 
 		local trace = util.TraceLine( { start = self:GetPos(), endpos = self:GetPos() + self:GetUp() * self:GetBeamLength(), filter = {self} } )
 

--- a/lua/entities/gmod_wire_colorer.lua
+++ b/lua/entities/gmod_wire_colorer.lua
@@ -48,7 +48,7 @@ if CLIENT then
 	function ENT:DrawWorldTipBody( pos )
 		-- get colors
 		local data = self:GetOverlayData()
-		local inColor = data and Color(data.r or 255,data.g or 255,data.b or 255,data.a or 255) or Color(255, 255, 255)
+		local inColor = istable(data) and Color(data.r or 255,data.g or 255,data.b or 255,data.a or 255) or Color(255, 255, 255)
 
 		local trace = util.TraceLine( { start = self:GetPos(), endpos = self:GetPos() + self:GetUp() * self:GetBeamLength(), filter = {self} } )
 

--- a/lua/entities/gmod_wire_indicator.lua
+++ b/lua/entities/gmod_wire_indicator.lua
@@ -84,7 +84,7 @@ if CLIENT then
 		-- Get colors
 		local data = self:GetOverlayData()
 
-		if data then
+		if istable(data) then
 			-- Merge the data onto the entity itself.
 			-- This allows us to use the same references as serverside
 			for k, v in pairs(data) do self[k] = v end

--- a/lua/entities/gmod_wire_indicator.lua
+++ b/lua/entities/gmod_wire_indicator.lua
@@ -84,9 +84,11 @@ if CLIENT then
 		-- Get colors
 		local data = self:GetOverlayData()
 
-		-- Merge the data onto the entity itself.
-		-- This allows us to use the same references as serverside
-		for k,v in pairs( data ) do self[k] = v end
+		if data then
+			-- Merge the data onto the entity itself.
+			-- This allows us to use the same references as serverside
+			for k, v in pairs(data) do self[k] = v end
+		end
 
 		-- A
 		local color_text = string.format("A color: %d,%d,%d,%d\nA value: %d",self.ar,self.ag,self.ab,self.aa,self.a)


### PR DESCRIPTION
As I understand it, self.OverlayData can sometimes be nil, so need to check it before iteration

Fixes:
```
[wire-master] addons/wire-master/lua/entities/gmod_wire_indicator.lua:89: bad argument wiremod#1 to 'pairs' (table expected, got nil)
1. pairs - [C]:-1
 2. DrawWorldTipBody - addons/wire-master/lua/entities/gmod_wire_indicator.lua:89
  3. DrawWorldTip - addons/wire-master/lua/entities/base_wire_entity.lua:203
   4. unknown - addons/wire-master/lua/entities/base_wire_entity.lua:227
    5. unknown - addons/hook-library-master/lua/includes/modules/hook.lua:313
```