### PR TITLE
Add vehicle inputs to Eye Pods

### DIFF
--- a/lua/entities/gmod_wire_eyepod.lua
+++ b/lua/entities/gmod_wire_eyepod.lua
@@ -293,7 +293,7 @@ function ENT:TriggerInput(iname, value)
 		if( not IsValid(value) ) then return end
 
 		self:LinkEnt(value)
-	elseif name == "Vehicles" then
+	elseif iname == "Vehicles" then
 		for k, v in ipairs( value ) do
 			if( TypeID(v) ~= TYPE_ENTITY ) then continue end
 			if( not IsValid(v) ) then continue end

--- a/lua/entities/gmod_wire_eyepod.lua
+++ b/lua/entities/gmod_wire_eyepod.lua
@@ -62,7 +62,7 @@ function ENT:Initialize()
 	self:DrawShadow(false)
 
 	-- Set wire I/O
-	self.Inputs = WireLib.CreateSpecialInputs(self, { "Enable", "SetPitch", "SetYaw", "SetViewAngle", "UnfreezePitch", "UnfreezeYaw", "Vehicle [ENTITY]", "Vehicles (Links all vehicles of passed array to this pod controller) [ARRAY]" }, { "NORMAL", "NORMAL", "NORMAL", "ANGLE", "NORMAL", "NORMAL", "ENTITY", "TABLE" })
+	self.Inputs = WireLib.CreateSpecialInputs(self, { "Enable", "SetPitch", "SetYaw", "SetViewAngle", "UnfreezePitch", "UnfreezeYaw", "Vehicle [ENTITY]", "Vehicles (Links all vehicles of passed array to this pod controller) [ARRAY]" }, { "NORMAL", "NORMAL", "NORMAL", "ANGLE", "NORMAL", "NORMAL", "ENTITY", "ARRAY" })
 	self.Outputs = WireLib.CreateSpecialOutputs(self, { "X", "Y", "XY" }, { "NORMAL", "NORMAL", "VECTOR2" })
 
 	-- Initialize values

--- a/lua/entities/gmod_wire_eyepod.lua
+++ b/lua/entities/gmod_wire_eyepod.lua
@@ -288,7 +288,7 @@ function ENT:TriggerInput(iname, value)
 		self.freezePitch = value == 0
 	elseif iname == "UnfreezeYaw" then
 		self.freezeYaw = value == 0
-	elseif iname == "Vehicle"
+	elseif iname == "Vehicle" then
 		if( TypeID(value) ~= TYPE_ENTITY ) then return end
 		if( not IsValid(value) ) then return end
 

--- a/lua/entities/gmod_wire_eyepod.lua
+++ b/lua/entities/gmod_wire_eyepod.lua
@@ -62,7 +62,7 @@ function ENT:Initialize()
 	self:DrawShadow(false)
 
 	-- Set wire I/O
-	self.Inputs = WireLib.CreateSpecialInputs(self, { "Enable", "SetPitch", "SetYaw", "SetViewAngle", "UnfreezePitch", "UnfreezeYaw" }, { "NORMAL", "NORMAL", "NORMAL", "ANGLE", "NORMAL", "NORMAL" })
+	self.Inputs = WireLib.CreateSpecialInputs(self, { "Enable", "SetPitch", "SetYaw", "SetViewAngle", "UnfreezePitch", "UnfreezeYaw", "Vehicle [ENTITY]", "Vehicles (Links all vehicles of passed array to this pod controller) [ARRAY]" }, { "NORMAL", "NORMAL", "NORMAL", "ANGLE", "NORMAL", "NORMAL", "ENTITY", "TABLE" })
 	self.Outputs = WireLib.CreateSpecialOutputs(self, { "X", "Y", "XY" }, { "NORMAL", "NORMAL", "VECTOR2" })
 
 	-- Initialize values
@@ -288,6 +288,17 @@ function ENT:TriggerInput(iname, value)
 		self.freezePitch = value == 0
 	elseif iname == "UnfreezeYaw" then
 		self.freezeYaw = value == 0
+	elseif iname == "Vehicle"
+		if( TypeID(value) ~= TYPE_ENTITY ) then return end
+		if( not IsValid(value) ) then return end
+
+		self:LinkEnt(value)
+	elseif name == "Vehicles" then
+		for k, v in ipairs( value ) do
+			if( TypeID(v) ~= TYPE_ENTITY ) then continue end
+			if( not IsValid(v) ) then continue end
+			self:LinkEnt( v )
+		end
 	end
 
 	if IsValid(self.pod) and IsValid(self.driver) then


### PR DESCRIPTION
Adds a "Vehicle" input to Eye Pods for feature parity with #3263 which will allow seats created later to gain Eye Pod functionality.