### PR TITLE
Fix eyepod unlink error

### DIFF
--- a/lua/entities/gmod_wire_eyepod.lua
+++ b/lua/entities/gmod_wire_eyepod.lua
@@ -166,7 +166,9 @@ function ENT:LinkEnt(vehicle)
 	end
 	self.pod = vehicle
 	vehicle:CallOnRemove("wire_eyepod_remove",function()
-		self:UnlinkEnt(vehicle)
+		if self:IsValid() then
+			self:UnlinkEnt(vehicle)
+		end
 	end)
 
 	self.rotate90 = false


### PR DESCRIPTION
Fixes:
```
- addons/wire/lua/entities/gmod_wire_eyepod.lua:169: attempt to call method 'UnlinkEnt' (a nil value)
1. <unknown> - addons/wire/lua/entities/gmod_wire_eyepod.lua:169
 2. ProtectedCall - [C]:-1
  3. <unknown> - lua/includes/extensions/entity.lua:158
   4. <unknown> - addons/hook-library/lua/includes/modules/hook.lua:313
```