### PR TITLE
Don't throw an error when there is a problem opening a file

### DIFF
--- a/lua/wire/client/text_editor/wire_expression2_editor.lua
+++ b/lua/wire/client/text_editor/wire_expression2_editor.lua
@@ -1970,7 +1970,7 @@ function Editor:LoadFile(Line, forcenewtab)
 
 	local f = file.Open(Line, "r", "DATA")
 	if not f then
-		WireLib.AddNotify("Erroring opening file: " .. Line, NOTIFY_ERROR, 5, NOTIFYSOUND_DRIP3)
+		WireLib.AddNotify("Erroring opening file: " .. Line, NOTIFY_ERROR, 5, NOTIFYSOUND_ERROR1)
 	else
 		local str = f:Read(f:Size()) or ""
 		f:Close()


### PR DESCRIPTION
Anything can happen to the file that will prevent us from opening it, and the notification looks more right than an error for a average user.