### PR TITLE
Fix lua error (again)

### DIFF
--- a/lua/entities/gmod_wire_indicator.lua
+++ b/lua/entities/gmod_wire_indicator.lua
@@ -88,6 +88,19 @@ if CLIENT then
 			-- Merge the data onto the entity itself.
 			-- This allows us to use the same references as serverside
 			for k, v in pairs(data) do self[k] = v end
+		else
+			-- Set the data to default to draw the body anyway
+			self.a = 0
+			self.ar = 0
+			self.ag = 0
+			self.ab = 0
+			self.aa = 0
+			self.b = 0
+			self.br = 0
+			self.bg = 0
+			self.bb = 0
+			self.ba = 0
+			self.value = 0
 		end
 
 		-- A


### PR DESCRIPTION
In my previous PR I didn't take into account that the code will still try to access the entity values, but if OverlayData == nil, they won't be set and an error will be thrown. So I decided to set them to the default ones
```
[wire-master] addons/wire-master/lua/entities/gmod_wire_indicator.lua:94: bad argument #2 to 'format' (number expected, got nil)
1. format - [C]:-1
 2. DrawWorldTipBody - addons/wire-master/lua/entities/gmod_wire_indicator.lua:94
  3. DrawWorldTip - addons/wire-master/lua/entities/base_wire_entity.lua:203
   4. unknown - addons/wire-master/lua/entities/base_wire_entity.lua:227
    5. unknown - addons/hook-library-master/lua/includes/modules/hook.lua:313
```