### PR TITLE
Default some of the turret values to prevent errors

### DIFF
--- a/lua/entities/gmod_wire_turret.lua
+++ b/lua/entities/gmod_wire_turret.lua
@@ -176,9 +176,9 @@ function ENT:Setup(delay, damage, force, sound, numbullets, spread, tracer, trac
 	self:SetDelay(delay)
 	self:SetSound(sound)
 	self:SetDamage(damage)
-	self:SetSpread(spread)
+	self:SetSpread(spread or 0.1)
 	self:SetTracer(tracer)
-	self:SetTraceNum(tracernum)
+	self:SetTraceNum(tracernum or 0)
 	self:SetNumBullets(numbullets)
 end
 


### PR DESCRIPTION
Fixes:
```
1. floor - [C]:-1 - bad argument #1 to 'floor' (number expected, got nil)
 2. SetTraceNum - addons/wire/lua/entities/gmod_wire_turret.lua:151
  3. Setup - addons/wire/lua/entities/gmod_wire_turret.lua:181
   4. <unknown> - addons/wire/lua/wire/server/wirelib.lua:1046
    5. xpcall - [C]:-1
     6. CreateEntityFromTable - addons/advdupe2/lua/advdupe2/sv_clipboard.lua:1063
      7. <unknown> - addons/advdupe2/lua/advdupe2/sv_clipboard.lua:1339
       8. pcall - [C]:-1
        9. func - addons/advdupe2/lua/advdupe2/sv_clipboard.lua:1543
         10. <unknown> - addons/ulib/lua/includes/modules/hook.lua:260
```
Same issue happens with :SetSpread


I think this happens when players have some old dupes, ideally this is fixed in a more universal way but i don't see a easy way to do so.