### PR TITLE
Set creator for holograms

### DIFF
--- a/lua/entities/gmod_wire_hologram.lua
+++ b/lua/entities/gmod_wire_hologram.lua
@@ -22,6 +22,7 @@ end
 
 function ENT:SetPlayer(ply)
 	self:SetPlayerEnt(ply)
+	self:SetCreator(ply)
 	self.steamid = ply:SteamID()
 end
 


### PR DESCRIPTION
Because of this, players playing with prop protection cannot manipulate the entities of their holograms.