### PR TITLE
Fix remote uploader upload lock

### DIFF
--- a/lua/wire/stools/expression2.lua
+++ b/lua/wire/stools/expression2.lua
@@ -590,7 +590,7 @@ if CLIENT then
 
 		net.Start( "wire_expression2_upload" )
 			net.WriteUInt( targetEntID, 16 )
-			net.WriteStream( datastr, function()
+			uploading = net.WriteStream( datastr, function()
 				uploading = false
 				uploadNext()
 			end )
@@ -600,6 +600,7 @@ if CLIENT then
 	-- Upload fail
 	net.Receive("wire_expression2_upload", function()
 		WireLib.AddNotify(LocalPlayer(), net.ReadString(), NOTIFY_ERROR, 7, NOTIFYSOUND_DRIP3)
+		uploading:Remove()
 		uploading = false
 	end)
 


### PR DESCRIPTION
If an error occurs while transferring a chip, the player will never be able to send the chip again until they restart. This should now be fixed with a fallback message

Fixes:
```
- Put an E2 into the Remote Updater panel
- Remove the E2
- Upload to the invalid E2 via Remote Updater
- "Invalid E2 specified, Upload aborted."
- E2 is now disabled until rejoin
```