### PR TITLE
Remove broken camera model

### DIFF
--- a/lua/wire/stools/rt_camera.lua
+++ b/lua/wire/stools/rt_camera.lua
@@ -36,8 +36,7 @@ TOOL.ClientConVar = {
 
 local MODELS = {
     ["models/maxofs2d/camera.mdl"] = true,
-    ["models/dav0r/camera.mdl"] = true,
-    ["models/props_wasteland/camera_lens001a.mdl"] = true
+    ["models/dav0r/camera.mdl"] = true
 }
 
 if SERVER then


### PR DESCRIPTION
I bought the entire Valve Complete Pack and mounted it into GMOD, but it looks like this model never existed
<img width="267" height="97" alt="image" src="https://github.com/user-attachments/assets/8dc1bfaa-5a90-4419-9bbe-ae6a128d488d" />
