### PR TITLE
Pass third "isPlay" argument in Expression2_CanEffect

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/effects.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/effects.lua
@@ -3,7 +3,7 @@ E2Lib.RegisterExtension("effects", false, "Allows E2s to play arbitrary effects.
 local wire_expression2_effect_burst_max = CreateConVar("wire_expression2_effect_burst_max", 4, FCVAR_ARCHIVE)
 local wire_expression2_effect_burst_rate = CreateConVar("wire_expression2_effect_burst_rate", 0.1, FCVAR_ARCHIVE)
 
--- Use hook Expression2_CanEffect(name, e2, isPlay) to blacklist/whitelist effects
+-- Use hook Expression2_CanEffect(name, e2, is_play) to blacklist/whitelist effects
 local effect_blacklist = {
 	dof_node = true
 }


### PR DESCRIPTION
Useful for stuff like this https://github.com/CFC-Servers/cfc_gmod_scripts/pull/54

Not super sure about calling the variable "isPlay" but its what i thought of first lol
Just PR'd this because users were complaining about prints when properly using effectCanPlay in their code

Thanks for considering!