### PR TITLE
Fix `E2Lib.isOwner` invalid arguments in `damage` core

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/damage.lua
+++ b/lua/entities/gmod_wire_expression2/core/damage.lua
@@ -117,7 +117,7 @@ e2function void entity:takeDamage(number amount, entity attacker)
 	if not Enabled:GetBool() then return self:throw("Dealing damage is disabled via wire_expression2_damage_enabled") end
 	if not IsValid(this) then return self:throw("Invalid entity!", nil) end
 	if not IsValid(attacker) then return self:throw("Invalid attacker entity!", nil) end
-	if not E2Lib.isOwner(attacker) then return self:throw("You do not own the attacker entity!", nil) end
+	if not E2Lib.isOwner(self, attacker) then return self:throw("You do not own the attacker entity!", nil) end
 	if not WireLib.CanDamage(self.player, this) then return self:throw("You cannot damage this entity!", nil) end
 
 	this:TakeDamage(amount, attacker, self.entity)
@@ -127,9 +127,9 @@ e2function void entity:takeDamage(number amount, entity attacker, entity inflict
 	if not Enabled:GetBool() then return self:throw("Dealing damage is disabled via wire_expression2_damage_enabled") end
 	if not IsValid(this) then return self:throw("Invalid entity!", nil) end
 	if not IsValid(attacker) then return self:throw("Invalid attacker entity!", nil) end
-	if not E2Lib.isOwner(attacker) then return self:throw("You do not own the attacker entity!", nil) end
+	if not E2Lib.isOwner(self, attacker) then return self:throw("You do not own the attacker entity!", nil) end
 	if not IsValid(inflictor) then return self:throw("Invalid inflictor entity!", nil) end
-	if not E2Lib.isOwner(inflictor) then return self:throw("You do not own the inflictor entity!", nil) end
+	if not E2Lib.isOwner(self, inflictor) then return self:throw("You do not own the inflictor entity!", nil) end
 	if not WireLib.CanDamage(self.player, this) then self:throw("You cannot damage this entity!", nil) end
 
 	this:TakeDamage(amount, attacker, inflictor)


### PR DESCRIPTION
Fixes:
```
@name bugreport/attacker_no_owner
@strict

# Shouldn't throw an error
owner():takeDamage(1,owner())
```