### PR TITLE
Fix `WireLib.ClientError` overflow

### DIFF
--- a/lua/wire/wireshared.lua
+++ b/lua/wire/wireshared.lua
@@ -306,7 +306,7 @@ elseif SERVER then
 	util.AddNetworkString("wire_clienterror")
 	function WireLib.ClientError(message, ply)
 		net.Start("wire_clienterror")
-			net.WriteString(message)
+			net.WriteString(string.sub(message, 1, 65532))
 		net.Send(ply)
 	end
 end


### PR DESCRIPTION
Fixes:
```
@name 
@inputs 
@outputs 
@persist 
@trigger none 
@strict

error("g":repeat(100000))
```
```
[Wiremod Canary] Trying to send an overflowed net message!
    1. ClientError - lua/wire/wireshared.lua:310
        2. Error - lua/entities/gmod_wire_expression2/init.lua:330
            3. Execute - lua/entities/gmod_wire_expression2/init.lua:153
                4. Setup - lua/entities/gmod_wire_expression2/init.lua:569
                    5. unknown - lua/wire/stools/expression2.lua:400
                        6. xpcall - [C]:-1
                            7. Remove - lua/autorun/netstream.lua:279
                                8. Read - lua/autorun/netstream.lua:258
                                    9. Read - lua/autorun/netstream.lua:131
                                        10. func - lua/autorun/netstream.lua:385
                                            11. unknown - lua/includes/extensions/net.lua:34
```