### PR TITLE
Add Expression2_PostCompileHook

### DIFF
--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -461,6 +461,7 @@ function ENT:CompileCode(buffer, files, filepath)
 	if not status then self:Error(tree.message) return end
 
 	if not self:PrepareIncludes(files) then return end
+	hook.Run("Expression2_PostCompile", self.player, self, buffer, directives)
 
 	local status, script, inst = E2Lib.Compiler.Execute(tree, directives, dvars, self.includes)
 	if not status then self:Error(script.message) return end


### PR DESCRIPTION
Will make chip logging easier to make, let's find out if the chip was actually compiled and get its directives (before the first execution)