### PR TITLE
Small optimization of thruster force calculation

### DIFF
--- a/lua/entities/gmod_wire_thruster.lua
+++ b/lua/entities/gmod_wire_thruster.lua
@@ -122,7 +122,7 @@ function ENT:SetForce( force, mul )
 	end
 
 	if self.neteffect then
-		self.effectforce = self.ThrustOffset:Length() * self.force * self.mul
+		self.effectforce = self.ThrustOffset:Length() * self.force * self.mul * 50
 		self.updateeffect = true
 	end
 


### PR DESCRIPTION
It doesn't explain anywhere that it multiplies the force by 50. This hurts making precise forces unless you know to divide the force by 50. Even then it multiplies it after the check for the maximum force. 

On the regular thruster I removed some unnecessary WorldToLocalVectors to just apply the force globally instead of locally since we already have it global. I have tested it in game and it works for me.