### PR TITLE
Fix issues with EGP Objects getting nil arguments

### DIFF
--- a/lua/entities/gmod_wire_egp/lib/egplib/objects.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/objects.lua
@@ -34,8 +34,10 @@ else
 end
 
 --- Used in a net writing context to transmit the object's entire data.
+---@param _ent Entity The EGP entity
+---@param _ply Player The sending player
 ---@see EGPObject.Receive
-function baseObj:Transmit()
+function baseObj:Transmit(_ent, _ply)
 	EGP.SendPosAng(self)
 	EGP.SendColor(nil, self)
 	EGP.SendMaterial(nil, self)

--- a/lua/entities/gmod_wire_egp/lib/egplib/umsgsystem.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/umsgsystem.lua
@@ -47,6 +47,8 @@ function EGP.umsg.End( ent )
 			EGP.IntervalCheck[CurSender].bytes = EGP.IntervalCheck[CurSender].bytes + bytes
 		else
 			ErrorNoHalt("Tried to end EGP net message outside of net context?")
+			CurSender = NULL
+			return
 		end
 
 		if ent.Users then

--- a/lua/entities/gmod_wire_egp/lib/objects/poly.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/poly.lua
@@ -21,7 +21,7 @@ Obj.Draw = function( self )
 		render.CullMode(MATERIAL_CULLMODE_CCW)
 	end
 end
-Obj.Transmit = function( self, Ent, ply )
+Obj.Transmit = function(self, ent, ply)
 	net.WriteBool(self.VerticesUpdate)
 	if self.VerticesUpdate then
 		if (#self.vertices <= 255) then
@@ -38,7 +38,7 @@ Obj.Transmit = function( self, Ent, ply )
 			EGP:InsertQueue( Ent, ply, EGP._SetVertex, "SetVertex", self.index, self.vertices )
 		end
 	end
-	base.Transmit(self)
+	base.Transmit(self, ent, ply)
 end
 
 Obj.Receive = function( self )

--- a/lua/entities/gmod_wire_egp/lib/objects/polyoutline.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/polyoutline.lua
@@ -13,9 +13,9 @@ Obj.Draw = function( self )
 	end
 end
 
-Obj.Transmit = function( self, Ent, ply )
+Obj.Transmit = function(self, ent, ply)
 	net.WriteInt(self.size, 16)
-	base.Transmit(self)
+	base.Transmit(self, ent, ply)
 end
 
 Obj.Receive = function( self )

--- a/lua/entities/gmod_wire_egp/lib/objects/textlayout.lua
+++ b/lua/entities/gmod_wire_egp/lib/objects/textlayout.lua
@@ -80,9 +80,9 @@ function Obj:Draw(ent, drawMat)
 		]]
 	end
 end
-Obj.Transmit = function( self, Ent, ply )
+Obj.Transmit = function(self, ent, ply)
 	EGP.SendSize(self)
-	base.Transmit(self)
+	base.Transmit(self, ent, ply)
 end
 Obj.Receive = function( self )
 	local tbl = {}


### PR DESCRIPTION
This PR fixes two issues with the EGP queue breaking when transmitting certain objects.

- Fixes baseclass calls that would omit necessary arguments that needed them
- Added early return to `EGP.umsg.End` if it detects it's outside of a net context