### PR TITLE
Minor wire trigger facelift + output forcing

### DIFF
--- a/lua/entities/gmod_wire_trigger.lua
+++ b/lua/entities/gmod_wire_trigger.lua
@@ -38,7 +38,12 @@ function ENT:Initialize()
 	self:SetSolid( SOLID_VPHYSICS )
 	local phys = self:GetPhysicsObject() if (phys:IsValid()) then phys:Wake() end
 
-	self.Outputs = WireLib.CreateOutputs(self, { "EntCount", "Entities [ARRAY]" })
+	self.Outputs = WireLib.CreateOutputs(self, {
+		"EntCount",
+		"Entities [ARRAY]",
+		"Entered (Entity that entered the trigger entity bounds last) [ENTITY]",
+		"Exited (Entity that left the trigger entity bounds last) [ENTITY]"
+	})
 end
 
 function ENT:Setup( model, filter, owneronly, sizex, sizey, sizez, offsetx, offsety, offsetz )

--- a/lua/entities/gmod_wire_trigger_entity.lua
+++ b/lua/entities/gmod_wire_trigger_entity.lua
@@ -25,6 +25,8 @@ function ENT:Reset()
 	if not IsValid( owner ) then return end
 	WireLib.TriggerOutput( owner, "EntCount", 0 )
 	WireLib.TriggerOutput( owner, "Entities", self.EntsInside )
+	WireLib.TriggerOutput( owner, "Entered", NULL )
+	WireLib.TriggerOutput( owner, "Exited", NULL )
 end
 
 function ENT:StartTouch( ent )
@@ -40,6 +42,7 @@ function ENT:StartTouch( ent )
 
 	WireLib.TriggerOutput( owner, "EntCount", #self.EntsInside )
 	WireLib.TriggerOutput( owner, "Entities", self.EntsInside )
+	WireLib.TriggerOutput( owner, "Entered", ent, nil, true )
 
 end
 function ENT:EndTouch( ent )
@@ -55,5 +58,6 @@ function ENT:EndTouch( ent )
 
 	WireLib.TriggerOutput( owner, "EntCount", #self.EntsInside )
 	WireLib.TriggerOutput( owner, "Entities", self.EntsInside )
+	WireLib.TriggerOutput( owner, "Exited", ent, nil, true )
 
 end

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -583,7 +583,7 @@ local function Wire_Link(dst, dstid, src, srcid, path)
 	WireLib.TriggerInput(dst, dstid, output.Value)
 end
 
-function WireLib.TriggerOutput(ent, oname, value, iter)
+function WireLib.TriggerOutput(ent, oname, value, iter, force)
 	if not entIsValid(ent) then return end
 	if not HasPorts(ent) then return end
 
@@ -599,7 +599,7 @@ function WireLib.TriggerOutput(ent, oname, value, iter)
 		value = ty.Zero()
 	end
 
-	if value ~= output.Value or output.Type == "ARRAY" or output.Type == "TABLE" or (output.Type == "ENTITY" and not rawequal(value, output.Value) --[[Covers the NULL==NULL case]]) then
+	if value ~= output.Value or output.Type == "ARRAY" or output.Type == "TABLE" or (output.Type == "ENTITY" and not rawequal(value, output.Value) --[[Covers the NULL==NULL case]]) or force then
 		local timeOfFrame = CurTime()
 		if timeOfFrame ~= output.TriggerTime then
 			-- Reset the TriggerLimit every frame

--- a/lua/wire/stools/trigger.lua
+++ b/lua/wire/stools/trigger.lua
@@ -60,7 +60,7 @@ function TOOL:GetConVars()
 end
 
 local function DrawTriggerOutlines( list )
-	cam.Start3D( LocalPlayer():EyePos(), LocalPlayer():EyeAngles() )
+	cam.Start3D( EyePos(), EyeAngles() )
 		for k,ent in pairs( list ) do
 			local trig = ent:GetTriggerEntity()
 


### PR DESCRIPTION
Made triggers output what entity entered and exited the trigger bounds (outputs named "Entered" and "Exited" respectively).

I've had to modify the WireLib.TriggerOutput function to allow it to "force" outputs (controlled by a variable) to make the new trigger outputs function how i wanted them to, else the same entity constantly entering and exiting the trigger bounds would only be detected entering and exiting only once.

Also I've fixed a minor bug of the trigger bounding box overlay drawing in the wrong position if the players camera is not at the player entities eye position (like when in the pac3 editor or any other form of freecam).