### PR TITLE
Add `nil` check in `wire_expression2_CallHook`

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/init.lua
+++ b/lua/entities/gmod_wire_expression2/core/init.lua
@@ -66,7 +66,7 @@ function registerType(name, id, def, input_serialize, output_serialize, type_che
 end
 
 function wire_expression2_CallHook(hookname, ...)
-	if not wire_expression_callbacks[hookname] then return end
+	if not wire_expression_callbacks or not wire_expression_callbacks[hookname] then return end
 	local ret_array = {}
 	local errors = {}
 	local ok, ret


### PR DESCRIPTION
Without this, attempting to call `E2Lib.replace_function` in `PreLoadExtensions` will result in an error, although this is the most reliable way to modify E2Lib