### PR TITLE
Fixed gmod_wire_cd_ray.lua

### DIFF
--- a/lua/entities/gmod_wire_cd_ray.lua
+++ b/lua/entities/gmod_wire_cd_ray.lua
@@ -177,8 +177,8 @@ function ENT:Think()
 		local h = lpos.z-disk.StackStartHeight //stack
 
 		local track = math.floor(r / disk.Precision)
-		local sector = math.floor(a*track)//*disk.Precision)
-		local stack = math.floor(h/disk.Precision)
+		local sector = math.floor(a*track) / disk.Precision)
+		local stack = math.floor(h / disk.Precision)
 		if (disk.DiskStacks == 1) then stack = 0 end
 
 		if (self.PrevDiskEnt ~= disk) then


### PR DESCRIPTION
Accidental commenting broke functionality.

I wanted to do stuff with this in game but wasn't able to. The fact that half of the code was commented out by only one //* and that it was surrounded by divisions made me suspicious. I'm not familiar with the codebase and how this actually works, but I'm hoping that this was just a simple mistake that was overlooked.

### **Please correct me if I'm wrong!**