### PR TITLE
Center RT Screen UV Coordinates

### DIFF
--- a/lua/entities/gmod_wire_rt_screen.lua
+++ b/lua/entities/gmod_wire_rt_screen.lua
@@ -255,13 +255,34 @@ if CLIENT then
         local y1 = -yraw
         local y2 = yraw
 
-        local y_center_offset = self:GetScaleY() * (1 - monitor.RatioX) / 2 
-        local u1, v1 = 0, y_center_offset
-        local u2, v2 = self:GetScaleX(), v1 + monitor.RatioX * self:GetScaleY()
+        local scaleX = self:GetScaleX()
+        local scaleY = self:GetScaleY()
+        local u1, v1, u2, v2
+        -- center smaller side 
+        if monitor.RatioX <= 1 then
+            local y_offset = scaleY * (1 - monitor.RatioX) * 0.5
+
+            u1 = 0
+            u2 = scaleX
+
+            v1 = y_offset
+            v2 = y_offset + monitor.RatioX * scaleY
+        else
+            local x_offset = scaleX * (1 - 1 / monitor.RatioX) * 0.5
+
+            u1 = x_offset
+            u2 = x_offset + scaleX / monitor.RatioX
+
+            v1 = 0
+            v2 = scaleY
+        end
+
         local scrU = self:GetScrollX()
         local scrV = self:GetScrollY()
-        u1 = u1 + scrU u2 = u2 + scrU
-        v1 = v1 + scrV v2 = v2 + scrV
+        u1 = u1 + scrU
+        u2 = u2 + scrU
+        v1 = v1 + scrV
+        v2 = v2 + scrV
 
 
         cam.Start3D2D(


### PR DESCRIPTION
Previously, the smaller side of an RT screen would clip the edge of the texture furthest from 0,0. Now it centers that clip so that any reduction in scale will keep the center of the screen in the same place. This fixes the camera view appearing off-center from its forward axis (visible as a downward tilt) and that apparent angle changing as FOV is changed.