### PR TITLE
Avoid to draw text, laser, beams into Resolved Depth Buffer

### DIFF
--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -18,9 +18,14 @@ if CLIENT then
 		self.PlayerWasLookingAtMe = false
 	end
 
-	function ENT:Draw()
+	function ENT:Draw( flags )
 		local entsTbl = EntityMeta.GetTable( self )
-		entsTbl.DoNormalDraw( self )
+		entsTbl.DoNormalDraw( self, false, false, flags )
+
+		local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
+
+		if is_depth_pass then return end
+
 		Wire_Render(self)
 		if entsTbl.GetBeamLength and (not entsTbl.GetShowBeam or entsTbl.GetShowBeam( self )) then
 			-- Every SENT that has GetBeamLength should draw a tracer. Some of them have the GetShowBeam boolean
@@ -270,14 +275,16 @@ if CLIENT then
 		end
 	end)
 
-	function ENT:DoNormalDraw(nohalo, notip)
-		if not nohalo and wire_drawoutline:GetBool() and looked_at == self then
+	function ENT:DoNormalDraw(nohalo, notip, flags)
+		local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
+
+		if not nohalo and wire_drawoutline:GetBool() and looked_at == self and not is_depth_pass then
 			self:DrawEntityOutline()
-			self:DrawModel()
+			self:DrawModel(flags)
 		else
-			self:DrawModel()
+			self:DrawModel(flags)
 		end
-		if not notip and looked_at == self then
+		if not notip and looked_at == self and not is_depth_pass then
 			self:AddWorldTip()
 		end
 	end

--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -20,11 +20,8 @@ if CLIENT then
 
 	function ENT:Draw( flags )
 		local entsTbl = EntityMeta.GetTable( self )
-		entsTbl.DoNormalDraw( self, false, false, flags )
-
-		local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
-
-		if is_depth_pass then return end
+		entsTbl.DoNormalDraw( self, nil, nil, flags )
+		if WireLib.IsDepthPass(flags) then return end
 
 		Wire_Render(self)
 		if entsTbl.GetBeamLength and (not entsTbl.GetShowBeam or entsTbl.GetShowBeam( self )) then
@@ -276,14 +273,14 @@ if CLIENT then
 	end)
 
 	function ENT:DoNormalDraw(nohalo, notip, flags)
-		local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
+		local is_depth_pass = WireLib.IsDepthPass(flags)
 
 		if not nohalo and wire_drawoutline:GetBool() and looked_at == self and not is_depth_pass then
 			self:DrawEntityOutline()
-			self:DrawModel(flags)
-		else
-			self:DrawModel(flags)
 		end
+
+		self:DrawModel(flags)
+
 		if not notip and looked_at == self and not is_depth_pass then
 			self:AddWorldTip()
 		end

--- a/lua/entities/gmod_wire_characterlcd/cl_init.lua
+++ b/lua/entities/gmod_wire_characterlcd/cl_init.lua
@@ -456,8 +456,12 @@ function ENT:DrawSpecialCharacter(c,x,y,w,h,r,g,b)
 end
 
 local VECTOR_1_1_1 = Vector(1, 1, 1)
-function ENT:Draw()
-	self:DrawModel()
+function ENT:Draw(flags)
+	self:DrawModel(flags)
+
+	local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
+
+	if is_depth_pass then return end
 
 	local tone = render.GetToneMappingScaleLinear()
 	render.SetToneMappingScaleLinear(VECTOR_1_1_1)

--- a/lua/entities/gmod_wire_characterlcd/cl_init.lua
+++ b/lua/entities/gmod_wire_characterlcd/cl_init.lua
@@ -459,9 +459,7 @@ local VECTOR_1_1_1 = Vector(1, 1, 1)
 function ENT:Draw(flags)
 	self:DrawModel(flags)
 
-	local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
-
-	if is_depth_pass then return end
+	if WireLib.IsDepthPass(flags) then return end
 
 	local tone = render.GetToneMappingScaleLinear()
 	render.SetToneMappingScaleLinear(VECTOR_1_1_1)

--- a/lua/entities/gmod_wire_consolescreen/cl_init.lua
+++ b/lua/entities/gmod_wire_consolescreen/cl_init.lua
@@ -567,8 +567,12 @@ function ENT:DrawSpecialCharacter(c,x,y,w,h,r,g,b)
 end
 
 local VECTOR_1_1_1 = Vector(1, 1, 1)
-function ENT:Draw()
-	self:DrawModel()
+function ENT:Draw(flags)
+	self:DrawModel(flags)
+
+	local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
+
+	if is_depth_pass then return end
 
 	local tone = render.GetToneMappingScaleLinear()
 	render.SetToneMappingScaleLinear(VECTOR_1_1_1)

--- a/lua/entities/gmod_wire_consolescreen/cl_init.lua
+++ b/lua/entities/gmod_wire_consolescreen/cl_init.lua
@@ -570,9 +570,7 @@ local VECTOR_1_1_1 = Vector(1, 1, 1)
 function ENT:Draw(flags)
 	self:DrawModel(flags)
 
-	local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
-
-	if is_depth_pass then return end
+	if WireLib.IsDepthPass(flags) then return end
 
 	local tone = render.GetToneMappingScaleLinear()
 	render.SetToneMappingScaleLinear(VECTOR_1_1_1)

--- a/lua/entities/gmod_wire_digitalscreen/cl_init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/cl_init.lua
@@ -312,8 +312,12 @@ function ENT:RedrawRow(y)
 end
 
 local VECTOR_1_1_1 = Vector(1, 1, 1)
-function ENT:Draw()
-	self:DrawModel()
+function ENT:Draw(flags)
+	self:DrawModel(flags)
+
+	local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
+
+	if is_depth_pass then return end
 
 	local tone = render.GetToneMappingScaleLinear()
 	render.SetToneMappingScaleLinear(VECTOR_1_1_1)

--- a/lua/entities/gmod_wire_digitalscreen/cl_init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/cl_init.lua
@@ -315,9 +315,7 @@ local VECTOR_1_1_1 = Vector(1, 1, 1)
 function ENT:Draw(flags)
 	self:DrawModel(flags)
 
-	local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
-
-	if is_depth_pass then return end
+	if WireLib.IsDepthPass(flags) then return end
 
 	local tone = render.GetToneMappingScaleLinear()
 	render.SetToneMappingScaleLinear(VECTOR_1_1_1)

--- a/lua/entities/gmod_wire_egp/cl_init.lua
+++ b/lua/entities/gmod_wire_egp/cl_init.lua
@@ -33,8 +33,13 @@ end
 function ENT:DrawEntityOutline() end
 
 local VECTOR_1_1_1 = Vector(1, 1, 1)
-function ENT:Draw()
-	self:DrawModel()
+function ENT:Draw(flags)
+	self:DrawModel(flags)
+
+	local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
+
+	if is_depth_pass then return end
+
 	Wire_Render(self)
 
 	local tone = render.GetToneMappingScaleLinear()

--- a/lua/entities/gmod_wire_egp/cl_init.lua
+++ b/lua/entities/gmod_wire_egp/cl_init.lua
@@ -36,9 +36,7 @@ local VECTOR_1_1_1 = Vector(1, 1, 1)
 function ENT:Draw(flags)
 	self:DrawModel(flags)
 
-	local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
-
-	if is_depth_pass then return end
+	if WireLib.IsDepthPass(flags) then return end
 
 	Wire_Render(self)
 

--- a/lua/entities/gmod_wire_egp_emitter.lua
+++ b/lua/entities/gmod_wire_egp_emitter.lua
@@ -151,11 +151,16 @@ if CLIENT then
 	 	end
 	end
 
-	function ENT:Draw()
+	function ENT:Draw(flags)
 		if self.GPU then -- if we're rendering on RT, use base EGP's draw function instead
-			BaseClass.Draw(self)
+			BaseClass.Draw(self, flags)
 		else
-			self:DrawModel()
+			self:DrawModel(flags)
+
+			local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
+
+			if is_depth_pass then return end
+
 			self:DrawNoRT()
 			Wire_Render(self)
 		end

--- a/lua/entities/gmod_wire_egp_emitter.lua
+++ b/lua/entities/gmod_wire_egp_emitter.lua
@@ -157,9 +157,7 @@ if CLIENT then
 		else
 			self:DrawModel(flags)
 
-			local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
-
-			if is_depth_pass then return end
+			if WireLib.IsDepthPass(flags) then return end
 
 			self:DrawNoRT()
 			Wire_Render(self)

--- a/lua/entities/gmod_wire_egp_hud/cl_init.lua
+++ b/lua/entities/gmod_wire_egp_hud/cl_init.lua
@@ -20,7 +20,12 @@ function ENT:EGP_Update() end
 
 function ENT:DrawEntityOutline() end
 
-function ENT:Draw()
-	self:DrawModel()
+function ENT:Draw(flags)
+	self:DrawModel(flags)
+
+	local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
+
+	if is_depth_pass then return end
+	
 	Wire_Render(self)
 end

--- a/lua/entities/gmod_wire_egp_hud/cl_init.lua
+++ b/lua/entities/gmod_wire_egp_hud/cl_init.lua
@@ -23,9 +23,7 @@ function ENT:DrawEntityOutline() end
 function ENT:Draw(flags)
 	self:DrawModel(flags)
 
-	local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
+	if WireLib.IsDepthPass(flags) then return end
 
-	if is_depth_pass then return end
-	
 	Wire_Render(self)
 end

--- a/lua/entities/gmod_wire_gpu/cl_init.lua
+++ b/lua/entities/gmod_wire_gpu/cl_init.lua
@@ -366,14 +366,18 @@ end
 local VECTOR_1_1_1 = Vector(1, 1, 1)
 --------------------------------------------------------------------------------
 -- Entity drawing function
-function ENT:Draw()
-	-- Calculate time-related variables
-	self.CurrentTime = CurTime()
-	self.DeltaTime = math.min(1/30,self.CurrentTime - (self.PreviousTime or 0))
-	self.PreviousTime = self.CurrentTime
-
+function ENT:Draw(flags)
 	-- Draw GPU itself
-	self:DrawModel()
+	self:DrawModel(flags)
+
+  local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
+
+  if is_depth_pass then return end
+
+    -- Calculate time-related variables
+  self.CurrentTime = CurTime()
+  self.DeltaTime = math.min(1/30,self.CurrentTime - (self.PreviousTime or 0))
+  self.PreviousTime = self.CurrentTime
   
 	local tone = render.GetToneMappingScaleLinear()
 	render.SetToneMappingScaleLinear(VECTOR_1_1_1)

--- a/lua/entities/gmod_wire_gpu/cl_init.lua
+++ b/lua/entities/gmod_wire_gpu/cl_init.lua
@@ -370,15 +370,13 @@ function ENT:Draw(flags)
 	-- Draw GPU itself
 	self:DrawModel(flags)
 
-  local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
-
-  if is_depth_pass then return end
+  if WireLib.IsDepthPass(flags) then return end
 
     -- Calculate time-related variables
   self.CurrentTime = CurTime()
   self.DeltaTime = math.min(1/30,self.CurrentTime - (self.PreviousTime or 0))
   self.PreviousTime = self.CurrentTime
-  
+
 	local tone = render.GetToneMappingScaleLinear()
 	render.SetToneMappingScaleLinear(VECTOR_1_1_1)
 
@@ -462,7 +460,7 @@ function ENT:Draw(flags)
 			end
 		end
 	end
-  
+
 	render.SetToneMappingScaleLinear(tone)
 	Wire_Render(self)
 end

--- a/lua/entities/gmod_wire_gpu/cl_init.lua
+++ b/lua/entities/gmod_wire_gpu/cl_init.lua
@@ -367,15 +367,15 @@ local VECTOR_1_1_1 = Vector(1, 1, 1)
 --------------------------------------------------------------------------------
 -- Entity drawing function
 function ENT:Draw(flags)
-	-- Draw GPU itself
+  -- Draw GPU itself
 	self:DrawModel(flags)
 
-  if WireLib.IsDepthPass(flags) then return end
+	if WireLib.IsDepthPass(flags) then return end
 
-    -- Calculate time-related variables
-  self.CurrentTime = CurTime()
-  self.DeltaTime = math.min(1/30,self.CurrentTime - (self.PreviousTime or 0))
-  self.PreviousTime = self.CurrentTime
+	-- Calculate time-related variables
+	self.CurrentTime = CurTime()
+	self.DeltaTime = math.min(1/30,self.CurrentTime - (self.PreviousTime or 0))
+	self.PreviousTime = self.CurrentTime
 
 	local tone = render.GetToneMappingScaleLinear()
 	render.SetToneMappingScaleLinear(VECTOR_1_1_1)

--- a/lua/entities/gmod_wire_graphics_tablet.lua
+++ b/lua/entities/gmod_wire_graphics_tablet.lua
@@ -33,8 +33,12 @@ if CLIENT then
 		return x,y,w,h
 	end
 
-	function ENT:Draw()
-		self:DrawModel()
+	function ENT:Draw(flags)
+		self:DrawModel(flags)
+
+		local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
+
+		if is_depth_pass then return end
 
 		local draw_background = self:GetDrawBackground()
 		self.GPU:RenderToWorld(nil, 512, function(x, y, w, h, monitor, pos, ang, res)

--- a/lua/entities/gmod_wire_graphics_tablet.lua
+++ b/lua/entities/gmod_wire_graphics_tablet.lua
@@ -36,9 +36,7 @@ if CLIENT then
 	function ENT:Draw(flags)
 		self:DrawModel(flags)
 
-		local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
-
-		if is_depth_pass then return end
+		if WireLib.IsDepthPass(flags) then return end
 
 		local draw_background = self:GetDrawBackground()
 		self.GPU:RenderToWorld(nil, 512, function(x, y, w, h, monitor, pos, ang, res)

--- a/lua/entities/gmod_wire_hologram.lua
+++ b/lua/entities/gmod_wire_hologram.lua
@@ -130,12 +130,15 @@ if CLIENT then
 			render.CullMode(1)
 		end
 
-		if selfTbl.GetDisableShading(self) then
+
+		local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
+
+		if selfTbl.GetDisableShading(self) or is_depth_pass then
 			render.SuppressEngineLighting(true)
-			EntityMeta.DrawModel(self)
+			EntityMeta.DrawModel(self, flags)
 			render.SuppressEngineLighting(false)
 		else
-			EntityMeta.DrawModel(self)
+			EntityMeta.DrawModel(self, flags)
 		end
 
 		if invert_model then

--- a/lua/entities/gmod_wire_hologram.lua
+++ b/lua/entities/gmod_wire_hologram.lua
@@ -130,7 +130,7 @@ if CLIENT then
 			render.CullMode(1)
 		end
 
-		if selfTbl.GetDisableShading(self) or and not WireLib.IsDepthPass(flags) then
+		if selfTbl.GetDisableShading(self) and not WireLib.IsDepthPass(flags) then
 			render.SuppressEngineLighting(true)
 			EntityMeta.DrawModel(self, flags)
 			render.SuppressEngineLighting(false)

--- a/lua/entities/gmod_wire_hologram.lua
+++ b/lua/entities/gmod_wire_hologram.lua
@@ -114,7 +114,7 @@ if CLIENT then
 		render.EnableClipping(selfTbl.oldClipState)
 	end
 
-	function ENT:Draw()
+	function ENT:Draw(flags)
 		local selfTbl = EntityMeta.GetTable(self)
 		if selfTbl.blocked or selfTbl.notvisible then return end
 
@@ -130,10 +130,7 @@ if CLIENT then
 			render.CullMode(1)
 		end
 
-
-		local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
-
-		if selfTbl.GetDisableShading(self) or is_depth_pass then
+		if selfTbl.GetDisableShading(self) or WireLib.IsDepthPass(flags) then
 			render.SuppressEngineLighting(true)
 			EntityMeta.DrawModel(self, flags)
 			render.SuppressEngineLighting(false)

--- a/lua/entities/gmod_wire_hologram.lua
+++ b/lua/entities/gmod_wire_hologram.lua
@@ -130,7 +130,7 @@ if CLIENT then
 			render.CullMode(1)
 		end
 
-		if selfTbl.GetDisableShading(self) or WireLib.IsDepthPass(flags) then
+		if selfTbl.GetDisableShading(self) or and not WireLib.IsDepthPass(flags) then
 			render.SuppressEngineLighting(true)
 			EntityMeta.DrawModel(self, flags)
 			render.SuppressEngineLighting(false)

--- a/lua/entities/gmod_wire_keypad.lua
+++ b/lua/entities/gmod_wire_keypad.lua
@@ -46,9 +46,13 @@ if CLIENT then
 	local color_red = Color(255, 0, 0)
 	local color_green = Color(0, 255, 0)
 
-	function ENT:Draw()
-		self:DrawModel()
+	function ENT:Draw(flags)
+		self:DrawModel(flags)
 
+		local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
+
+		if is_depth_pass then return end
+	
 		local entpos = self:GetPos()
 		if entpos:Distance(EyePos()) > 512 then return end
 

--- a/lua/entities/gmod_wire_keypad.lua
+++ b/lua/entities/gmod_wire_keypad.lua
@@ -49,10 +49,8 @@ if CLIENT then
 	function ENT:Draw(flags)
 		self:DrawModel(flags)
 
-		local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
+		if WireLib.IsDepthPass(flags) then return end
 
-		if is_depth_pass then return end
-	
 		local entpos = self:GetPos()
 		if entpos:Distance(EyePos()) > 512 then return end
 

--- a/lua/entities/gmod_wire_oscilloscope.lua
+++ b/lua/entities/gmod_wire_oscilloscope.lua
@@ -78,8 +78,12 @@ if CLIENT then
 		end
 	end)
 
-	function ENT:Draw()
-		self:DrawModel()
+	function ENT:Draw(flags)
+		self:DrawModel(flags)
+
+		local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
+
+		if is_depth_pass then return end
 
 		local length = self:GetNWFloat("Length", 50)
 		local r,g,b = self:GetNWFloat("R"), self:GetNWFloat("G"), self:GetNWFloat("B")

--- a/lua/entities/gmod_wire_oscilloscope.lua
+++ b/lua/entities/gmod_wire_oscilloscope.lua
@@ -81,9 +81,7 @@ if CLIENT then
 	function ENT:Draw(flags)
 		self:DrawModel(flags)
 
-		local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
-
-		if is_depth_pass then return end
+		if WireLib.IsDepthPass(flags) then return end
 
 		local length = self:GetNWFloat("Length", 50)
 		local r,g,b = self:GetNWFloat("R"), self:GetNWFloat("G"), self:GetNWFloat("B")

--- a/lua/entities/gmod_wire_pixel.lua
+++ b/lua/entities/gmod_wire_pixel.lua
@@ -4,8 +4,8 @@ ENT.PrintName       = "Wire Pixel"
 ENT.WireDebugName	= "Pixel"
 
 if CLIENT then
-	function ENT:Draw()
-		self:DrawModel()
+	function ENT:Draw(flags)
+		self:DrawModel(flags)
 	end
 
 	return  -- No more client

--- a/lua/entities/gmod_wire_rt_screen.lua
+++ b/lua/entities/gmod_wire_rt_screen.lua
@@ -304,9 +304,13 @@ if CLIENT then
         cam.End3D2D()
     end
 
-    function ENT:Draw()
-        self:DrawModel()
+    function ENT:Draw(flags)
+        self:DrawModel(flags)
 
+		local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
+
+		if is_depth_pass then return end
+		
         if self.MonitorDesc == nil then
             return
         end

--- a/lua/entities/gmod_wire_rt_screen.lua
+++ b/lua/entities/gmod_wire_rt_screen.lua
@@ -307,10 +307,8 @@ if CLIENT then
     function ENT:Draw(flags)
         self:DrawModel(flags)
 
-		local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
+        if WireLib.IsDepthPass(flags) then return end
 
-		if is_depth_pass then return end
-		
         if self.MonitorDesc == nil then
             return
         end

--- a/lua/entities/gmod_wire_screen.lua
+++ b/lua/entities/gmod_wire_screen.lua
@@ -87,8 +87,11 @@ if CLIENT then
 		surface.DrawText( value )
 	end
 
-	function ENT:Draw()
-		self:DrawModel()
+	function ENT:Draw(flags)
+		self:DrawModel(flags)
+
+		local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
+		if is_depth_pass then return end
 
 		self.GPU:RenderToWorld(nil, 188, function(x, y, w, h)
 			surface.SetDrawColor(0, 0, 0, 255)

--- a/lua/entities/gmod_wire_screen.lua
+++ b/lua/entities/gmod_wire_screen.lua
@@ -90,8 +90,7 @@ if CLIENT then
 	function ENT:Draw(flags)
 		self:DrawModel(flags)
 
-		local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
-		if is_depth_pass then return end
+		if WireLib.IsDepthPass(flags) then return end
 
 		self.GPU:RenderToWorld(nil, 188, function(x, y, w, h)
 			surface.SetDrawColor(0, 0, 0, 255)

--- a/lua/entities/gmod_wire_textscreen.lua
+++ b/lua/entities/gmod_wire_textscreen.lua
@@ -137,8 +137,11 @@ if CLIENT then
 		if fullUpdate then return end
 		self.GPU:Finalize()
 	end
-	function ENT:Draw()
-		self:DrawModel()
+	function ENT:Draw(flags)
+		self:DrawModel(flags)
+
+		local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
+		if is_depth_pass then return end
 
 		if self.NeedRefresh then
 			self.NeedRefresh = nil

--- a/lua/entities/gmod_wire_textscreen.lua
+++ b/lua/entities/gmod_wire_textscreen.lua
@@ -140,8 +140,7 @@ if CLIENT then
 	function ENT:Draw(flags)
 		self:DrawModel(flags)
 
-		local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
-		if is_depth_pass then return end
+		if WireLib.IsDepthPass(flags) then return end
 
 		if self.NeedRefresh then
 			self.NeedRefresh = nil

--- a/lua/entities/gmod_wire_waypoint.lua
+++ b/lua/entities/gmod_wire_waypoint.lua
@@ -9,8 +9,11 @@ end
 
 if CLIENT then
 	local physBeamMat = Material("cable/physbeam")
-	function ENT:Draw()
-		BaseClass.Draw(self)
+	function ENT:Draw(flags)
+		BaseClass.Draw(self, flags)
+
+		local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
+		if is_depth_pass then return end
 
 		local nextWP = self:GetNextWaypoint()
 		if IsValid(nextWP) and (LocalPlayer():GetEyeTrace().Entity == self) and (EyePos():Distance(self:GetPos()) < 4096) then

--- a/lua/entities/gmod_wire_waypoint.lua
+++ b/lua/entities/gmod_wire_waypoint.lua
@@ -12,8 +12,7 @@ if CLIENT then
 	function ENT:Draw(flags)
 		BaseClass.Draw(self, flags)
 
-		local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
-		if is_depth_pass then return end
+		if WireLib.IsDepthPass(flags) then return end
 
 		local nextWP = self:GetNextWaypoint()
 		if IsValid(nextWP) and (LocalPlayer():GetEyeTrace().Entity == self) and (EyePos():Distance(self:GetPos()) < 4096) then

--- a/lua/weapons/laserpointer/cl_init.lua
+++ b/lua/weapons/laserpointer/cl_init.lua
@@ -19,7 +19,10 @@ local function WorldToViewModel(point)
 	return point
 end
 
-function SWEP:PostDrawViewModel(vm, wep, ply)
+function SWEP:PostDrawViewModel(vm, wep, ply, flags)
+	local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
+	if is_depth_pass then return end
+	
 	if self:GetLaserEnabled() then
 		local att = vm:GetAttachment(vm:LookupAttachment("muzzle") or 0)
 		if not att then return end

--- a/lua/weapons/laserpointer/cl_init.lua
+++ b/lua/weapons/laserpointer/cl_init.lua
@@ -20,9 +20,8 @@ local function WorldToViewModel(point)
 end
 
 function SWEP:PostDrawViewModel(vm, wep, ply, flags)
-	local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0)
-	if is_depth_pass then return end
-	
+	if WireLib.IsDepthPass(flags) then return end
+
 	if self:GetLaserEnabled() then
 		local att = vm:GetAttachment(vm:LookupAttachment("muzzle") or 0)
 		if not att then return end

--- a/lua/wire/client/cl_wirelib.lua
+++ b/lua/wire/client/cl_wirelib.lua
@@ -245,6 +245,10 @@ function WireLib.hud_debug(text, oneframe)
 	end)
 end
 
+function WireLib.IsDepthPass(flags)
+	return bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0
+end
+
 local old_renderhalos = WireLib.__old_renderhalos or hook.GetTable().PostDrawEffects.RenderHalos
 WireLib.__old_renderhalos = old_renderhalos
 if old_renderhalos ~= nil then


### PR DESCRIPTION
Changes:
- Added flags to Draw, DrawModel functions.
- Added Shadow depth and Resolved depth check to avoid draw colored render funcs as laser, text, beams into Depth.
- Adding of flags argument to DrawModel function allow to avoid bug of render of decals into resolved Depth Buffer.

Resolved Depth can writes using:
```lua
hook.Add("NeedsDepthPass", "depth", function() return true end)
```

Debug of Resolved Depth:
```lua
hook.Add("HUDPaint", "depth", function()
render.DrawTextureToScreen("_rt_ResolvedFullFrameDepth")
end)
```