### PR TITLE
Dont store functiondata permanently

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/extloader.lua
+++ b/lua/entities/gmod_wire_expression2/core/extloader.lua
@@ -50,7 +50,6 @@ if ENT then
 		ENT = nil
 
 		_Msg( "Calling constructors for all Expression 2 chips." )
-		wire_expression2_prepare_functiondata()
 		if not args or args[1] ~= "nosend" then
 			for _, p in player.Iterator() do
 				if IsValid( p ) then wire_expression2_sendfunctions( p ) end


### PR DESCRIPTION
The `functiondata` would easily contain 20k+ entries while it was rarely being used, generating it when needed would save some memory.