### PR TITLE
Fix nil error

### DIFF
--- a/lua/wire/client/gmod_tool_auto.lua
+++ b/lua/wire/client/gmod_tool_auto.lua
@@ -77,7 +77,7 @@ end)
 concommand.Add("toolcpanel", function(ply,cmd,args)
 	local toolname = args[1]
 	if not toolname then return end
-		
+
 	local panel = toolbuttons["gmod_tool " .. toolname]
 	if panel then panel:DoClick() end
 end)

--- a/lua/wire/client/gmod_tool_auto.lua
+++ b/lua/wire/client/gmod_tool_auto.lua
@@ -75,7 +75,10 @@ hook.Add("PostReloadToolsMenu", "toolcpanel_ListTools",function()
 	end
 end)
 concommand.Add("toolcpanel", function(ply,cmd,args)
-	local panel = toolbuttons["gmod_tool "..args[1]]
+	local toolname = args[1]
+	if not toolname then return end
+		
+	local panel = toolbuttons["gmod_tool " .. toolname]
 	if panel then panel:DoClick() end
 end)
 


### PR DESCRIPTION
Fixes:
```
- addons/wire/lua/wire/client/gmod_tool_auto.lua:78: attempt to concatenate a nil value
1. <unknown> - addons/wire/lua/wire/client/gmod_tool_auto.lua:78
 2. <unknown> - lua/includes/modules/concommand.lua:54
```