### PR TITLE
Fix parsing for long port details in Starfall

### DIFF
--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -32,13 +32,13 @@ end
 
 -- Allow to specify the description and type, like "Name (Description) [TYPE]"
 local function ParsePortName(namedesctype, fbtype, fbdesc)
-	local namedesc, tp = namedesctype:match("^(.+) %[(.+)%]$")
+	local namedesc, tp = string.match(namedesctype, "^(.+) %[(.+)%]$")
 	if not namedesc then
 		namedesc = namedesctype
 		tp = fbtype
 	end
 
-	local name, desc = namedesc:match("^(.+) %((.*)%)$")
+	local name, desc = string.match(namedesc, "^(.+) %((.*)%)$")
 	if not name then
 		name = namedesc
 		desc = fbdesc


### PR DESCRIPTION
When an entity has a wire port that is long enough (for example, one causing issues in this case would be `Fuze (Sets the delay in seconds in which explosive rounds will detonate after leaving the weapon.)`), spawning it through a Starfall function causes an error and leaves a broken entity behind. The root cause is the way that the pattern matching functions are used in this particular function, which this PR aims to fix by preventing Starfall from tripping over its own detour at this point (as suggested in [thegrb93/StarfallEx#1240](https://github.com/thegrb93/StarfallEx/issues/1240#issuecomment-997322960)).

This is intended to address ACF-Team/ACF-3#437.