### PR TITLE
Check isentity on owner in DrawWorldTip

### DIFF
--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -159,7 +159,7 @@ if CLIENT then
 		local name
 		if CPPI then
 			local owner = self:CPPIGetOwner()
-			name = string.format("(%s)", IsValid(owner) and owner:Nick() or "World")
+			name = string.format("(%s)", isentity(owner) and IsValid(owner) and owner:Nick() or "World")
 		else
 			name = "(" .. self:GetPlayerName() .. ")"
 		end


### PR DESCRIPTION
Same as https://github.com/wiremod/wire/pull/3292

Was broke/undone by https://github.com/wiremod/wire/pull/3477

```
[Wiremod Canary] lua/includes/util.lua:263: attempt to index local 'object' (a number value)
  1. IsValid - lua/includes/util.lua:263
   2. DrawWorldTip - lua/entities/base_wire_entity.lua:162
    3. unknown - lua/entities/base_wire_entity.lua:227
     4. unknown - addons/libbys_optimizers/lua/includes/modules/hook.lua:313 (x6)
```