### PR TITLE
Fix lua error

### DIFF
--- a/lua/wire/stools/trigger.lua
+++ b/lua/wire/stools/trigger.lua
@@ -65,7 +65,7 @@ local function DrawTriggerOutlines( list )
 			local trigger = ent:GetTriggerEntity()
 
 			if trigger:IsValid() then
-				render.DrawWireframeBox(trigger:GetPos(), angle_zero, trig:OBBMins(), trig:OBBMaxs(), Color(255, 255, 0), true)
+				render.DrawWireframeBox(trigger:GetPos(), angle_zero, trigger:OBBMins(), trigger:OBBMaxs(), Color(255, 255, 0), true)
 				render.DrawLine(trigger:GetPos(), ent:GetPos(), Color(255, 255, 0))
 			end
 		end


### PR DESCRIPTION
Fixes:
```
- addons/wire/lua/wire/stools/trigger.lua:67: Tried to use a NULL entity!
1. GetPos - [C]:-1
 2. DrawTriggerOutlines - addons/wire/lua/wire/stools/trigger.lua:67
  3. DrawHUD - addons/wire/lua/wire/stools/trigger.lua:83
   4. drawhud - gamemodes/sandbox/entities/weapons/gmod_tool/cl_init.lua:61
    5. <unknown> - addons/classicbox-scripts-main/lua/autorun/client/cl_misc.lua:101
```
+optimizes iteration a bit