### PR TITLE
Rename `_NULL` to `_NO_ENTITY`

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -91,7 +91,7 @@ end
 --[[******************************************************************************]]
 -- Functions getting string
 
-E2Lib.registerConstant("NO_ENTITY", NULL, "An invalid entity)
+E2Lib.registerConstant("NO_ENTITY", NULL, "An invalid entity")
 
 [deprecated = "Use the constant NO_ENTITY instead"]
 e2function entity noentity()

--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -91,9 +91,9 @@ end
 --[[******************************************************************************]]
 -- Functions getting string
 
-E2Lib.registerConstant("NULL", NULL)
+E2Lib.registerConstant("NO_ENTITY", NULL, "An invalid entity)
 
-[deprecated = "Use the constant NULL instead"]
+[deprecated = "Use the constant NO_ENTITY instead"]
 e2function entity noentity()
 	return NULL
 end


### PR DESCRIPTION
A more understandable name because some people might not understand the NULL concept. It hasn't been that long since this constant was added, so i think it's acceptable.