### PR TITLE
Update description for min vertex distance convar

### DIFF
--- a/lua/entities/gmod_wire_customprop/shared.lua
+++ b/lua/entities/gmod_wire_customprop/shared.lua
@@ -11,7 +11,7 @@ ENT.AdminSpawnable	= false
 -- It seems to require more time exponentially to the vertices amount.
 -- The same amount of vertices in total, but broken into different convexes greatly reduces the performance hit.
 CreateConVar("wire_customprops_hullsize_max", 2048, {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "The max hull size of a custom prop")
-CreateConVar("wire_customprops_minvertexdistance", 0.2, {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "The min distance between two vertices in a custom prop.")
+CreateConVar("wire_customprops_minvertexdistance", 0.2, {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "The minimum squared distance between two vertices in a custom prop.")
 CreateConVar("wire_customprops_vertices_max", 64, {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "How many vertices custom props can have.", 4)
 CreateConVar("wire_customprops_convexes_max", 12, {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "How many convexes custom props can have.", 1)
 CreateConVar("wire_customprops_max", 16, {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "The maximum number of custom props a player can spawn. (0 to disable)", 0)


### PR DESCRIPTION
The mesh calculation uses this number as a squared distance, which is contradictory to the description.
GitHub seems to insist that a newline must be added to the end, unclear if anything should be done about it.