### PR TITLE
Fix world prop exploit.

### DIFF
--- a/lua/entities/gmod_wire_simple_explosive.lua
+++ b/lua/entities/gmod_wire_simple_explosive.lua
@@ -25,6 +25,9 @@ function ENT:Initialize()
 end
 
 function ENT:Setup( key, damage, removeafter, radius )
+	if not isnumber(damage) then damage = 1 end
+	if not isnumber(radius) then radius = 32 end
+
 	self.key			= key
 	self.damage			= math.Min(damage, 1500)
 	self.removeafter	= removeafter


### PR DESCRIPTION
1. `ent_create gmod_wire_simple_explosive SOMEMODEL.mdl`
2. Use default duplicator to copy & past this entity.
3. Errors in console.

It turns World in some prop protection addons.