### PR TITLE
Fix NULL error in prop core

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/prop.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/prop.lua
@@ -377,7 +377,10 @@ function PropCore.CreateSent(self, class, pos, angles, freeze, data)
 	entity:CallOnRemove( "wire_expression2_propcore_remove",
 		function( entity )
 			self.data.spawnedProps[ entity ] = nil
-			self.player.E2totalspawnedprops = E2totalspawnedprops - 1
+
+			if IsValid(self.player) then
+				self.player.E2totalspawnedprops = E2totalspawnedprops - 1
+			end
 		end
 	)
 


### PR DESCRIPTION
Fixes error after #3347 because when removeing a chip, player may already be invalid
```
- Tried to use a NULL entity!
1. __newindex - [C]:-1
 2. Function - entities/gmod_wire_expression2/core/custom/prop.lua:380
  3. <unknown> - lua/includes/extensions/entity.lua:158
   4. <unknown> - addons/hook-library-master/lua/includes/modules/hook.lua:313
```