### PR TITLE
Properly pass draw args through

### DIFF
--- a/lua/entities/gmod_wire_button.lua
+++ b/lua/entities/gmod_wire_button.lua
@@ -18,9 +18,10 @@ if CLIENT then
 		baseclass.Get("gmod_button").UpdateLever(self)
 	end
 
+	local wire_drawoutline = GetConVar("wire_drawoutline")
 	function ENT:Draw( flags )
 		self:DoNormalDraw(true,false, flags)
-		if LocalPlayer():GetEyeTrace().Entity == self and EyePos():DistToSqr( self:GetPos() ) < 512^2 and GetConVarNumber("wire_drawoutline")~=0 then
+		if LocalPlayer():GetEyeTrace().Entity == self and EyePos():DistToSqr( self:GetPos() ) < 512^2 and wire_drawoutline:GetInt()~=0 then
 			if self:GetOn() then
 				halo_ent = self
 				halo_blur = 4 + math.sin(CurTime()*20)*2

--- a/lua/entities/gmod_wire_button.lua
+++ b/lua/entities/gmod_wire_button.lua
@@ -18,8 +18,8 @@ if CLIENT then
 		baseclass.Get("gmod_button").UpdateLever(self)
 	end
 
-	function ENT:Draw()
-		self:DoNormalDraw(true,false)
+	function ENT:Draw( flags )
+		self:DoNormalDraw(true,false, flags)
 		if LocalPlayer():GetEyeTrace().Entity == self and EyePos():DistToSqr( self:GetPos() ) < 512^2 and GetConVarNumber("wire_drawoutline")~=0 then
 			if self:GetOn() then
 				halo_ent = self

--- a/lua/entities/gmod_wire_dynamic_button.lua
+++ b/lua/entities/gmod_wire_dynamic_button.lua
@@ -11,8 +11,8 @@ end
 if CLIENT then
 	local halo_ent, halo_blur
 
-	function ENT:Draw()
-		self:DoNormalDraw(true,false)
+	function ENT:Draw( flags )
+		self:DoNormalDraw(true,false, flags)
 		if LocalPlayer():GetEyeTrace().Entity == self and EyePos():Distance( self:GetPos() ) < 512 then
 			if self:GetOn() then
 				halo_ent = self

--- a/lua/entities/gmod_wire_fx_emitter.lua
+++ b/lua/entities/gmod_wire_fx_emitter.lua
@@ -24,7 +24,7 @@ ComboBox_Wire_FX_Emitter_Options = {}
 
 function AddFXEmitterEffect(name, func, nicename)
 	fx_emitter.fxcount = fx_emitter.fxcount+1
-	// Maintain a global reference for these effects
+	-- Maintain a global reference for these effects
 	ComboBox_Wire_FX_Emitter_Options[name] = fx_emitter.fxcount
 	if CLIENT then
 		fx_emitter.Effects[fx_emitter.fxcount] = func
@@ -40,7 +40,7 @@ if CLIENT then
 	ENT.Delay = 0.05
 
 	function ENT:Draw( ... )
-		// Don't draw if we are in camera mode
+		-- Don't draw if we are in camera mode
 		local ply = LocalPlayer()
 		local wep = ply:GetActiveWeapon()
 		if ( wep:IsValid() ) then
@@ -59,7 +59,7 @@ if CLIENT then
 
 		local Effect = self:GetEffect()
 
-		// Missing effect... replace it if possible :/
+		-- Missing effect... replace it if possible :/
 		if ( not self.Effects[ Effect ] ) then if ( self.Effects[1] ) then Effect = 1 else return end end
 
 		local Angle = self:GetAngles()
@@ -73,13 +73,13 @@ if CLIENT then
 		local b, e = pcall( self.Effects[Effect], FXPos, Angle )
 
 		if (not b) then
-			// Report the error
+			-- Report the error
 			Print(self.Effects)
 			Print(FXPos)
 			Print(Angle)
 			Msg("Error in Emitter "..tostring(Effect).."\n -> "..tostring(e).."\n")
 
-			// Remove the naughty function
+			-- Remove the naughty function
 			self.Effects[ Effect ] = nil
 		end
 	end

--- a/lua/entities/gmod_wire_fx_emitter.lua
+++ b/lua/entities/gmod_wire_fx_emitter.lua
@@ -39,7 +39,7 @@ include( "wire/fx_emitter_default.lua" )
 if CLIENT then
 	ENT.Delay = 0.05
 
-	function ENT:Draw()
+	function ENT:Draw( ... )
 		// Don't draw if we are in camera mode
 		local ply = LocalPlayer()
 		local wep = ply:GetActiveWeapon()
@@ -48,7 +48,7 @@ if CLIENT then
 			if ( weapon_name == "gmod_camera" ) then return end
 		end
 
-		BaseClass.Draw( self )
+		BaseClass.Draw( self, ... )
 	end
 
 	function ENT:Think()


### PR DESCRIPTION
Fixes:
```
[wire] addons/wire/lua/wire/client/cl_wirelib.lua:249: bad argument #1 to 'band' (number expected, got nil)
  1. band - [C]:-1
   2. IsDepthPass - addons/wire/lua/wire/client/cl_wirelib.lua:249
    3. DoNormalDraw - addons/wire/lua/entities/base_wire_entity.lua:276
     4. Draw - addons/wire/lua/entities/base_wire_entity.lua:23
      5. unknown - addons/wire/lua/entities/gmod_wire_fx_emitter.lua:51
```