### PR TITLE
Improved the message that appears when preprocessed E2 core has invalid syntax

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/extloader.lua
+++ b/lua/entities/gmod_wire_expression2/core/extloader.lua
@@ -95,6 +95,10 @@ local function e2_include_pass2(name, luaname, contents)
 	if not preprocessedSource then return include(name) end
 
 	local func = CompileString(preprocessedSource, luaname)
+	if func == nil then
+		error("File not compiled, see previous error", 0)
+	end
+
 
 	local ok, err = pcall(func)
 	if not ok then -- an error occured while executing


### PR DESCRIPTION
Without this PR 'attempt to call nil value' error appears.