### PR TITLE
Fix #3471

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/bone.lua
+++ b/lua/entities/gmod_wire_expression2/core/bone.lua
@@ -19,7 +19,6 @@ end)
 -- faster access to some math library functions
 local abs = math.abs
 local atan2 = math.atan2
-local sqrt = math.sqrt
 local asin = math.asin
 local Clamp = math.Clamp
 


### PR DESCRIPTION
Fixes the E2Lib.isValidBone function to return the bone index
Fixes #3471