### PR TITLE
Improve `entity:toString()`

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -900,7 +900,14 @@ end
 
 --- Returns <ent> formatted as a string. Returns "<code>(null)</code>" for invalid entities.
 e2function string toString(entity ent)
-	if not IsValid(ent) then return "(null)" end
+	if not IsValid(ent) then
+		if ent:IsWorld() then
+			return "(world)"
+		end
+
+		return "(null)"
+	end
+
 	return tostring(ent)
 end
 


### PR DESCRIPTION
Allows us to distinguish between `NULL` and `WORLD` in print