### PR TITLE
Fix entity tostring when passed nil

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/entity.lua
@@ -900,15 +900,15 @@ end
 
 --- Returns <ent> formatted as a string. Returns "<code>(null)</code>" for invalid entities.
 e2function string toString(entity ent)
-	if not IsValid(ent) then
-		if ent:IsWorld() then
+	if ent then
+		if ent:IsValid() then
+			return tostring(ent)
+		elseif ent:IsWorld() then
 			return "(world)"
 		end
-
-		return "(null)"
 	end
 
-	return tostring(ent)
+	return "(null)"
 end
 
 e2function string entity:toString() = e2function string toString(entity ent)


### PR DESCRIPTION
Adds an explicit nil check. Would call `nil:IsWorld` otherwise.