### PR TITLE
Add `NULL` constant, deprecate `noentity()`

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -91,6 +91,9 @@ end
 --[[******************************************************************************]]
 -- Functions getting string
 
+E2Lib.registerConstant("NULL", NULL)
+
+[deprecated = "Use the constant NULL instead"]
 e2function entity noentity()
 	return NULL
 end


### PR DESCRIPTION
There is no reason to do this through a function