### PR TITLE
Constraint core improvements

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/constraintcore.lua
@@ -129,7 +129,6 @@ local function addUndo(self, const_type, const, rope)
 		undo.Create("E2 " .. const_type)
 			undo.SetPlayer(ply)
 			undo.AddEntity(const)
-			print(const)
 			if rope then undo.AddEntity(rope) end
 		undo.Finish()
 	end


### PR DESCRIPTION
Replaces the limits system with the GMOD system with `sbox_maxconstraints/sbox_maxropeconstraints`
Makes undo text prettier
Fixes no-collides cleanup type
Disables no-collides on remove