### PR TITLE
Mitigate performance issues with arrays and tables

### DIFF
--- a/data/expression2/tests/regressions/3325.txt
+++ b/data/expression2/tests/regressions/3325.txt
@@ -1,0 +1,65 @@
+## SHOULD_PASS:EXECUTE
+
+# Tables
+
+let A = table(1, 2, 3, "four", vec(5))
+
+let B = table(1 = 1, 2 = 2, 3 = 3, 4 = "four", 5 = vec(5))
+
+let Count = 0
+
+function err(K:number, X:string, V:string) {
+    return format("Failed at key %d with values [%s, %s]", K, X, V)
+}
+
+foreach(K:number, V:number = B) {
+    Count += K
+    let X = A[K, number]
+    assert(X == V, err(K, toString(X), toString(V)))
+}
+
+assert(Count == 6)
+
+foreach(K:number, V:string = B) {
+    Count += K
+    let X = A[K, string]
+    assert(X == V, err(K, X, V))
+}
+
+assert(Count == 10)
+
+foreach(K:number, V:vector = B) {
+    Count += K
+    let X = A[K, vector]
+    assert(X == V, err(K, toString(X), toString(V)))
+}
+
+assert(Count == 15)
+
+# Arrays
+
+let C = array(1, 2, 3, "four", vec(5))
+
+let D = array(1 = 1, 2 = 2, 3 = 3, 4 = "four", 5 = vec(5))
+
+Count = 0
+
+foreach(K:number, V:number = D) {
+    Count += K
+    let X = C[K, number]
+    assert(X == V, err(K, toString(X), toString(V)))
+}
+
+assert(Count == 6)
+
+if(1) {
+    let X = C[4, string]
+    let V = D[4, string]
+    assert(X == V, err(4, X, V))
+}
+
+if(1) {
+    let X = C[5, vector]
+    let V = D[5, vector]
+    assert(X == V, err(5, toString(X), toString(V)))
+}

--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -923,6 +923,13 @@ function Parser:Expr15()
 
 	local fn = self:Consume(TokenVariant.LowerIdent)
 	if fn then
+		-- Transform key value
+		if fn.value == "array" then
+			return Node.new(NodeVariant.ExprArray, self:ArgumentsKV(Grammar.LParen, Grammar.RParen) or self:Arguments(), fn.trace:stitch(self:Prev().trace))
+		elseif fn.value == "table" then
+			return Node.new(NodeVariant.ExprTable, self:ArgumentsKV(Grammar.LParen, Grammar.RParen) or self:Arguments(), fn.trace:stitch(self:Prev().trace))
+		end
+
 		return Node.new(NodeVariant.ExprCall, { fn, self:Arguments() }, fn.trace:stitch(self:Prev().trace))
 	end
 

--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -923,13 +923,6 @@ function Parser:Expr15()
 
 	local fn = self:Consume(TokenVariant.LowerIdent)
 	if fn then
-		-- Transform key value
-		if fn.value == "array" then
-			return Node.new(NodeVariant.ExprArray, self:ArgumentsKV(Grammar.LParen, Grammar.RParen) or self:Arguments(), fn.trace:stitch(self:Prev().trace))
-		elseif fn.value == "table" then
-			return Node.new(NodeVariant.ExprTable, self:ArgumentsKV(Grammar.LParen, Grammar.RParen) or self:Arguments(), fn.trace:stitch(self:Prev().trace))
-		end
-
 		return Node.new(NodeVariant.ExprCall, { fn, self:Arguments() }, fn.trace:stitch(self:Prev().trace))
 	end
 

--- a/lua/entities/gmod_wire_expression2/core/array.lua
+++ b/lua/entities/gmod_wire_expression2/core/array.lua
@@ -48,7 +48,7 @@ __e2setcost(1)
 e2function array array(...args)
 	-- Assume the arguments passed to the array do not contain illegal array types,
 	-- from the compile time checks.
-	self.prf = self.prf + #args * (1 / 4)
+	self.prf = self.prf + #args * (1 / 4) + 50
 
 	return args
 end

--- a/lua/entities/gmod_wire_expression2/core/array.lua
+++ b/lua/entities/gmod_wire_expression2/core/array.lua
@@ -48,7 +48,7 @@ __e2setcost(1)
 e2function array array(...args)
 	-- Assume the arguments passed to the array do not contain illegal array types,
 	-- from the compile time checks.
-	self.prf = self.prf + #args * (1 / 4) + 50
+	self.prf = self.prf + #args * (1 / 4)
 
 	return args
 end

--- a/lua/entities/gmod_wire_expression2/core/table.lua
+++ b/lua/entities/gmod_wire_expression2/core/table.lua
@@ -397,8 +397,6 @@ __e2setcost(1)
 
 -- Creates a table
 e2function table table(...tbl)
-	table_check_perf(self, tbl)
-
 	local ret = newE2Table()
 	if #tbl == 0 then return ret end -- Don't construct table
 
@@ -414,8 +412,10 @@ e2function table table(...tbl)
 			ret.ntypes[k] = tid
 		end
 	end
-
 	ret.size = size
+
+	table_perf_check(self, ret)
+
 	return ret
 end
 

--- a/lua/entities/gmod_wire_expression2/core/table.lua
+++ b/lua/entities/gmod_wire_expression2/core/table.lua
@@ -346,8 +346,8 @@ end
 --- @param tbl E2Table
 --- @return number size # The size of the table
 --- @return number perf # The adjusted op count after increasing
-local function table_perf_check(self, tbl)
-	local size = tbl.size
+local function table_perf_check(self, tbl, size)
+	size = size or tbl.size
 	return size, num_perf_check(self, size)
 end
 
@@ -397,6 +397,8 @@ __e2setcost(1)
 
 -- Creates a table
 e2function table table(...tbl)
+	table_perf_check(self, v, 100) -- Table construction is expensive
+
 	local ret = newE2Table()
 	if #tbl == 0 then return ret end -- Don't construct table
 
@@ -413,7 +415,6 @@ e2function table table(...tbl)
 		end
 	end
 	ret.size = size
-
 	table_perf_check(self, ret)
 
 	return ret

--- a/lua/entities/gmod_wire_expression2/core/table.lua
+++ b/lua/entities/gmod_wire_expression2/core/table.lua
@@ -397,7 +397,7 @@ __e2setcost(1)
 
 -- Creates a table
 e2function table table(...tbl)
-	num_perf_check(self, 100) -- Table construction is expensive
+	num_perf_check(self, #tbl)
 
 	local ret = newE2Table()
 	if #tbl == 0 then return ret end -- Don't construct table
@@ -415,7 +415,6 @@ e2function table table(...tbl)
 		end
 	end
 	ret.size = size
-	table_perf_check(self, ret)
 
 	return ret
 end

--- a/lua/entities/gmod_wire_expression2/core/table.lua
+++ b/lua/entities/gmod_wire_expression2/core/table.lua
@@ -346,8 +346,8 @@ end
 --- @param tbl E2Table
 --- @return number size # The size of the table
 --- @return number perf # The adjusted op count after increasing
-local function table_perf_check(self, tbl, size)
-	size = size or tbl.size
+local function table_perf_check(self, tbl)
+	local size = tbl.size
 	return size, num_perf_check(self, size)
 end
 
@@ -397,7 +397,7 @@ __e2setcost(1)
 
 -- Creates a table
 e2function table table(...tbl)
-	table_perf_check(self, v, 100) -- Table construction is expensive
+	num_perf_check(self, 100) -- Table construction is expensive
 
 	local ret = newE2Table()
 	if #tbl == 0 then return ret end -- Don't construct table


### PR DESCRIPTION
- Expressions were processed exponentially by the parser because it would reset its progress on certain fail states. This is fixed by caching previously met expressions.
- E2 cost for creating tables is now dynamically generated and gated as should be expected