### PR TITLE
Add convar for window width of E2 time quota moving average

### DIFF
--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -24,14 +24,14 @@ do
 			e2_hardquota = 1000000
 			e2_tickquota = 100000
 			e2_timequota = -1
-			e2_timeaverage = -1
 		else
 			e2_softquota = wire_expression2_quotasoft:GetFloat()
 			e2_hardquota = wire_expression2_quotahard:GetFloat()
 			e2_tickquota = wire_expression2_quotatick:GetFloat()
 			e2_timequota = wire_expression2_quotatime:GetFloat() * 0.001
-			e2_timeaverage = 1 / wire_expression2_quota_average:GetFloat()
 		end
+
+		e2_timeaverage = 1 / wire_expression2_quota_average:GetFloat()
 	end
 	cvars.AddChangeCallback("wire_expression2_unlimited", updateQuotas)
 	cvars.AddChangeCallback("wire_expression2_quotasoft", updateQuotas)

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -8,6 +8,7 @@ e2_softquota = nil
 e2_hardquota = nil
 e2_tickquota = nil
 e2_timequota = nil
+e2_timeaverage = nil
 
 do
 	local wire_expression2_unlimited = GetConVar("wire_expression2_unlimited")
@@ -15,6 +16,7 @@ do
 	local wire_expression2_quotahard = GetConVar("wire_expression2_quotahard")
 	local wire_expression2_quotatick = GetConVar("wire_expression2_quotatick")
 	local wire_expression2_quotatime = GetConVar("wire_expression2_quotatime")
+	local wire_expression2_quota_average = GetConVar("wire_expression2_quota_average")
 
 	local function updateQuotas()
 		if wire_expression2_unlimited:GetBool() then
@@ -22,11 +24,13 @@ do
 			e2_hardquota = 1000000
 			e2_tickquota = 100000
 			e2_timequota = -1
+			e2_timeaverage = -1
 		else
 			e2_softquota = wire_expression2_quotasoft:GetFloat()
 			e2_hardquota = wire_expression2_quotahard:GetFloat()
 			e2_tickquota = wire_expression2_quotatick:GetFloat()
 			e2_timequota = wire_expression2_quotatime:GetFloat() * 0.001
+			e2_timeaverage = 1 / wire_expression2_quota_average:GetFloat()
 		end
 	end
 	cvars.AddChangeCallback("wire_expression2_unlimited", updateQuotas)
@@ -34,6 +38,7 @@ do
 	cvars.AddChangeCallback("wire_expression2_quotahard", updateQuotas)
 	cvars.AddChangeCallback("wire_expression2_quotatick", updateQuotas)
 	cvars.AddChangeCallback("wire_expression2_quotatime", updateQuotas)
+	cvars.AddChangeCallback("wire_expression2_quota_average", updateQuotas)
 	updateQuotas()
 end
 
@@ -115,9 +120,10 @@ function ENT:UpdatePerf(selfTbl)
 	if not context then return end
 	if selfTbl.error then return end
 
-	context.prfbench = context.prfbench * 0.95 + context.prf * 0.05
+	local average_weight = 1 - e2_timeaverage
+	context.prfbench = context.prfbench * average_weight + context.prf * e2_timeaverage
 	context.prfcount = context.prfcount + context.prf - e2_softquota
-	context.timebench = context.timebench * 0.95 + context.time * 0.05 -- Average it over the last 20 ticks
+	context.timebench = context.timebench * average_weight + context.time * e2_timeaverage -- Average it over the last X ticks
 
 	if context.prfcount < 0 then context.prfcount = 0 end
 

--- a/lua/entities/gmod_wire_expression2/shared.lua
+++ b/lua/entities/gmod_wire_expression2/shared.lua
@@ -13,6 +13,7 @@ CreateConVar("wire_expression2_quotasoft", "10000", {FCVAR_REPLICATED})
 CreateConVar("wire_expression2_quotahard", "100000", {FCVAR_REPLICATED})
 CreateConVar("wire_expression2_quotatick", "25000", {FCVAR_REPLICATED})
 CreateConVar("wire_expression2_quotatime", "-1", {FCVAR_REPLICATED}, "Time in (ms) that all E2s of one player can consume before killing (-1 is infinite)")
+CreateConVar("wire_expression2_quota_average", "100", {FCVAR_REPLICATED}, "The chip load window width in ticks (smaller is sharp, larger is smooth)")
 
 include("core/e2lib.lua")
 include("base/debug.lua")

--- a/lua/entities/gmod_wire_expression2/shared.lua
+++ b/lua/entities/gmod_wire_expression2/shared.lua
@@ -13,7 +13,7 @@ CreateConVar("wire_expression2_quotasoft", "10000", {FCVAR_REPLICATED})
 CreateConVar("wire_expression2_quotahard", "100000", {FCVAR_REPLICATED})
 CreateConVar("wire_expression2_quotatick", "25000", {FCVAR_REPLICATED})
 CreateConVar("wire_expression2_quotatime", "-1", {FCVAR_REPLICATED}, "Time in (ms) that all E2s of one player can consume before killing (-1 is infinite)")
-CreateConVar("wire_expression2_quota_average", "100", {FCVAR_REPLICATED}, "The chip load window width in ticks (smaller is sharp, larger is smooth)")
+CreateConVar("wire_expression2_quota_average", "100", {FCVAR_REPLICATED}, "The chip load window width in ticks (smaller is roughly, larger is smooth)")
 
 include("core/e2lib.lua")
 include("base/debug.lua")


### PR DESCRIPTION
It will help smooth out lag spikes that cause e2 to crash. By default, it now takes an average of 100 ticks instead of 20