### PR TITLE
Fix NULL error

### DIFF
--- a/lua/entities/gmod_wire_explosive.lua
+++ b/lua/entities/gmod_wire_explosive.lua
@@ -132,7 +132,8 @@ end
 
 function ENT:OnTakeDamage( dmginfo )
 
-	if ( dmginfo:GetInflictor():GetClass() == "gmod_wire_explosive"  and not self.Affectother ) then return end
+	local inflictor = dmginfo:GetInflictor()
+	if inflictor:IsValid() and inflictor:GetClass() == "gmod_wire_explosive" and not self.Affectother then return end
 
 	if ( not self.Notaffected ) then self:TakePhysicsDamage( dmginfo ) end
 


### PR DESCRIPTION
Fixes:
```
[wire-master] addons/wire-master/lua/entities/gmod_wire_explosive.lua:135: Tried to use a NULL entity!
1. GetClass - [C]:-1
 2. unknown - addons/wire-master/lua/entities/gmod_wire_explosive.lua:135
  3. TakeDamageInfo - [C]:-1
   4. applyDamage - starfall/libs_sv/entities.lua:312
    5. unknown - SF:aimbot.txt:52
     6. xpcall - [C]:-1
      7. run - addons/starfallex-master/lua/starfall/instance.lua:568
       8. runScriptHook - addons/starfallex-master/lua/starfall/instance.lua:599
        9. unknown - addons/starfallex-master/lua/starfall/sflib.lua:1098
         10. unknown - addons/hook-library-master/lua/includes/modules/hook.lua:313
          11. FireBullets - [C]:-1
           12. FireWeapon - lua/weapons/simple_base/sh_attack.lua:124
            13. PrimaryFire - lua/weapons/simple_base/sh_attack.lua:43
             14. unknown - lua/weapons/simple_base/shared.lua:224
```
If you deal damage yourself via `CTakeDamageInfo` and do not set the inflictor, it will be `NULL`