### PR TITLE
Allow duplicate inputs in FPGAs

### DIFF
--- a/lua/entities/gmod_wire_fpga/init.lua
+++ b/lua/entities/gmod_wire_fpga/init.lua
@@ -311,7 +311,7 @@ function ENT:ValidateData(data)
 		if gate.isInput then
 			if not node.ioName then return "missing input name" end
 			if inputTypes[node.ioName] then
-				if inputTypes[node.ioName] != getOutputType(gate, 1) then return "duplicate input name (" .. node.ioName .. ") with different type " end
+				if inputTypes[node.ioName] != getOutputType(gate, 1) then return "duplicate input name (" .. node.ioName .. ") where type differs" end
 			end
 			if node.ioName == "Trigger" then return "'Trigger' input name is reserved" end
 			inputNames[node.ioName] = true


### PR DESCRIPTION
closes #3515 

You can now have multiple inputs inside an FPGA with the same name, all mapping to the same wire input on the FPGA gate

Also added serverside compile checks for multiple inputs with same name but different type - as that is still not allowed