### PR TITLE
Don't call ShowOutput in gates every time

### DIFF
--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -427,7 +427,9 @@ end
 net.Receive( "wire_overlay_request", function( len, ply )
 	if net.ReadBool() then
 		local ent = net.ReadEntity()
-		if not (ent and ent:IsValid()) then return end
+		if not IsValid(ent) then return end
+		if ent.PrepareOverlayData then ent:PrepareOverlayData() end
+
 		local lastUpdate = net.ReadFloat()
 
 		local row = {lastUpdate, ent}

--- a/lua/entities/gmod_wire_gate.lua
+++ b/lua/entities/gmod_wire_gate.lua
@@ -63,7 +63,6 @@ function ENT:Setup(action, noclip)
 	self.Updating = nil
 
 	self:CalcOutput()
-	self:ShowOutput()
 end
 
 
@@ -91,7 +90,6 @@ function ENT:TriggerInput(iname, value, iter)
 	if not action or action.timed then return end
 
 	selfTbl.CalcOutput(self, iter, selfTbl)
-	selfTbl.ShowOutput(self, selfTbl)
 end
 
 function ENT:Think()
@@ -102,7 +100,6 @@ function ENT:Think()
 
 	if action and action.timed then
 		selfTbl.CalcOutput(self, nil, selfTbl)
-		selfTbl.ShowOutput(self, selfTbl)
 		self:NextThink(CurTime() + 0.02)
 
 		return true
@@ -146,6 +143,10 @@ function ENT:ShowOutput(selfTbl)
 	end
 
 	self:SetOverlayText(txt)
+end
+
+function ENT:PrepareOverlayData()
+	self:ShowOutput()
 end
 
 function ENT:OnRestore()


### PR DESCRIPTION
Instead, it adds a PrepareOverlayData function that will only be called when the player requests it. Can be implemented for all wire sents, but for gates it will be most efficient.

**Potential breaking change**: addons may rely on server-side overlaydata