### PR TITLE
Fix NULL error

### DIFF
--- a/lua/entities/gmod_wire_adv_emarker.lua
+++ b/lua/entities/gmod_wire_adv_emarker.lua
@@ -78,13 +78,19 @@ function ENT:CheckEnt( ent )
 	return false, 0
 end
 
-function ENT:LinkEnt( ent )
-	if (self:CheckEnt( ent )) then return false	end
-	self.Marks[#self.Marks+1] = ent
+function ENT:LinkEnt(ent)
+	if self:CheckEnt(ent) then return false	end
+
+	table.insert(self.Marks, ent)
+
 	ent:CallOnRemove("AdvEMarker.Unlink", function(ent)
-		self:UnlinkEnt(ent)
+		if self:IsValid() then
+			self:UnlinkEnt(ent)
+		end
 	end)
+
 	self:UpdateOutputs()
+
 	return true
 end
 


### PR DESCRIPTION
Just got this error causing `player/ents.Iterator` to explode
```
[wire-master] addons/wire-master/lua/entities/gmod_wire_adv_emarker.lua:85: attempt to call method 'UnlinkEnt' (a nil value)
1. Function - addons/wire-master/lua/entities/gmod_wire_adv_emarker.lua:85
 2. unknown - lua/includes/extensions/entity.lua:158
  3. unknown - addons/hook-library-master/lua/includes/modules/hook.lua:313
```