### PR TITLE
Make `entityDamage` event use `PostEntityTakeDamage`

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/damage.lua
+++ b/lua/entities/gmod_wire_expression2/core/damage.lua
@@ -132,6 +132,6 @@ E2Lib.registerEvent("entityDamage", {
 	{ "Damage", "xdm" }
 })
 
-hook.Add("PostEntityTakeDamage", "E2_entityDamage", function(victim, dmg, took)
+hook.Add("PostEntityTakeDamage", "E2_entityDamage", function(victim, dmg)
 	E2Lib.triggerEvent("entityDamage", { victim, dmg })
 end)

--- a/lua/entities/gmod_wire_expression2/core/damage.lua
+++ b/lua/entities/gmod_wire_expression2/core/damage.lua
@@ -129,10 +129,9 @@ end
 
 E2Lib.registerEvent("entityDamage", {
 	{ "Victim", "e" },
-	{ "Damage", "xdm" },
-	{ "Took", "n" }
+	{ "Damage", "xdm" }
 })
 
 hook.Add("PostEntityTakeDamage", "E2_entityDamage", function(victim, dmg, took)
-	E2Lib.triggerEvent("entityDamage", { victim, dmg, took and 1 or 0 })
+	E2Lib.triggerEvent("entityDamage", { victim, dmg })
 end)

--- a/lua/entities/gmod_wire_expression2/core/damage.lua
+++ b/lua/entities/gmod_wire_expression2/core/damage.lua
@@ -129,9 +129,10 @@ end
 
 E2Lib.registerEvent("entityDamage", {
 	{ "Victim", "e" },
-	{ "Damage", "xdm" }
+	{ "Damage", "xdm" },
+	{ "Took", "n" }
 })
 
-hook.Add("EntityTakeDamage", "E2_entityDamage", function(victim, dmg)
+hook.Add("PostEntityTakeDamage", "E2_entityDamage", function(victim, dmg, took)
 	E2Lib.triggerEvent("entityDamage", { victim, dmg })
 end)

--- a/lua/entities/gmod_wire_expression2/core/damage.lua
+++ b/lua/entities/gmod_wire_expression2/core/damage.lua
@@ -134,5 +134,5 @@ E2Lib.registerEvent("entityDamage", {
 })
 
 hook.Add("PostEntityTakeDamage", "E2_entityDamage", function(victim, dmg, took)
-	E2Lib.triggerEvent("entityDamage", { victim, dmg })
+	E2Lib.triggerEvent("entityDamage", { victim, dmg, took and 1 or 0 })
 end)


### PR DESCRIPTION
The main reason for this event is to process damage taken, not to change it. So for more accurate information, it is better to use `PostEntityTakeDamage`