### PR TITLE
Fix timer error for invalid entity

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/timer.lua
+++ b/lua/entities/gmod_wire_expression2/core/timer.lua
@@ -104,7 +104,9 @@ local function luaTimerCreate(self, name, delay, repetitions, callback)
 	}
 
 	timer.Create(internalName, delay, repetitions, function()
-		ent:Execute(callback)
+		if ent:IsValid() then
+			ent:Execute(callback)
+		end
 
 		if timer.RepsLeft(internalName) == 0 and luaTimers[entIndex] then
 			luaTimers[entIndex][name] = nil


### PR DESCRIPTION
Timer can fire after the entity has been removed

Error variable trace (ignore the stdout color control chars)
```
[38;2;156;241;255mTraces of level 1 (Execute)
[39m[38;2;156;241;255m- Local 1 (Level) (number) = 1
[39m[38;2;156;241;255m- Local 2 (Info) (table) = table: 0x80887ef681ce68b2
[39m[38;2;156;241;255m- Local 3 (Indent) (string) = 
[39m[38;2;156;241;255m- Local 4 (Function) (function) = function: 0x80887ef6b2cb1ffa
[39m[38;2;156;241;255m- Local 5 (FunctionName) (string) = Execute
[39m[38;2;156;241;255m- Local 6 (Local) (number) = 6
[39m[38;2;156;241;255m	Traces of level 2 ([Unknown Function])
[39m[38;2;156;241;255m	- UpValue 1 (ent) (Entity) = Entity [Invalid]
[39m[38;2;156;241;255m	- UpValue 2 (callback) (function) = function: 0x80887ef6fcac4bba
[39m[38;2;156;241;255m	- UpValue 3 (internalName) (string) = 479_gmod_wire_expression2_luatimer_simpletimer_19
[39m[38;2;156;241;255m	- UpValue 4 (luaTimers) (table) = table: 0x80887ef6b1cb69b2
[39m[38;2;156;241;255m	- UpValue 5 (entIndex) (number) = 479
[39m[38;2;156;241;255m	- UpValue 6 (name) (string) = simpletimer_19
[39m[38;2;156;241;255m	- Local 1 ((*temporary)) (nil) = nil
[39m[38;2;156;241;255m	- Local 2 ((*temporary)) (number) = 6.4624744847913e-310
[39m[38;2;156;241;255m	- Local 3 ((*temporary)) (Entity) = Entity [Invalid]
[39m[38;2;156;241;255m	- Local 4 ((*temporary)) (function) = function: 0x80887ef6fcac4bba
[39m[38;2;156;241;255m	- Local 5 ((*temporary)) (string) = attempt to call method 'Execute' (a nil value)
[39m[38;2;156;241;255m
[ERROR] entities/gmod_wire_expression2/core/timer.lua:107: attempt to call method 'Execute' (a nil value)
  1. unknown - entities/gmod_wire_expression2/core/timer.lua:107

[39m[38;2;156;241;255mTimer Failed! [479_gmod_wire_expression2_luatimer_simpletimer_19][@entities/gmod_wire_expression2/core/timer.lua (line 106)]
```