### PR TITLE
Better outputs/inputs creation for gates + force Outputs/Inputs creation

### DIFF
--- a/lua/entities/gmod_wire_gate.lua
+++ b/lua/entities/gmod_wire_gate.lua
@@ -21,12 +21,12 @@ function ENT:Setup(action, noclip)
 	self.action = action
 	self.WireDebugName = gate.name
 
-	self.Inputs = WireLib.AdjustSpecialInputs(self, gate.inputs, gate.inputtypes)
+	WireLib.AdjustSpecialInputs(self, gate.inputs, gate.inputtypes)
 
 	if gate.outputs then
-		self.Outputs = WireLib.AdjustSpecialOutputs(self, gate.outputs, gate.outputtypes)
+		WireLib.AdjustSpecialOutputs(self, gate.outputs, gate.outputtypes)
 	else
-		self.Outputs = WireLib.AdjustSpecialOutputs(self, { "Out" }, gate.outputtypes)
+		WireLib.AdjustSpecialOutputs(self, { "Out" }, gate.outputtypes)
 	end
 
 	if gate.reset then

--- a/lua/entities/gmod_wire_gate.lua
+++ b/lua/entities/gmod_wire_gate.lua
@@ -9,8 +9,8 @@ local Wire_EnableGateInputValues = CreateConVar("Wire_EnableGateInputValues", 1,
 
 function ENT:Initialize()
 	self:PhysicsInit(SOLID_VPHYSICS)
-	self.Inputs = {}
-	self.Outputs = {}
+	self.Inputs = WireLib.CreateInputs(self, {})
+	self.Outputs = WireLib.CreateOutputs(self, {})
 end
 
 function ENT:Setup(action, noclip)
@@ -21,12 +21,12 @@ function ENT:Setup(action, noclip)
 	self.action = action
 	self.WireDebugName = gate.name
 
-	WireLib.AdjustSpecialInputs(self, gate.inputs, gate.inputtypes)
+	self.Inputs = WireLib.AdjustSpecialInputs(self, gate.inputs, gate.inputtypes)
 
 	if gate.outputs then
-		WireLib.AdjustSpecialOutputs(self, gate.outputs, gate.outputtypes)
+		self.Outputs = WireLib.AdjustSpecialOutputs(self, gate.outputs, gate.outputtypes)
 	else
-		WireLib.AdjustSpecialOutputs(self, { "Out" }, gate.outputtypes)
+		self.Outputs = WireLib.AdjustSpecialOutputs(self, { "Out" }, gate.outputtypes)
 	end
 
 	if gate.reset then

--- a/lua/entities/gmod_wire_gate.lua
+++ b/lua/entities/gmod_wire_gate.lua
@@ -9,8 +9,8 @@ local Wire_EnableGateInputValues = CreateConVar("Wire_EnableGateInputValues", 1,
 
 function ENT:Initialize()
 	self:PhysicsInit(SOLID_VPHYSICS)
-	self.Inputs = WireLib.CreateInputs(self, {})
-	self.Outputs = WireLib.CreateOutputs(self, {})
+	WireLib.CreateInputs(self, {})
+	WireLib.CreateOutputs(self, {})
 end
 
 function ENT:Setup(action, noclip)

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -322,7 +322,7 @@ function WireLib.AdjustSpecialOutputs(ent, names, types, descs)
 	types = types or {}
 	descs = descs or {}
 
-	local ent_ports = ent.Outputs or {}
+	local ent_ports = ent.Outputs
 	if not ent_ports then ent_ports = {} ent.Outputs = ent_ports end
 
 	local ent_mods = ent.EntityMods

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -268,7 +268,10 @@ end
 function WireLib.AdjustSpecialInputs(ent, names, types, descs)
 	types = types or {}
 	descs = descs or {}
-	local ent_ports = ent.Inputs or {}
+
+	local ent_ports = ent.Inputs
+	if not ent_ports then ent_ports = {} ent.Inputs = ent_ports end
+
 	for n,v in ipairs(names) do
 		local name, desc, tp = ParsePortName(v, types[n] or "NORMAL", descs and descs[n])
 
@@ -320,6 +323,7 @@ function WireLib.AdjustSpecialOutputs(ent, names, types, descs)
 	descs = descs or {}
 
 	local ent_ports = ent.Outputs or {}
+	if not ent_ports then ent_ports = {} ent.Outputs = ent_ports end
 
 	local ent_mods = ent.EntityMods
 	if ent_mods then


### PR DESCRIPTION
I still don't know the exact cause of this error, but it probably occurs when the gate is not initialized correctly. I don't know why this happens, but probably explicitly overwriting the outputs will fix it.
If someone smarter tells me what the exact cause is, I'll be glad, because I've been getting this error for a year now.