### PR TITLE
Fix issues with global vertices/position on EGP polys

### DIFF
--- a/lua/entities/gmod_wire_egp/lib/egplib/parenting.lua
+++ b/lua/entities/gmod_wire_egp/lib/egplib/parenting.lua
@@ -23,8 +23,7 @@ EGP.ParentingFuncs.addUV = addUV
 local function makeArray( v, fakepos )
 	local ret = {}
 	if isstring(v.verticesindex) then
-		if not fakepos then
-			if (not v["_"..v.verticesindex]) then EGP:AddParentIndexes( v ) end
+		if not fakepos and v["_"..v.verticesindex] then
 			for k,v in ipairs( v["_"..v.verticesindex] ) do
 				ret[#ret+1] = v.x
 				ret[#ret+1] = v.y

--- a/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpfunctions.lua
@@ -853,7 +853,7 @@ end
 e2function array wirelink:egpGlobalVertices( number index )
 	local hasobject, _, object = hasObject(this, index)
 	if hasobject and object.verticesindex then
-		local data = EGP:GetGlobalVertices(object)
+		local data = EGP.GetGlobalVertices(this, object)
 		if data.vertices then
 			local ret = {}
 			for i=1,#data.vertices do

--- a/lua/entities/gmod_wire_expression2/core/egpobjects.lua
+++ b/lua/entities/gmod_wire_expression2/core/egpobjects.lua
@@ -588,7 +588,7 @@ end
 e2function array egpobject:globalVertices()
 	if not isValid(this) then return self:throw("Invalid EGP Object", {}) end
 	if this.verticesindex then
-		local data = EGP:GetGlobalVertices(this.EGP, this)
+		local data = EGP.GetGlobalVertices(this.EGP, this)
 		if data.vertices then
 			local ret = {}
 			for i = 1, #data.vertices do


### PR DESCRIPTION
- `makeArray` doesn't add parent indexes anymore, because doing that would break calculations and have objects in some quasi-parented state. I don't know why it ever did that.
- Fixed two different ways to improperly call of `EGP.GetGlobalVertices`

Yeah.