### PR TITLE
Optimize events execution

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/init.lua
+++ b/lua/entities/gmod_wire_expression2/core/init.lua
@@ -270,11 +270,15 @@ end
 function E2Lib.triggerEvent(name, args)
 	assert(E2Lib.Env.Events[name], "E2Lib.triggerEvent on nonexisting event: '" .. name .. "'")
 
-	for ent in pairs(E2Lib.Env.Events[name].listening) do
+	local event_listeners = E2Lib.Env.Events[name].listening
+
+	for i = #event_listeners, 1, -1 do
+		local ent = event_listeners[i]
+
 		if ent.ExecuteEvent then
 			ent:ExecuteEvent(name, args)
-		else -- Destructor somehow wasn't run?
-			E2Lib.Env.Events[name].listening[ent] = nil
+		else
+			table.remove(event_listeners, i)
 		end
 	end
 end
@@ -285,12 +289,16 @@ end
 function E2Lib.triggerEventOmit(name, args, ignore)
 	assert(E2Lib.Env.Events[name], "E2Lib.triggerEventOmit on nonexisting event: '" .. name .. "'")
 
-	for ent in pairs(E2Lib.Env.Events[name].listening) do
+	local event_listeners = E2Lib.Env.Events[name].listening
+
+	for i = #listeners, 1, -1 do
+		local ent = event_listeners[i]
+
 		if not ignore[ent] then -- Don't trigger ignored chips
 			if ent.ExecuteEvent then
 				ent:ExecuteEvent(name, args)
 			else -- Destructor somehow wasn't run?
-				E2Lib.Env.Events[name].listening[ent] = nil
+				table.remove(event_listeners, i)
 			end
 		end
 	end

--- a/lua/entities/gmod_wire_expression2/core/init.lua
+++ b/lua/entities/gmod_wire_expression2/core/init.lua
@@ -291,7 +291,7 @@ function E2Lib.triggerEventOmit(name, args, ignore)
 
 	local event_listeners = E2Lib.Env.Events[name].listening
 
-	for i = #listeners, 1, -1 do
+	for i = #event_listeners, 1, -1 do
 		local ent = event_listeners[i]
 
 		if not ignore[ent] then -- Don't trigger ignored chips

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -93,7 +93,12 @@ function ENT:Destruct()
 				E2Lib.Env.Events[evt].destructor(self.context)
 			end
 
-			E2Lib.Env.Events[evt].listening[self] = nil
+			for k, ent in pairs(E2Lib.Env.Events[evt].listening) do
+				if ent == self then
+					table.remove(E2Lib.Env.Events[evt].listening, k)
+					break
+				end
+			end
 		end
 	end
 end
@@ -572,7 +577,8 @@ function ENT:Setup(buffer, includes, restore, forcecompile, filepath)
 				-- If the event has a constructor to run when the E2 is made and listening to the event.
 				E2Lib.Env.Events[evt].constructor(self.context)
 			end
-			E2Lib.Env.Events[evt].listening[self] = true
+
+			table.insert(E2Lib.Env.Events[evt].listening, self)
 		end
 	end
 


### PR DESCRIPTION
Optimizes iteration over event listeners slightly by not using `pairs`.
In terms of behavior, this only changes that iteration over the table happens in reverse order.