### PR TITLE
Fixes CD disk stacks

### DIFF
--- a/lua/entities/gmod_wire_cd_disk.lua
+++ b/lua/entities/gmod_wire_cd_disk.lua
@@ -74,7 +74,7 @@ function ENT:Setup(precision, iradius, skin)
 
 	self.DiskSectors = 0
 	self.TrackSectors = {}
-	self.FirstTrack = math.floor((self.IRadius) / self.Precision)
+	self.FirstTrack = math.floor(self.IRadius / self.Precision)
 	for i=self.FirstTrack,self.DiskTracks-1 do
 		self.TrackSectors[i] = self.DiskSectors
 		self.DiskSectors = self.DiskSectors + math.floor(2*3.1415926*i) + 1

--- a/lua/entities/gmod_wire_cd_disk.lua
+++ b/lua/entities/gmod_wire_cd_disk.lua
@@ -69,8 +69,6 @@ function ENT:Setup(precision, iradius, skin)
 	if iradius then self.IRadius = math.max(iradius,0) end
 	if skin then self.Skin = skin self:SetSkin(skin) end
 
-	self.StackStartHeight = -min.z
-
 	self.DiskStacks = math.max(1,math.floor((max.z - min.z) / self.Precision)+1)
 	self.DiskTracks = math.floor(0.5*math.min(max.x - min.x,max.y - min.y) / self.Precision)
 

--- a/lua/entities/gmod_wire_cd_ray.lua
+++ b/lua/entities/gmod_wire_cd_ray.lua
@@ -174,7 +174,10 @@ function ENT:Think()
 
 		local r = (lpos.x^2+lpos.y^2)^0.5 //radius
 		local a = math.fmod(3.1415926+math.atan2(lpos.x,lpos.y),2*3.1415926) //angle
-		local h = lpos.z-disk.StackStartHeight //stack
+		
+		local mins, maxs = disk:GetPhysicsObject():GetAABB() --axis aligned bounding box
+		local n = (lpos.z - mins.z) / (maxs.z - mins.z) --normalize the hit position to the bounding box's thickness: bottom of disk = 0, top of disk = 1
+		local h = math.Clamp(n * disk.DiskStacks, 0, disk.DiskStacks - 1) --stack = normalized hit position * stack amount
 
 		local track = math.floor(r / disk.Precision)
 		local sector = math.floor(a*track)//*disk.Precision)

--- a/lua/entities/gmod_wire_cd_ray.lua
+++ b/lua/entities/gmod_wire_cd_ray.lua
@@ -18,36 +18,36 @@ function ENT:Initialize()
 	self.Outputs = Wire_CreateOutputs(self, {"Data","Sector","LocalSector","Track","Stack","Address"})
 
 	self.Command = {}
-	self.Command[0]  = 0 //[W] Write ray on
-	self.Command[1]  = 0 //[W] Read ray on
-	self.Command[2]  = 0 //[R] Current sector (global)
-	self.Command[3]  = 0 //[R] Current sector (on track)
-	self.Command[4]  = 0 //[R] Current track
-	self.Command[5]  = 0 //[R] Current stack
-	self.Command[6]  = 0 //[R] Current address (global)
-	self.Command[7]  = 0 //[R] Current address (in current stack)
+	self.Command[0]  = 0 --[W] Write ray on
+	self.Command[1]  = 0 --[W] Read ray on
+	self.Command[2]  = 0 --[R] Current sector (global)
+	self.Command[3]  = 0 --[R] Current sector (on track)
+	self.Command[4]  = 0 --[R] Current track
+	self.Command[5]  = 0 --[R] Current stack
+	self.Command[6]  = 0 --[R] Current address (global)
+	self.Command[7]  = 0 --[R] Current address (in current stack)
 
-	self.Command[8]  = 0 //[W] Buffer ready (read or write - pick the ray)
-	self.Command[9]  = 0 //[W] Continious mode
-	self.Command[10] = 0 //[W] Wait for address mode
-	self.Command[11] = 0 //[W] Target address (in current stack)
-	self.Command[12] = 0 //[W] Wait for track&sector mode
-	self.Command[13] = 0 //[W] Target sector
-	self.Command[14] = 0 //[W] Target track
+	self.Command[8]  = 0 --[W] Buffer ready (read or write - pick the ray)
+	self.Command[9]  = 0 --[W] Continious mode
+	self.Command[10] = 0 --[W] Wait for address mode
+	self.Command[11] = 0 --[W] Target address (in current stack)
+	self.Command[12] = 0 --[W] Wait for track&sector mode
+	self.Command[13] = 0 --[W] Target sector
+	self.Command[14] = 0 --[W] Target track
 
-	self.Command[21] = 0 //[R] Raw disk spin velocity
-	self.Command[22] = 0 //[R] Raw disk spin angle
-	self.Command[23] = 0 //[R] Raw distance from disk center
-	self.Command[24] = 0 //[R] Raw stack index
+	self.Command[21] = 0 --[R] Raw disk spin velocity
+	self.Command[22] = 0 --[R] Raw disk spin angle
+	self.Command[23] = 0 --[R] Raw distance from disk center
+	self.Command[24] = 0 --[R] Raw stack index
 
-	self.Command[25] = 0 //[R] Disk precision (Inches Per Block)
-	self.Command[26] = 0 //[R] Disk sectors (total)
-	self.Command[27] = 0 //[R] Disk tracks (total)
-	self.Command[28] = 0 //[R] First track number
-	self.Command[29] = 0 //[R] Bytes per block
-	self.Command[30] = 0 //[R] Disk size (per stack)
-	self.Command[31] = 0 //[R] Disk volume (bytes total)
-	self.Command[32] = 0 //[R] Disk entity id
+	self.Command[25] = 0 --[R] Disk precision (Inches Per Block)
+	self.Command[26] = 0 --[R] Disk sectors (total)
+	self.Command[27] = 0 --[R] Disk tracks (total)
+	self.Command[28] = 0 --[R] First track number
+	self.Command[29] = 0 --[R] Bytes per block
+	self.Command[30] = 0 --[R] Disk size (per stack)
+	self.Command[31] = 0 --[R] Disk volume (bytes total)
+	self.Command[32] = 0 --[R] Disk entity id
 
 	self.WriteBuffer = {}
 	self.PrevDiskEnt = nil
@@ -133,10 +133,10 @@ function ENT:DoJob()
 
 		if dojob then
 			if (self.Command[9] == 0) then self.Command[8] = 0 end
-			local sector_addr = self.Sector.."."..self.Track.."."..self.Stack//{s=sector,t=track,st=stack}
-			if (self.Command[0] ~= 0) then //write ray
+			local sector_addr = self.Sector.."."..self.Track.."."..self.Stack--{s=sector,t=track,st=stack}
+			if (self.Command[0] ~= 0) then --write ray
 				disk.DiskMemory[sector_addr] = table.Copy(self.WriteBuffer)
-			else //read ray
+			else --read ray
 				self.WriteBuffer = table.Copy(disk.DiskMemory[sector_addr]) or { [0] = 0 }
 			end
 		end
@@ -163,24 +163,22 @@ function ENT:Think()
 		self:SetColor(Color(255, 255, 255, 255))
 	end
 
-	if ((trace.Entity) and
-		(trace.Entity:IsValid()) and
-		(trace.Entity:GetClass() == "gmod_wire_cd_disk")) then
+	if trace.Entity and trace.Entity:IsValid() and trace.Entity:GetClass() == "gmod_wire_cd_disk" then
 		local pos = trace.HitPos
 		local disk = trace.Entity
 		local lpos = disk:WorldToLocal(pos)
 
 		local vel = disk.Entity:GetPhysicsObject():GetAngleVelocity().z
 
-		local r = (lpos.x^2+lpos.y^2)^0.5 //radius
-		local a = math.fmod(3.1415926+math.atan2(lpos.x,lpos.y),2*3.1415926) //angle
+		local r = (lpos.x^2+lpos.y^2)^0.5 --radius
+		local a = math.fmod(3.1415926+math.atan2(lpos.x,lpos.y),2*3.1415926) --angle
 
 		local mins, maxs = disk:GetPhysicsObject():GetAABB() --axis aligned bounding box
 		local n = (lpos.z - mins.z) / (maxs.z - mins.z) --normalize the hit position to the bounding box's thickness: bottom of disk = 0, top of disk = 1
 		local h = math.Clamp(n * disk.DiskStacks, 0, disk.DiskStacks - 1) --stack = normalized hit position * stack amount: if we have a disk with 4 stacks and our hit position is 0.6 we'd get stack 2 (0.6 x 4 = 2.4, floored to 2 later)
 
 		local track = math.floor(r / disk.Precision)
-		local sector = math.floor(a*track)//*disk.Precision)
+		local sector = math.floor(a*track)--*disk.Precision)
 		local stack = math.floor(h/disk.Precision)
 		if (disk.DiskStacks == 1) then stack = 0 end
 
@@ -198,21 +196,21 @@ function ENT:Think()
 		end
 
 		if ((track >= disk.FirstTrack) and (stack >= 0) and (sector >= 0) and
-			//(track < disk.DiskTracks) and
+			--(track < disk.DiskTracks) and
 			(stack < disk.DiskStacks)) then
-			self.Command[21] = vel //[R] Raw disk spin velocity
-			self.Command[22] = a //[R] Raw disk spin angle
-			self.Command[23] = r //[R] Raw distance from disk center
-			self.Command[24] = h //[R] Raw stack index
+			self.Command[21] = vel --[R] Raw disk spin velocity
+			self.Command[22] = a --[R] Raw disk spin angle
+			self.Command[23] = r --[R] Raw distance from disk center
+			self.Command[24] = h --[R] Raw stack index
 
 			if (not disk.TrackSectors[track]) then disk.TrackSectors[track] = 0 end
 
-			self.Command[2]  = disk.DiskSectors*stack+disk.TrackSectors[track]+sector //[R] Current sector (global)
-			self.Command[3]  = sector //[R] Current sector (on track)
-			self.Command[4]  = track //[R] Current track
-			self.Command[5]  = stack //[R] Current stack
-			self.Command[6]  = self.Command[2]*disk.BytesPerBlock //[R] Current address (global)
-			self.Command[7]  = (disk.TrackSectors[track]+sector)*disk.BytesPerBlock //[R] Current address (in current stack)
+			self.Command[2]  = disk.DiskSectors*stack+disk.TrackSectors[track]+sector --[R] Current sector (global)
+			self.Command[3]  = sector --[R] Current sector (on track)
+			self.Command[4]  = track --[R] Current track
+			self.Command[5]  = stack --[R] Current stack
+			self.Command[6]  = self.Command[2]*disk.BytesPerBlock --[R] Current address (global)
+			self.Command[7]  = (disk.TrackSectors[track]+sector)*disk.BytesPerBlock --[R] Current address (in current stack)
 
 			if ((self.Command[0] ~= 0) or (self.Command[1] ~= 0)) then
 				self.Sector = sector
@@ -259,7 +257,7 @@ function ENT:Think()
 		self.Command[32] = 0
 	end
 
-	//Update output
+	--Update output
 	if (self.WriteBuffer[0]) then
 		Wire_TriggerOutput(self, "Data",self.WriteBuffer[0])
 	else

--- a/lua/entities/gmod_wire_cd_ray.lua
+++ b/lua/entities/gmod_wire_cd_ray.lua
@@ -174,10 +174,10 @@ function ENT:Think()
 
 		local r = (lpos.x^2+lpos.y^2)^0.5 //radius
 		local a = math.fmod(3.1415926+math.atan2(lpos.x,lpos.y),2*3.1415926) //angle
-		
+
 		local mins, maxs = disk:GetPhysicsObject():GetAABB() --axis aligned bounding box
 		local n = (lpos.z - mins.z) / (maxs.z - mins.z) --normalize the hit position to the bounding box's thickness: bottom of disk = 0, top of disk = 1
-		local h = math.Clamp(n * disk.DiskStacks, 0, disk.DiskStacks - 1) --stack = normalized hit position * stack amount
+		local h = math.Clamp(n * disk.DiskStacks, 0, disk.DiskStacks - 1) --stack = normalized hit position * stack amount: if we have a disk with 4 stacks and our hit position is 0.6 we'd get stack 2 (0.6 x 4 = 2.4, floored to 2 later)
 
 		local track = math.floor(r / disk.Precision)
 		local sector = math.floor(a*track)//*disk.Precision)

--- a/lua/entities/gmod_wire_cd_ray.lua
+++ b/lua/entities/gmod_wire_cd_ray.lua
@@ -175,11 +175,11 @@ function ENT:Think()
 
 		local mins, maxs = disk:GetPhysicsObject():GetAABB() --axis aligned bounding box
 		local n = (lpos.z - mins.z) / (maxs.z - mins.z) --normalize the hit position to the bounding box's thickness: bottom of disk = 0, top of disk = 1
-		local h = math.Clamp(n * disk.DiskStacks, 0, disk.DiskStacks - 1) --stack = normalized hit position * stack amount: if we have a disk with 4 stacks and our hit position is 0.6 we'd get stack 2 (0.6 x 4 = 2.4, floored to 2 later)
+		local h = math.Clamp(n * disk.DiskStacks, 0, disk.DiskStacks - 1) --stack = normalized hit position * stack amount: if we have a disk with 4 stacks and our hit position is 0.6 we'd get stack 2 (0.6 x 4 = 2.4, rounded to 2 later)
 
 		local track = math.floor(r / disk.Precision)
 		local sector = math.floor(a*track)--*disk.Precision)
-		local stack = math.floor(h/disk.Precision)
+		local stack = math.Round(h/disk.Precision)
 		if (disk.DiskStacks == 1) then stack = 0 end
 
 		if (self.PrevDiskEnt ~= disk) then


### PR DESCRIPTION
Trying to use the other stacks on CD disks is like completely broken.

Large disk, you can't use the fourth stack.
Medium disk, you can't use the first and fourth stack.
Small disk, you can only use the third stack.

This will (hopefully) fix that issue.
I've tested this with different disk models like circle4x4 and it seems to work fine.