### PR TITLE
Center soundbrowser

### DIFF
--- a/lua/wire/client/sound_browser.lua
+++ b/lua/wire/client/sound_browser.lua
@@ -679,6 +679,7 @@ local function CreateSoundBrowser(path, se)
 	SoundBrowserPanel = vgui.Create("DFrame") -- The main frame.
 	SoundBrowserPanel:SetPos(50,25)
 	SoundBrowserPanel:SetSize(1000, 700)
+	SoundBrowserPanel:Center()
 
 	SoundBrowserPanel:SetMinWidth(700)
 	SoundBrowserPanel:SetMinHeight(400)


### PR DESCRIPTION
I don't like that soundbrowser opens somewhere in the upper left part of the screen instead of the center