### PR TITLE
Fix lua error

### DIFF
--- a/lua/entities/gmod_wire_hologram.lua
+++ b/lua/entities/gmod_wire_hologram.lua
@@ -386,6 +386,8 @@ if CLIENT then
 
 	concommand.Add("wire_holograms_unblock_client",
 		function(ply, command, args)
+			if not args[1] then print("Invalid steamid") return end
+
 			local toblock = checkSteamid(args[1])
 			if not toblock then print("Invalid SteamId") return end
 			if not blocked[toblock] then print("This steamid isn't blocked") return end


### PR DESCRIPTION
Fixes:
```
- addons/wire-master/lua/entities/gmod_wire_hologram.lua:389: bad argument #1 to 'checkSteamid' (string expected, got nil)
1. checkSteamid - [C]:-1
 2. <unknown> - addons/wire-master/lua/entities/gmod_wire_hologram.lua:389
  3. <unknown> - lua/includes/modules/concommand.lua:54
```