### PR TITLE
Fix lua error

### DIFF
--- a/lua/entities/gmod_wire_spu/cl_init.lua
+++ b/lua/entities/gmod_wire_spu/cl_init.lua
@@ -55,9 +55,13 @@ local function SPU_SoundSources(um)
   if not SPU:IsValid() then return end
 
   for i=0,WireSPU_MaxChannels-1 do
-    SPU.SoundSources[i] = ents.GetByIndex(um:ReadLong())
-    SPU.SoundSources[i]:SetNoDraw(true)
-    SPU.SoundSources[i]:SetModelScale(0,0)
+    local soundsource = ents.GetByIndex(um:ReadLong())
+
+    if soundsource:IsValid() then
+      SPU.SoundSources[i] = soundsource
+      SPU.SoundSources[i]:SetNoDraw(true)
+      SPU.SoundSources[i]:SetModelScale(0,0)
+    end
   end
 
   -- Reset VM


### PR DESCRIPTION
Fixes:
```
- addons/wire/lua/entities/gmod_wire_spu/cl_init.lua:59: Tried to use a NULL entity!
1. SetNoDraw - [C]:-1
 2. Function - addons/wire/lua/entities/gmod_wire_spu/cl_init.lua:59
  3. <unknown> - lua/includes/modules/usermessage.lua:80
```
There may be a better solution, but i still don't understand the zcpu structure very well