### PR TITLE
Fix E2 test regressions

### DIFF
--- a/data/expression2/tests/runtime/libraries/serialization.txt
+++ b/data/expression2/tests/runtime/libraries/serialization.txt
@@ -1,17 +1,17 @@
 ## SHOULD_PASS:EXECUTE
 
-assert( jsonEncode( table(1 = 1, 2 = 2) ) == "[1.0,2.0]" )
+assert( jsonEncode( table(1 = 1, 2 = 2) ) == "[1,2]" )
 
-assert( jsonEncode( table("foo", "bar", 1, "baz", array(1, 2, 3)) ) == "[\"foo\",\"bar\",1.0,\"baz\",[1.0,2.0,3.0]]" )
+assert( jsonEncode( table("foo", "bar", 1, "baz", array(1.1, 2.2, 3.3)) ) == "[\"foo\",\"bar\",1,\"baz\",[1.1,2.2,3.3]]" )
 
-const T0 = jsonDecode("[\"foo\",\"bar\",1.0,\"baz\",[1.0,2.0,3.0]]")
+const T0 = jsonDecode("[\"foo\",\"bar\",1,\"baz\",[1.1,2.2,3.3]]")
 assert(T0[1, string] == "foo")
 assert(T0[2, string] == "bar")
 assert(T0[3, number] == 1)
 assert(T0[4, string] == "baz")
-assert(T0[5, table][1, number] == 1) # Deserializes any table as table
-assert(T0[5, table][2, number] == 2)
-assert(T0[5, table][3, number] == 3)
+assert(T0[5, table][1, number] == 1.1) # Deserializes any table as table
+assert(T0[5, table][2, number] == 2.2)
+assert(T0[5, table][3, number] == 3.3)
 
 assert( vonEncode(array(1, 2, noentity())) == "n1;2;e0;" )
 

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -1494,7 +1494,11 @@ function E2Lib.compileScript(code, owner)
 		else
 			local _, why, trace = E2Lib.unpackException(why)
 
-			if trace then
+			if why == "exit" then
+				return true
+			elseif why == "perf" then
+				return false,  "tick quota exceeded (at line " .. trace.start_line .. ", char " .. trace.start_col .. ")"
+			elseif trace then
 				return false, "Runtime error: '" .. why .. "' at line " .. trace.start_line .. ", col " .. trace.start_col
 			else
 				return false, why


### PR DESCRIPTION
Two tests were failing consistently for me. It seems to just be small stuff.
- Changed JSON encoding test to new way JSON serializer encodes integers and also added explicit floats just in case
- Changed `E2Lib.compileScript` to filter out exit and perf errors, because normal E2s do this