### PR TITLE
More gates

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/unitconv.lua
+++ b/lua/entities/gmod_wire_expression2/core/unitconv.lua
@@ -2,132 +2,30 @@
   Unit conversion
 \******************************************************************************/
 
-/*
-	u   - source unit
-	A Source Unit is 0.75 Inch long, more info here:
-	http://developer.valvesoftware.com/wiki/Dimensions#Map_Grid_Units:_quick_reference
-
-	mm  - millimeter
-	cm  - centimeter
-	dm  - decimeter
-	m   - meter
-	km  - kilometer
-	in  - inch
-	ft  - foot
-	yd  - yard
-	mi  - mile
-	nmi - nautical mile
-
-	g   - gram
-	kg  - kilogram
-	t   - tonne
-	oz  - ounce
-	lb  - pound
-*/
-
-local speed = {
-	["u/s"]   = 1 / 0.75,
-	["u/m"]   = 60 * (1 / 0.75),
-	["u/h"]   = 3600 * (1 / 0.75),
-
-	["mm/s"]  = 25.4,
-	["cm/s"]  = 2.54,
-	["dm/s"]  = 0.254,
-	["m/s"]   = 0.0254,
-	["km/s"]  = 0.0000254,
-	["in/s"]  = 1,
-	["ft/s"]  = 1 / 12,
-	["yd/s"]  = 1 / 36,
-	["mi/s"]  = 1 / 63360,
-	["nmi/s"] = 127 / 9260000,
-
-	["mm/m"]  = 60 * 25.4,
-	["cm/m"]  = 60 * 2.54,
-	["dm/m"]  = 60 * 0.254,
-	["m/m"]   = 60 * 0.0254,
-	["km/m"]  = 60 * 0.0000254,
-	["in/m"]  = 60,
-	["ft/m"]  = 60 / 12,
-	["yd/m"]  = 60 / 36,
-	["mi/m"]  = 60 / 63360,
-	["nmi/m"] = 60 * 127 / 9260000,
-
-	["mm/h"]  = 3600 * 25.4,
-	["cm/h"]  = 3600 * 2.54,
-	["dm/h"]  = 3600 * 0.254,
-	["m/h"]   = 3600 * 0.0254,
-	["km/h"]  = 3600 * 0.0000254,
-	["in/h"]  = 3600,
-	["ft/h"]  = 3600 / 12,
-	["yd/h"]  = 3600 / 36,
-	["mi/h"]  = 3600 / 63360,
-	["nmi/h"] = 3600 * 127 / 9260000,
-
-	["mph"]   = 3600 / 63360,
-	["knots"] = 3600 * 127 / 9260000,
-	["mach"]  = 0.0254 / 295,
-}
-
-local length = {
-	["u"]   = 1 / 0.75,
-
-	["mm"]  = 25.4,
-	["cm"]  = 2.54,
-	["dm"]  = 0.254,
-	["m"]   = 0.0254,
-	["km"]  = 0.0000254,
-	["in"]  = 1,
-	["ft"]  = 1 / 12,
-	["yd"]  = 1 / 36,
-	["mi"]  = 1 / 63360,
-	["nmi"] = 127 / 9260000,
-}
-
-local weight = {
-	["g"]  = 1000,
-	["kg"] = 1,
-	["t"]  = 0.001,
-	["oz"] = 1 / 0.028349523125,
-	["lb"] = 1 / 0.45359237,
-}
-
 __e2setcost(2) -- approximated
 
+local unitconv = WireLib.UnitConv
+
 e2function number toUnit(string rv1, rv2)
-
-	if speed[rv1] then
-		return (rv2 * 0.75) * speed[rv1]
-	elseif length[rv1] then
-		return (rv2 * 0.75) * length[rv1]
-	elseif weight[rv1] then
-		return rv2 * weight[rv1]
-	end
-
-	return -1
+    for _, tbl in pairs(unitconv) do
+        if tbl[rv1] then
+            return rv2 * tbl[rv1]
+        end
+    end
+    return -1
 end
 
 e2function number fromUnit(string rv1, rv2)
-
-	if speed[rv1] then
-		return (rv2 / 0.75) / speed[rv1]
-	elseif length[rv1] then
-		return (rv2 / 0.75) / length[rv1]
-	elseif weight[rv1] then
-		return rv2 / weight[rv1]
-	end
-
-	return -1
+    for _, tbl in pairs(unitconv) do
+        if tbl[rv1] then
+            return rv2 / tbl[rv1]
+        end
+    end
+    return -1
 end
 
 e2function number convertUnit(string rv1, string rv2, rv3)
-
-	if speed[rv1] and speed[rv2] then
-		return rv3 * (speed[rv2] / speed[rv1])
-	elseif length[rv1] and length[rv2] then
-		return rv3 * (length[rv2] / length[rv1])
-	elseif weight[rv1] and weight[rv2] then
-		return rv3 * (weight[rv2] / weight[rv1])
-	end
-
-	return -1
+    local factor = WireLib.ConvertUnit(rv1, rv2)
+    if factor then return rv3 * factor end
+    return -1
 end

--- a/lua/entities/gmod_wire_interactiveprop.lua
+++ b/lua/entities/gmod_wire_interactiveprop.lua
@@ -134,6 +134,19 @@ InteractiveModels = {
 			{type="DNumberScratch", x = 85, y = 55, name="Knob6"},
 		}
 	},
+	["models/props_lab/reciever01d.mdl"] = {
+		width = 112,
+		height = 80,
+		title="reciever01d",
+		widgets={
+			{type="DNumberScratch", x = 10, y = 30, name="Knob1", color=Color(128,64,64)},
+			{type="DNumberScratch", x = 35, y = 30, name="Knob2", color=Color(128,64,64)},
+			{type="DNumberScratch", x = 10, y = 55, name="Knob3"},
+			{type="DNumberScratch", x = 35, y = 55, name="Knob4"},
+			{type="DNumberScratch", x = 60, y = 55, name="Knob5"},
+			{type="DNumberScratch", x = 85, y = 55, name="Knob6"},
+		}
+	},
 	["models/props_interiors/vendingmachinesoda01a.mdl"] = {
 		width = 60,
 		height = 200,

--- a/lua/wire/gates/entity.lua
+++ b/lua/wire/gates/entity.lua
@@ -1027,4 +1027,213 @@ GateActions["entity_heading"] = {
 	end
 }
 
+GateActions["entity_getattachments"] = {
+	name = "Attachments",
+	description = "Returns an array of all attachment IDs for the entity's model.",
+	inputs = { "Ent" },
+	inputtypes = { "ENTITY" },
+	outputs = { "IDs", "Names" },
+	outputtypes = { "ARRAY", "ARRAY" },
+	output = function(gate, Ent)
+		if not Ent:IsValid() then return {}, {} end
+		local attachments = Ent:GetAttachments()
+		if not attachments or #attachments == 0 then return {}, {} end
+		local ids = {}
+		local names = {}
+		for _, att in ipairs(attachments) do
+			ids[#ids + 1] = att.id
+			names[#names + 1] = att.name
+		end
+		return ids, names
+	end,
+	label = function(Out)
+		return string.format("Attachments: %d found", #Out.IDs)
+	end
+}
+
+GateActions["entity_getattachment"] = {
+	name = "Attachment",
+	description = "Gets the position and angle of a specific attachment by ID or Name. Return Position/Angles must be > 0 to output their respective values.",
+	inputs = { "Ent", "ID", "Name", "Return Position", "Return Angles" },
+	inputtypes = { "ENTITY", "NORMAL", "STRING", "NORMAL", "NORMAL" },
+	outputs = { "Position", "Angles" },
+	outputtypes = { "VECTOR", "ANGLE" },
+	timed = true,
+	output = function(gate, Ent, ID, Name, ReturnPos, ReturnAng)
+		if not Ent:IsValid() then return vec0, ang0 end
+
+		local attachID = ID
+		if Name and Name ~= "" then
+			local found = Ent:LookupAttachment(Name)
+			if found and found > 0 then
+				attachID = found
+			end
+		end
+
+		if not attachID or attachID <= 0 then return vec0, ang0 end
+
+		local attData = Ent:GetAttachment(attachID)
+		if not attData then return vec0, ang0 end
+
+		local pos = vec0
+		local ang = ang0
+
+		if ReturnPos and ReturnPos > 0 then
+			pos = attData.Pos
+		end
+		if ReturnAng and ReturnAng > 0 then
+			ang = attData.Ang
+		end
+
+		return pos, ang
+	end,
+	label = function(Out, Ent, ID, Name)
+		return string.format("attachment(%s, id=%s, name=%q) Pos=(%d,%d,%d) Ang=(%d,%d,%d)",
+			tostring(Ent), tostring(ID), tostring(Name or ""),
+			Out.Position.x, Out.Position.y, Out.Position.z,
+			Out.Angles.p, Out.Angles.y, Out.Angles.r)
+	end
+}
+
+GateActions["entity_isfrozen"] = {
+	name = "Is Frozen",
+	inputs = { "Ent" },
+	inputtypes = { "ENTITY" },
+	outputtypes = { "NORMAL" },
+	timed = true,
+	output = function(gate, Ent)
+		if not Ent:IsValid() then return 0 end
+		local phys = Ent:GetPhysicsObject()
+		if not IsValid(phys) then return 0 end
+		return phys:IsMoveable() and 0 or 1
+	end,
+	label = function(Out)
+		return string.format("Is Frozen = %d", Out)
+	end
+}
+
+GateActions["entity_getchildren"] = {
+	name = "Children",
+	description = "Returns an array of all children entities parented to the given entity.",
+	inputs = { "Ent" },
+	inputtypes = { "ENTITY" },
+	outputs = { "Children", "Count" },
+	outputtypes = { "ARRAY", "NORMAL" },
+	output = function(gate, Ent)
+		if not Ent:IsValid() then return {}, 0 end
+		local keytable = Ent:GetChildren()
+		local result = {}
+		local i = 1
+		for _, child in pairs(keytable) do
+			if IsValid(child) then
+				result[i] = child
+				i = i + 1
+			end
+		end
+		return result, #result
+	end,
+	label = function(Out)
+		return string.format("Children: %d found", Out.Count)
+	end
+}
+
+GateActions["entity_vehicle"] = {
+    name = "Vehicle",
+    description = "Returns the vehicle that the player is currently sitting in. Returns NULL if the player is not in a vehicle.",
+    inputs = { "Ent" },
+    inputtypes = { "ENTITY" },
+    outputtypes = { "ENTITY" },
+    timed = true,
+    output = function(gate, Ent)
+        if not IsValid(Ent) then return NULL end
+        if not Ent:IsPlayer() then return NULL end
+        return Ent:GetVehicle()
+    end,
+    label = function(Out, Ent)
+        return string.format("vehicle(%s) = %s", tostring(Ent), tostring(Out))
+    end
+}
+
+local moveTypes = {
+	[0] = "NONE",
+	[1] = "ISOMETRIC",
+	[2] = "WALK",
+	[3] = "STEP",
+	[4] = "FLY",
+	[5] = "FLYGRAVITY",
+	[6] = "VPHYSICS",
+	[7] = "PUSH",
+	[8] = "NOCLIP",
+	[9] = "LADDER",
+	[10] = "OBSERVER",
+	[11] = "CUSTOM",
+}
+
+GateActions["entity_getmovetype"] = {
+    name = "Move Type",
+    description = "Returns the move type of an entity. 0=NONE, 1=ISOMETRIC, 2=WALK, 3=STEP, 4=FLY, 5=FLYGRAVITY, 6=VPHYSICS, 7=PUSH, 8=NOCLIP, 9=LADDER, 10=OBSERVER, 11=CUSTOM",
+    inputs = { "Ent" },
+    inputtypes = { "ENTITY" },
+    outputtypes = { "NORMAL" },
+    timed = true,
+    output = function(gate, Ent)
+        if not IsValid(Ent) then return 0 end
+        return Ent:GetMoveType()
+    end,
+    label = function(Out, Ent)
+        return string.format("getMoveType(%s) = %s", tostring(Ent), moveTypes[Out] or tostring(Out))
+    end
+}
+
+GateActions["entity_activeweapon"] = {
+    name = "Weapon",
+    description = "Returns the weapon the player is currently holding.",
+    inputs = { "Ent" },
+    inputtypes = { "ENTITY" },
+    outputtypes = { "ENTITY" },
+    timed = true,
+    output = function(gate, Ent)
+        if not IsValid(Ent) then return NULL end
+        if not Ent:IsPlayer() then return NULL end
+        return Ent:GetActiveWeapon()
+    end,
+    label = function(Out, Ent)
+        local name = IsValid(Out) and Out:GetClass() or "none"
+        return string.format("activeWeapon(%s) = %s", tostring(Ent), name)
+    end
+}
+
+GateActions["entity_weapons"] = {
+    name = "Weapons",
+    description = "Returns an array of all weapons in the player's inventory.",
+    inputs = { "Ent" },
+    inputtypes = { "ENTITY" },
+    outputtypes = { "ARRAY" },
+    timed = true,
+    output = function(gate, Ent)
+        if not IsValid(Ent) then return {} end
+        if not Ent:IsPlayer() then return {} end
+        return Ent:GetWeapons()
+    end,
+    label = function(Out, Ent)
+        return string.format("Weapons(%s) = %d items", tostring(Ent), #Out)
+    end
+}
+
+GateActions["entity_eyepos"] = {
+    name = "Eye Position",
+    description = "Returns the position of the player's eyes.",
+    inputs = { "Ent" },
+    inputtypes = { "ENTITY" },
+    outputtypes = { "VECTOR" },
+    timed = true,
+    output = function(gate, Ent)
+        if not IsValid(Ent) or not Ent:IsPlayer() then return vec0 end
+        return Ent:EyePos()
+    end,
+    label = function(Out, Ent)
+        return string.format("eyePos(%s) = (%d,%d,%d)", tostring(Ent), Out.x, Out.y, Out.z)
+    end
+}
+
 GateActions()

--- a/lua/wire/gates/entity.lua
+++ b/lua/wire/gates/entity.lua
@@ -1171,17 +1171,17 @@ local moveTypes = {
 
 GateActions["entity_getmovetype"] = {
     name = "Move Type",
-    description = "Returns the move type of an entity. 0=NONE, 1=ISOMETRIC, 2=WALK, 3=STEP, 4=FLY, 5=FLYGRAVITY, 6=VPHYSICS, 7=PUSH, 8=NOCLIP, 9=LADDER, 10=OBSERVER, 11=CUSTOM",
+    description = "Returns the move type of an entity.",
     inputs = { "Ent" },
     inputtypes = { "ENTITY" },
-    outputtypes = { "NORMAL" },
+    outputtypes = { "STRING" },
     timed = true,
     output = function(gate, Ent)
-        if not IsValid(Ent) then return 0 end
-        return Ent:GetMoveType()
+        if not IsValid(Ent) then return moveTypes[0] end
+        return moveTypes[Ent:GetMoveType()]
     end,
     label = function(Out, Ent)
-        return string.format("getMoveType(%s) = %s", tostring(Ent), moveTypes[Out] or tostring(Out))
+        return string.format("getMoveType(%s) = %s", tostring(Ent), Out or "")
     end
 }
 

--- a/lua/wire/gates/find.lua
+++ b/lua/wire/gates/find.lua
@@ -1,0 +1,110 @@
+--[[
+	Find gates
+]]
+
+GateActions("Find")
+
+local function safeClassMatch(class, filter)
+    if filter == "" then return true end
+    local ok, result = pcall(string.match, string.lower(class), string.lower(filter))
+    return ok and result ~= nil
+end
+
+GateActions["find_incone"] = {
+    name = "Find In Cone",
+    description = "Finds all entities within a spherical cone. Returns an array of entities. Filter accepts a Lua pattern for class name. Ignore is an array of entities to exclude.",
+    inputs = { "Clk", "Position", "Direction", "Length", "Degrees", "Filter", "Ignore" },
+    inputtypes = { "NORMAL", "VECTOR", "VECTOR", "NORMAL", "NORMAL", "STRING", "ARRAY" },
+    outputs = { "Entities", "Count" },
+    outputtypes = { "ARRAY", "NORMAL" },
+    timed = true,
+    output = function(gate, Clk, Position, Direction, Length, Degrees, Filter, Ignore)
+        if Clk == 0 then
+            return gate.Outputs.Entities.Value, gate.Outputs.Count.Value
+        end
+
+        if not isvector(Position)       then Position = Vector(0, 0, 0) end
+        if not isvector(Direction)      then Direction = Vector(0, 0, 1) end
+        if not Length  or Length  <= 0  then Length    = 1024 end
+        if not Degrees or Degrees <= 0  then Degrees   = 45 end
+        if not isstring(Filter)         then Filter    = "" end
+
+        Direction = Direction:GetNormalized()
+
+        local ignoreLookup = {}
+        if istable(Ignore) then
+            for _, v in ipairs(Ignore) do
+                if IsValid(v) then ignoreLookup[v] = true end
+            end
+        end
+
+        local cosDegrees = math.cos(math.rad(Degrees))
+        local findlist   = ents.FindInSphere(Position, Length)
+        local result     = {}
+
+        for _, ent in ipairs(findlist) do
+            if IsValid(ent) and not ignoreLookup[ent] then
+                local dot = Direction:Dot((ent:GetPos() - Position):GetNormalized())
+                if dot > cosDegrees then
+                    if safeClassMatch(ent:GetClass(), Filter) then
+                        result[#result + 1] = ent
+                    end
+                end
+            end
+        end
+
+        return result, #result
+    end,
+    label = function(Out, Clk, Position, Direction, Length, Degrees, Filter)
+        return string.format("findInCone(%s, len=%s, deg=%s, filter=%q) = %d",
+            tostring(Position), tostring(Length), tostring(Degrees), tostring(Filter), Out.Count)
+    end
+}
+
+GateActions["find_inbox"] = {
+    name = "Find In Box",
+    description = "Finds all entities within an axis-aligned box. Returns an array of entities. Filter accepts a Lua pattern for class name. Ignore is an array of entities to exclude.",
+    inputs = { "Clk", "Min", "Max", "Filter", "Ignore" },
+    inputtypes = { "NORMAL", "VECTOR", "VECTOR", "STRING", "ARRAY" },
+    outputs = { "Entities", "Count" },
+    outputtypes = { "ARRAY", "NORMAL" },
+    timed = true,
+    output = function(gate, Clk, Min, Max, Filter, Ignore)
+        if Clk == 0 then
+            return gate.Outputs.Entities.Value, gate.Outputs.Count.Value
+        end
+
+        if not isvector(Min)    then Min    = Vector(0, 0, 0) end
+        if not isvector(Max)    then Max    = Vector(0, 0, 0) end
+        if not isstring(Filter) then Filter = "" end
+
+        local rMin = Vector(math.min(Min.x, Max.x), math.min(Min.y, Max.y), math.min(Min.z, Max.z))
+        local rMax = Vector(math.max(Min.x, Max.x), math.max(Min.y, Max.y), math.max(Min.z, Max.z))
+
+        local ignoreLookup = {}
+        if istable(Ignore) then
+            for _, v in ipairs(Ignore) do
+                if IsValid(v) then ignoreLookup[v] = true end
+            end
+        end
+
+        local findlist = ents.FindInBox(rMin, rMax)
+        local result   = {}
+
+        for _, ent in ipairs(findlist) do
+            if IsValid(ent) and not ignoreLookup[ent] then
+                if safeClassMatch(ent:GetClass(), Filter) then
+                    result[#result + 1] = ent
+                end
+            end
+        end
+
+        return result, #result
+    end,
+    label = function(Out, Clk, Min, Max, Filter)
+        return string.format("findInBox(%s → %s, filter=%q) = %d",
+            tostring(Min), tostring(Max), tostring(Filter), Out.Count)
+    end
+}
+
+GateActions()

--- a/lua/wire/gates/serverinfo.lua
+++ b/lua/wire/gates/serverinfo.lua
@@ -2,7 +2,6 @@
 		Server Info
 ]]
 
-local sv_hostip   = game.GetIPAddress()
 local sv_map      = game.GetMap()
 local sv_maxplayers = game.MaxPlayers()
 
@@ -27,7 +26,7 @@ GateActions["sv_hostip"] = {
     inputs = {},
     outputtypes = { "STRING" },
     output = function(gate)
-        return sv_hostip
+        return game.GetIPAddress()
     end,
     label = function(Out)
         return string.format("hostip = %q", Out)

--- a/lua/wire/gates/serverinfo.lua
+++ b/lua/wire/gates/serverinfo.lua
@@ -1,0 +1,118 @@
+--[[
+		Server Info
+]]
+
+local sv_hostip   = game.GetIPAddress()
+local sv_map      = game.GetMap()
+local sv_maxplayers = game.MaxPlayers()
+
+GateActions("Server")
+
+GateActions["sv_hostname"] = {
+    name = "Hostname",
+    description = "Returns the server's hostname.",
+    inputs = {},
+    outputtypes = { "STRING" },
+    output = function(gate)
+        return GetHostName()
+    end,
+    label = function(Out)
+        return string.format("hostname = %q", Out)
+    end
+}
+
+GateActions["sv_hostip"] = {
+    name = "Host IP",
+    description = "Returns the server's IP address.",
+    inputs = {},
+    outputtypes = { "STRING" },
+    output = function(gate)
+        return sv_hostip
+    end,
+    label = function(Out)
+        return string.format("hostip = %q", Out)
+    end
+}
+
+GateActions["sv_map"] = {
+    name = "Map",
+    description = "Returns the current map name.",
+    inputs = {},
+    outputtypes = { "STRING" },
+    output = function(gate)
+        return sv_map
+    end,
+    label = function(Out)
+        return string.format("map = %q", Out)
+    end
+}
+
+GateActions["sv_maxplayers"] = {
+    name = "Max Players",
+    description = "Returns the maximum number of players allowed on the server.",
+    inputs = {},
+    outputtypes = { "NORMAL" },
+    output = function(gate)
+        return sv_maxplayers
+    end,
+    label = function(Out)
+        return string.format("maxPlayers = %d", Out)
+    end
+}
+
+GateActions["sv_numplayers"] = {
+    name = "Num Players",
+    description = "Returns the current number of players on the server.",
+    inputs = {},
+    outputtypes = { "NORMAL" },
+    timed = true,
+    output = function(gate)
+        return player.GetCount()
+    end,
+    label = function(Out)
+        return string.format("numPlayers = %d", Out)
+    end
+}
+
+GateActions["sv_airdensity"] = {
+    name = "Air Density",
+    description = "Returns the air density of the physics environment.",
+    inputs = {},
+    outputtypes = { "NORMAL" },
+    output = function(gate)
+        return physenv.GetAirDensity()
+    end,
+    label = function(Out)
+        return string.format("airDensity = %f", Out)
+    end
+}
+
+
+GateActions["sv_propgravity"] = {
+    name = "Prop Gravity",
+    description = "Returns the gravity vector of the physics environment.",
+    inputs = {},
+    outputtypes = { "VECTOR" },
+    output = function(gate)
+        return physenv.GetGravity()
+    end,
+    label = function(Out)
+        return string.format("propGravity = (%d,%d,%d)", Out.x, Out.y, Out.z)
+    end
+}
+
+GateActions["sv_tickinterval"] = {
+    name = "Tick Interval",
+    description = "Returns the server's tick interval in seconds.",
+    inputs = {},
+    outputtypes = { "NORMAL" },
+    timed = true,
+    output = function(gate)
+        return engine.TickInterval()
+    end,
+    label = function(Out)
+        return string.format("tickInterval = %f", Out)
+    end
+}
+
+GateActions()

--- a/lua/wire/gates/time.lua
+++ b/lua/wire/gates/time.lua
@@ -341,5 +341,20 @@ GateActions["servertime"] = {
     end
 }
 
+GateActions["frametime"] = {
+	name = "Frame Time",
+	description = "Returns the CurTime-based time in seconds it took to render the last frame.",
+	inputs = {},
+	outputs = { "Out" },
+	outputtypes = { "NORMAL" },
+	timed = true,
+	output = function(gate)
+		return FrameTime()
+	end,
+	label = function(Out)
+		return string.format("Frame Time = %f", Out.Out)
+	end
+}
+
 
 GateActions()

--- a/lua/wire/gates/time.lua
+++ b/lua/wire/gates/time.lua
@@ -341,20 +341,4 @@ GateActions["servertime"] = {
     end
 }
 
-GateActions["frametime"] = {
-	name = "Frame Time",
-	description = "Returns the CurTime-based time in seconds it took to render the last frame.",
-	inputs = {},
-	outputs = { "Out" },
-	outputtypes = { "NORMAL" },
-	timed = true,
-	output = function(gate)
-		return FrameTime()
-	end,
-	label = function(Out)
-		return string.format("Frame Time = %f", Out.Out)
-	end
-}
-
-
 GateActions()

--- a/lua/wire/gates/unitconv.lua
+++ b/lua/wire/gates/unitconv.lua
@@ -4,65 +4,6 @@
 
 GateActions("Unit Conversion")
 
-local speed = {
-    ["u/s"]   = 1 / 0.75,
-    ["u/m"]   = 60 * (1 / 0.75),
-    ["u/h"]   = 3600 * (1 / 0.75),
-    ["mm/s"]  = 25.4,
-    ["cm/s"]  = 2.54,
-    ["dm/s"]  = 0.254,
-    ["m/s"]   = 0.0254,
-    ["km/s"]  = 0.0000254,
-    ["in/s"]  = 1,
-    ["ft/s"]  = 1 / 12,
-    ["yd/s"]  = 1 / 36,
-    ["mi/s"]  = 1 / 63360,
-    ["nmi/s"] = 127 / 9260000,
-    ["mm/m"]  = 60 * 25.4,
-    ["cm/m"]  = 60 * 2.54,
-    ["dm/m"]  = 60 * 0.254,
-    ["m/m"]   = 60 * 0.0254,
-    ["km/m"]  = 60 * 0.0000254,
-    ["in/m"]  = 60,
-    ["ft/m"]  = 60 / 12,
-    ["yd/m"]  = 60 / 36,
-    ["mi/m"]  = 60 / 63360,
-    ["nmi/m"] = 60 * 127 / 9260000,
-    ["mm/h"]  = 3600 * 25.4,
-    ["cm/h"]  = 3600 * 2.54,
-    ["dm/h"]  = 3600 * 0.254,
-    ["m/h"]   = 3600 * 0.0254,
-    ["km/h"]  = 3600 * 0.0000254,
-    ["in/h"]  = 3600,
-    ["ft/h"]  = 3600 / 12,
-    ["yd/h"]  = 3600 / 36,
-    ["mi/h"]  = 3600 / 63360,
-    ["nmi/h"] = 3600 * 127 / 9260000,
-    ["mph"]   = 3600 / 63360,
-    ["knots"] = 3600 * 127 / 9260000,
-    ["mach"]  = 0.0254 / 295,
-}
-local length = {
-    ["u"]   = 1 / 0.75,
-    ["mm"]  = 25.4,
-    ["cm"]  = 2.54,
-    ["dm"]  = 0.254,
-    ["m"]   = 0.0254,
-    ["km"]  = 0.0000254,
-    ["in"]  = 1,
-    ["ft"]  = 1 / 12,
-    ["yd"]  = 1 / 36,
-    ["mi"]  = 1 / 63360,
-    ["nmi"] = 127 / 9260000,
-}
-local weight = {
-    ["g"]  = 1000,
-    ["kg"] = 1,
-    ["t"]  = 0.001,
-    ["oz"] = 1 / 0.028349523125,
-    ["lb"] = 1 / 0.45359237,
-}
-
 GateActions["unit_tounit"] = {
     name = "To Unit",
     description = "Converts a value from Source units (inches) to the specified unit. Supports speed (m/s, km/h, mph...), length (m, cm, ft...) and weight (kg, lb, oz...).",
@@ -70,12 +11,10 @@ GateActions["unit_tounit"] = {
     inputtypes = { "NORMAL", "STRING" },
     outputtypes = { "NORMAL" },
     output = function(gate, Value, Unit)
-        if speed[Unit] then
-            return (Value * 0.75) * speed[Unit]
-        elseif length[Unit] then
-            return (Value * 0.75) * length[Unit]
-        elseif weight[Unit] then
-            return Value * weight[Unit]
+        for _, tbl in pairs(WireLib.UnitConv) do
+            if tbl[Unit] then
+                return Value * tbl[Unit]
+            end
         end
         return 0
     end,
@@ -91,12 +30,10 @@ GateActions["unit_fromunit"] = {
     inputtypes = { "NORMAL", "STRING" },
     outputtypes = { "NORMAL" },
     output = function(gate, Value, Unit)
-        if speed[Unit] then
-            return (Value / 0.75) / speed[Unit]
-        elseif length[Unit] then
-            return (Value / 0.75) / length[Unit]
-        elseif weight[Unit] then
-            return Value / weight[Unit]
+        for _, tbl in pairs(WireLib.UnitConv) do
+            if tbl[Unit] then
+                return Value / tbl[Unit]
+            end
         end
         return 0
     end,
@@ -107,21 +44,17 @@ GateActions["unit_fromunit"] = {
 
 GateActions["unit_convertunit"] = {
     name = "Convert Unit",
-    description = "Converts a value from one unit to another. Both units must be of the same type (speed, length or weight).",
-    inputs = { "Value", "From", "To" },
-    inputtypes = { "NORMAL", "STRING", "STRING" },
+    description = "Returns the conversion factor between two units. Both units must be of the same type (speed, length or weight).",
+    inputs = { "From", "To" },
+    inputtypes = { "STRING", "STRING" },
     outputtypes = { "NORMAL" },
-    output = function(gate, Value, From, To)
-        if speed[From] and speed[To] then
-            return Value * (speed[To] / speed[From])
-        elseif length[From] and length[To] then
-            return Value * (length[To] / length[From])
-        elseif weight[From] and weight[To] then
-            return Value * (weight[To] / weight[From])
-        end
-        return 0
+    output = function(gate, From, To)
+        local factor = WireLib.ConvertUnit(From, To)
+        return factor or 0
     end,
-    label = function(Out, Value, From, To)
-        return string.format("convertUnit(%s, %q → %q) = %f", tostring(Value), tostring(From), tostring(To), Out)
+    label = function(Out, From, To)
+        return string.format("convertUnit(%q → %q) = %f", tostring(From), tostring(To), Out)
     end
 }
+
+GateActions()

--- a/lua/wire/gates/unitconv.lua
+++ b/lua/wire/gates/unitconv.lua
@@ -1,0 +1,127 @@
+--[[
+		Unit Conversion
+]]
+
+GateActions("Unit Conversion")
+
+local speed = {
+    ["u/s"]   = 1 / 0.75,
+    ["u/m"]   = 60 * (1 / 0.75),
+    ["u/h"]   = 3600 * (1 / 0.75),
+    ["mm/s"]  = 25.4,
+    ["cm/s"]  = 2.54,
+    ["dm/s"]  = 0.254,
+    ["m/s"]   = 0.0254,
+    ["km/s"]  = 0.0000254,
+    ["in/s"]  = 1,
+    ["ft/s"]  = 1 / 12,
+    ["yd/s"]  = 1 / 36,
+    ["mi/s"]  = 1 / 63360,
+    ["nmi/s"] = 127 / 9260000,
+    ["mm/m"]  = 60 * 25.4,
+    ["cm/m"]  = 60 * 2.54,
+    ["dm/m"]  = 60 * 0.254,
+    ["m/m"]   = 60 * 0.0254,
+    ["km/m"]  = 60 * 0.0000254,
+    ["in/m"]  = 60,
+    ["ft/m"]  = 60 / 12,
+    ["yd/m"]  = 60 / 36,
+    ["mi/m"]  = 60 / 63360,
+    ["nmi/m"] = 60 * 127 / 9260000,
+    ["mm/h"]  = 3600 * 25.4,
+    ["cm/h"]  = 3600 * 2.54,
+    ["dm/h"]  = 3600 * 0.254,
+    ["m/h"]   = 3600 * 0.0254,
+    ["km/h"]  = 3600 * 0.0000254,
+    ["in/h"]  = 3600,
+    ["ft/h"]  = 3600 / 12,
+    ["yd/h"]  = 3600 / 36,
+    ["mi/h"]  = 3600 / 63360,
+    ["nmi/h"] = 3600 * 127 / 9260000,
+    ["mph"]   = 3600 / 63360,
+    ["knots"] = 3600 * 127 / 9260000,
+    ["mach"]  = 0.0254 / 295,
+}
+local length = {
+    ["u"]   = 1 / 0.75,
+    ["mm"]  = 25.4,
+    ["cm"]  = 2.54,
+    ["dm"]  = 0.254,
+    ["m"]   = 0.0254,
+    ["km"]  = 0.0000254,
+    ["in"]  = 1,
+    ["ft"]  = 1 / 12,
+    ["yd"]  = 1 / 36,
+    ["mi"]  = 1 / 63360,
+    ["nmi"] = 127 / 9260000,
+}
+local weight = {
+    ["g"]  = 1000,
+    ["kg"] = 1,
+    ["t"]  = 0.001,
+    ["oz"] = 1 / 0.028349523125,
+    ["lb"] = 1 / 0.45359237,
+}
+
+GateActions["unit_tounit"] = {
+    name = "To Unit",
+    description = "Converts a value from Source units (inches) to the specified unit. Supports speed (m/s, km/h, mph...), length (m, cm, ft...) and weight (kg, lb, oz...).",
+    inputs = { "Value", "Unit" },
+    inputtypes = { "NORMAL", "STRING" },
+    outputtypes = { "NORMAL" },
+    output = function(gate, Value, Unit)
+        if speed[Unit] then
+            return (Value * 0.75) * speed[Unit]
+        elseif length[Unit] then
+            return (Value * 0.75) * length[Unit]
+        elseif weight[Unit] then
+            return Value * weight[Unit]
+        end
+        return 0
+    end,
+    label = function(Out, Value, Unit)
+        return string.format("toUnit(%s, %q) = %f", tostring(Value), tostring(Unit), Out)
+    end
+}
+
+GateActions["unit_fromunit"] = {
+    name = "From Unit",
+    description = "Converts a value from the specified unit back to Source units (inches). Supports speed, length and weight.",
+    inputs = { "Value", "Unit" },
+    inputtypes = { "NORMAL", "STRING" },
+    outputtypes = { "NORMAL" },
+    output = function(gate, Value, Unit)
+        if speed[Unit] then
+            return (Value / 0.75) / speed[Unit]
+        elseif length[Unit] then
+            return (Value / 0.75) / length[Unit]
+        elseif weight[Unit] then
+            return Value / weight[Unit]
+        end
+        return 0
+    end,
+    label = function(Out, Value, Unit)
+        return string.format("fromUnit(%s, %q) = %f", tostring(Value), tostring(Unit), Out)
+    end
+}
+
+GateActions["unit_convertunit"] = {
+    name = "Convert Unit",
+    description = "Converts a value from one unit to another. Both units must be of the same type (speed, length or weight).",
+    inputs = { "Value", "From", "To" },
+    inputtypes = { "NORMAL", "STRING", "STRING" },
+    outputtypes = { "NORMAL" },
+    output = function(gate, Value, From, To)
+        if speed[From] and speed[To] then
+            return Value * (speed[To] / speed[From])
+        elseif length[From] and length[To] then
+            return Value * (length[To] / length[From])
+        elseif weight[From] and weight[To] then
+            return Value * (weight[To] / weight[From])
+        end
+        return 0
+    end,
+    label = function(Out, Value, From, To)
+        return string.format("convertUnit(%s, %q → %q) = %f", tostring(Value), tostring(From), tostring(To), Out)
+    end
+}

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -204,6 +204,107 @@ WireLib.DT = {
 	},
 }
 
+--- Conversion factors for unit conversion gates and E2 functions.
+--- Each value represents the factor to convert from natural units to this unit.
+--- Natural units: inches for length/speed, kilograms for weight.
+---
+--- Unit abbreviations:
+---   u   - Source unit (1 Source Unit = 0.75 inches)
+---         See: http://developer.valvesoftware.com/wiki/Dimensions#Map_Grid_Units:_quick_reference
+---   mm  - millimeter
+---   cm  - centimeter
+---   dm  - decimeter
+---   m   - meter
+---   km  - kilometer
+---   in  - inch
+---   ft  - foot
+---   yd  - yard
+---   mi  - mile
+---   nmi - nautical mile
+---   g   - gram
+---   kg  - kilogram
+---   t   - tonne
+---   oz  - ounce
+---   lb  - pound
+---@type table<string, table<string, number>>
+WireLib.UnitConv = {
+    --- Speed units (natural unit: in/s)
+    speed = {
+        ["u/s"]   = 1 / 0.75,
+        ["u/m"]   = 60 * (1 / 0.75),
+        ["u/h"]   = 3600 * (1 / 0.75),
+        ["mm/s"]  = 25.4,
+        ["cm/s"]  = 2.54,
+        ["dm/s"]  = 0.254,
+        ["m/s"]   = 0.0254,
+        ["km/s"]  = 0.0000254,
+        ["in/s"]  = 1,
+        ["ft/s"]  = 1 / 12,
+        ["yd/s"]  = 1 / 36,
+        ["mi/s"]  = 1 / 63360,
+        ["nmi/s"] = 127 / 9260000,
+        ["mm/m"]  = 60 * 25.4,
+        ["cm/m"]  = 60 * 2.54,
+        ["dm/m"]  = 60 * 0.254,
+        ["m/m"]   = 60 * 0.0254,
+        ["km/m"]  = 60 * 0.0000254,
+        ["in/m"]  = 60,
+        ["ft/m"]  = 60 / 12,
+        ["yd/m"]  = 60 / 36,
+        ["mi/m"]  = 60 / 63360,
+        ["nmi/m"] = 60 * 127 / 9260000,
+        ["mm/h"]  = 3600 * 25.4,
+        ["cm/h"]  = 3600 * 2.54,
+        ["dm/h"]  = 3600 * 0.254,
+        ["m/h"]   = 3600 * 0.0254,
+        ["km/h"]  = 3600 * 0.0000254,
+        ["in/h"]  = 3600,
+        ["ft/h"]  = 3600 / 12,
+        ["yd/h"]  = 3600 / 36,
+        ["mi/h"]  = 3600 / 63360,
+        ["nmi/h"] = 3600 * 127 / 9260000,
+        ["mph"]   = 3600 / 63360,
+        ["knots"] = 3600 * 127 / 9260000,
+        ["mach"]  = 0.0254 / 295,
+    },
+    --- Length units (natural unit: inches)
+    length = {
+        ["u"]   = 1 / 0.75,
+        ["mm"]  = 25.4,
+        ["cm"]  = 2.54,
+        ["dm"]  = 0.254,
+        ["m"]   = 0.0254,
+        ["km"]  = 0.0000254,
+        ["in"]  = 1,
+        ["ft"]  = 1 / 12,
+        ["yd"]  = 1 / 36,
+        ["mi"]  = 1 / 63360,
+        ["nmi"] = 127 / 9260000,
+    },
+    --- Weight units (natural unit: kilograms)
+    weight = {
+        ["g"]  = 1000,
+        ["kg"] = 1,
+        ["t"]  = 0.001,
+        ["oz"] = 1 / 0.028349523125,
+        ["lb"] = 1 / 0.45359237,
+    },
+}
+
+--- Returns the conversion factor between two units.
+--- Returns nil if units are unknown or of different types.
+---@param from string
+---@param to string
+---@return number|nil
+function WireLib.ConvertUnit(from, to)
+    for _, tbl in pairs(WireLib.UnitConv) do
+        if tbl[from] and tbl[to] then
+            return tbl[to] / tbl[from]
+        end
+    end
+    return nil
+end
+
 --- Gets default value of a WireLib type.
 --- Assumes `type` is a valid string type in the WireLib.DT table.
 --- For example `VECTOR` / `NORMAL` / `ARRAY`


### PR DESCRIPTION
It might not be the end of the list, so feel free to suggest your ideas — what you’ve been missing in the gates and what would actually be useful in practice 🙃 

Entity gates:
- entity_vehicle: returns the vehicle a player is sitting in
- entity_getmovetype: returns move type enum (WALK, NOCLIP, FLY, etc.)
- entity_activeweapon: returns the weapon a player is currently holding
- entity_weapons: returns an array of all weapons in player inventory
- entity_eyepos: returns the world position of a player's eyes
- entity_getchildren: returns an array of children parented to an entity

Ranger gates:
- rd_hull_pos: hull trace between two positions with optional entity parenting
- rd_hull_ang: hull trace by angle and distance with optional entity parenting
- Both hull trace gates support Filter (ARRAY) and Parent (ENTITY) inputs

Misc:
- frametime: returns the time in seconds it took to render the last frame
- added reciever01d to interactive prop