### PR TITLE
Allow setName to be used on vehicles

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/selfaware.lua
+++ b/lua/entities/gmod_wire_expression2/core/selfaware.lua
@@ -130,19 +130,21 @@ local function doSetName(self, this, name)
 
 		this:SetNWString("name", name)
 		this:SetOverlayText(name)
+	elseif this:IsVehicle() and this.VehicleTable and this.VehicleTable.Name then
+		this.VehicleTable.Name = name
 	else
 		if #name > 200 then name = string.sub(name, 1, 200) end
 		if string.find(name, "[\n\r\"]") then return self:throw("setName name contains illegal characters!") end
 		if this:GetNWString("WireName") == name then return end
 		this:SetNWString("WireName", name)
 		duplicator.StoreEntityModifier(this, "WireName", { name = name })
-
 	end
 
 	data_SetName._n = totalRuns + 1
-
 	self.prf = self.prf + (totalRuns - 1) ^ 2 * totalChars -- Disincentivize repeated use
+
 end
+
 
 __e2setcost(100)
 


### PR DESCRIPTION
gmod allows for custom names to be displayed if a vehicle with a set name kills another entity as shown in the screenshot

https://github.com/Facepunch/garrysmod/blob/a453ed844691d396b7fd848074b965dfca0ef147/garrysmod/gamemodes/base/gamemode/npc.lua#L64

![image](https://github.com/user-attachments/assets/574f833a-dc85-41f9-a5bb-1f1c3153b1d5)

![image](https://github.com/user-attachments/assets/4beeac0a-b58d-48a9-8f0e-306b7aa53435)