### PR TITLE
Fix CalcOutput call

### DIFF
--- a/lua/entities/gmod_wire_gate.lua
+++ b/lua/entities/gmod_wire_gate.lua
@@ -101,7 +101,7 @@ function ENT:Think()
 	local action = selfTbl.Action
 
 	if action and action.timed then
-		selfTbl.CalcOutput(self, selfTbl)
+		selfTbl.CalcOutput(self, nil, selfTbl)
 		selfTbl.ShowOutput(self, selfTbl)
 		self:NextThink(CurTime() + 0.02)
 


### PR DESCRIPTION
Seems to fix:
![image](https://github.com/user-attachments/assets/a7b440a1-8e34-4012-bdf0-ecf23e9e9cd7)


Happened after pulling latest `wire`, likely traces to:
https://github.com/wiremod/wire/commit/63eb7b3e8a2eeb54ad86e577b6bbef147b046d73#r158915695