### PR TITLE
Fix digital screen not updating/marking changes when clearing rows and columns.

### DIFF
--- a/lua/entities/gmod_wire_digitalscreen/init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/init.lua
@@ -243,19 +243,25 @@ end
 function ENT:ClearPixel(i)
 	if self.Memory[1048569] == 1 then
 		-- R G B mode
-		self.Memory[i*3] = 0
-		self.Memory[i*3+1] = 0
-		self.Memory[i*3+2] = 0
+		i = i * 3
+		self.Memory[i] = 0
+		self.Memory[i+1] = 0
+		self.Memory[i+2] = 0
+		self:MarkCellChanged(i)
+		self:MarkCellChanged(i+1)
+		self:MarkCellChanged(i+2)
 		return
 	end
 
 	-- other modes
 	self.Memory[i] = 0
+	self:MarkCellChanged(i)
 end
 
 function ENT:ClearCellRange(start, length)
 	for i = start, start + length - 1 do
 		self.Memory[i] = 0
+		self:MarkCellChanged(i)
 	end
 end
 


### PR DESCRIPTION
Typically when you write to the digital screen (via hispeed) it marks that the cell has changed via *MarkCellChanged*. Whenever you clear a row or column it would write to the memory, but it would not mark the cell as changed. I've tested both rows and columns on single cell and the 3 cell color mode.