### PR TITLE
Revert depth pass support, it seems to conflict with other wire addons

### DIFF
--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -18,11 +18,9 @@ if CLIENT then
 		self.PlayerWasLookingAtMe = false
 	end
 
-	function ENT:Draw( flags )
+	function ENT:Draw()
 		local entsTbl = EntityMeta.GetTable( self )
-		entsTbl.DoNormalDraw( self, nil, nil, flags )
-		if WireLib.IsDepthPass(flags) then return end
-
+		entsTbl.DoNormalDraw( self )
 		Wire_Render(self)
 		if entsTbl.GetBeamLength and (not entsTbl.GetShowBeam or entsTbl.GetShowBeam( self )) then
 			-- Every SENT that has GetBeamLength should draw a tracer. Some of them have the GetShowBeam boolean
@@ -272,16 +270,14 @@ if CLIENT then
 		end
 	end)
 
-	function ENT:DoNormalDraw(nohalo, notip, flags)
-		local is_depth_pass = WireLib.IsDepthPass(flags)
-
-		if not nohalo and wire_drawoutline:GetBool() and looked_at == self and not is_depth_pass then
+	function ENT:DoNormalDraw(nohalo, notip)
+		if not nohalo and wire_drawoutline:GetBool() and looked_at == self then
 			self:DrawEntityOutline()
+			self:DrawModel()
+		else
+			self:DrawModel()
 		end
-
-		self:DrawModel(flags)
-
-		if not notip and looked_at == self and not is_depth_pass then
+		if not notip and looked_at == self then
 			self:AddWorldTip()
 		end
 	end

--- a/lua/entities/gmod_wire_button.lua
+++ b/lua/entities/gmod_wire_button.lua
@@ -18,10 +18,9 @@ if CLIENT then
 		baseclass.Get("gmod_button").UpdateLever(self)
 	end
 
-	local wire_drawoutline = GetConVar("wire_drawoutline")
-	function ENT:Draw( flags )
-		self:DoNormalDraw(true,false, flags)
-		if LocalPlayer():GetEyeTrace().Entity == self and EyePos():DistToSqr( self:GetPos() ) < 512^2 and wire_drawoutline:GetInt()~=0 then
+	function ENT:Draw()
+		self:DoNormalDraw(true,false)
+		if LocalPlayer():GetEyeTrace().Entity == self and EyePos():DistToSqr( self:GetPos() ) < 512^2 and GetConVarNumber("wire_drawoutline")~=0 then
 			if self:GetOn() then
 				halo_ent = self
 				halo_blur = 4 + math.sin(CurTime()*20)*2

--- a/lua/entities/gmod_wire_characterlcd/cl_init.lua
+++ b/lua/entities/gmod_wire_characterlcd/cl_init.lua
@@ -456,10 +456,8 @@ function ENT:DrawSpecialCharacter(c,x,y,w,h,r,g,b)
 end
 
 local VECTOR_1_1_1 = Vector(1, 1, 1)
-function ENT:Draw(flags)
-	self:DrawModel(flags)
-
-	if WireLib.IsDepthPass(flags) then return end
+function ENT:Draw()
+	self:DrawModel()
 
 	local tone = render.GetToneMappingScaleLinear()
 	render.SetToneMappingScaleLinear(VECTOR_1_1_1)

--- a/lua/entities/gmod_wire_consolescreen/cl_init.lua
+++ b/lua/entities/gmod_wire_consolescreen/cl_init.lua
@@ -567,10 +567,8 @@ function ENT:DrawSpecialCharacter(c,x,y,w,h,r,g,b)
 end
 
 local VECTOR_1_1_1 = Vector(1, 1, 1)
-function ENT:Draw(flags)
-	self:DrawModel(flags)
-
-	if WireLib.IsDepthPass(flags) then return end
+function ENT:Draw()
+	self:DrawModel()
 
 	local tone = render.GetToneMappingScaleLinear()
 	render.SetToneMappingScaleLinear(VECTOR_1_1_1)

--- a/lua/entities/gmod_wire_digitalscreen/cl_init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/cl_init.lua
@@ -312,10 +312,8 @@ function ENT:RedrawRow(y)
 end
 
 local VECTOR_1_1_1 = Vector(1, 1, 1)
-function ENT:Draw(flags)
-	self:DrawModel(flags)
-
-	if WireLib.IsDepthPass(flags) then return end
+function ENT:Draw()
+	self:DrawModel()
 
 	local tone = render.GetToneMappingScaleLinear()
 	render.SetToneMappingScaleLinear(VECTOR_1_1_1)

--- a/lua/entities/gmod_wire_dynamic_button.lua
+++ b/lua/entities/gmod_wire_dynamic_button.lua
@@ -11,8 +11,8 @@ end
 if CLIENT then
 	local halo_ent, halo_blur
 
-	function ENT:Draw( flags )
-		self:DoNormalDraw(true,false, flags)
+	function ENT:Draw()
+		self:DoNormalDraw(true,false)
 		if LocalPlayer():GetEyeTrace().Entity == self and EyePos():Distance( self:GetPos() ) < 512 then
 			if self:GetOn() then
 				halo_ent = self

--- a/lua/entities/gmod_wire_egp/cl_init.lua
+++ b/lua/entities/gmod_wire_egp/cl_init.lua
@@ -33,11 +33,8 @@ end
 function ENT:DrawEntityOutline() end
 
 local VECTOR_1_1_1 = Vector(1, 1, 1)
-function ENT:Draw(flags)
-	self:DrawModel(flags)
-
-	if WireLib.IsDepthPass(flags) then return end
-
+function ENT:Draw()
+	self:DrawModel()
 	Wire_Render(self)
 
 	local tone = render.GetToneMappingScaleLinear()

--- a/lua/entities/gmod_wire_egp_emitter.lua
+++ b/lua/entities/gmod_wire_egp_emitter.lua
@@ -151,14 +151,11 @@ if CLIENT then
 	 	end
 	end
 
-	function ENT:Draw(flags)
+	function ENT:Draw()
 		if self.GPU then -- if we're rendering on RT, use base EGP's draw function instead
-			BaseClass.Draw(self, flags)
+			BaseClass.Draw(self)
 		else
-			self:DrawModel(flags)
-
-			if WireLib.IsDepthPass(flags) then return end
-
+			self:DrawModel()
 			self:DrawNoRT()
 			Wire_Render(self)
 		end

--- a/lua/entities/gmod_wire_egp_hud/cl_init.lua
+++ b/lua/entities/gmod_wire_egp_hud/cl_init.lua
@@ -20,10 +20,7 @@ function ENT:EGP_Update() end
 
 function ENT:DrawEntityOutline() end
 
-function ENT:Draw(flags)
-	self:DrawModel(flags)
-
-	if WireLib.IsDepthPass(flags) then return end
-
+function ENT:Draw()
+	self:DrawModel()
 	Wire_Render(self)
 end

--- a/lua/entities/gmod_wire_fx_emitter.lua
+++ b/lua/entities/gmod_wire_fx_emitter.lua
@@ -24,7 +24,7 @@ ComboBox_Wire_FX_Emitter_Options = {}
 
 function AddFXEmitterEffect(name, func, nicename)
 	fx_emitter.fxcount = fx_emitter.fxcount+1
-	-- Maintain a global reference for these effects
+	// Maintain a global reference for these effects
 	ComboBox_Wire_FX_Emitter_Options[name] = fx_emitter.fxcount
 	if CLIENT then
 		fx_emitter.Effects[fx_emitter.fxcount] = func
@@ -39,8 +39,8 @@ include( "wire/fx_emitter_default.lua" )
 if CLIENT then
 	ENT.Delay = 0.05
 
-	function ENT:Draw( ... )
-		-- Don't draw if we are in camera mode
+	function ENT:Draw()
+		// Don't draw if we are in camera mode
 		local ply = LocalPlayer()
 		local wep = ply:GetActiveWeapon()
 		if ( wep:IsValid() ) then
@@ -48,7 +48,7 @@ if CLIENT then
 			if ( weapon_name == "gmod_camera" ) then return end
 		end
 
-		BaseClass.Draw( self, ... )
+		BaseClass.Draw( self )
 	end
 
 	function ENT:Think()
@@ -59,7 +59,7 @@ if CLIENT then
 
 		local Effect = self:GetEffect()
 
-		-- Missing effect... replace it if possible :/
+		// Missing effect... replace it if possible :/
 		if ( not self.Effects[ Effect ] ) then if ( self.Effects[1] ) then Effect = 1 else return end end
 
 		local Angle = self:GetAngles()
@@ -73,13 +73,13 @@ if CLIENT then
 		local b, e = pcall( self.Effects[Effect], FXPos, Angle )
 
 		if (not b) then
-			-- Report the error
+			// Report the error
 			Print(self.Effects)
 			Print(FXPos)
 			Print(Angle)
 			Msg("Error in Emitter "..tostring(Effect).."\n -> "..tostring(e).."\n")
 
-			-- Remove the naughty function
+			// Remove the naughty function
 			self.Effects[ Effect ] = nil
 		end
 	end

--- a/lua/entities/gmod_wire_gpu/cl_init.lua
+++ b/lua/entities/gmod_wire_gpu/cl_init.lua
@@ -366,17 +366,15 @@ end
 local VECTOR_1_1_1 = Vector(1, 1, 1)
 --------------------------------------------------------------------------------
 -- Entity drawing function
-function ENT:Draw(flags)
-  -- Draw GPU itself
-	self:DrawModel(flags)
-
-	if WireLib.IsDepthPass(flags) then return end
-
+function ENT:Draw()
 	-- Calculate time-related variables
 	self.CurrentTime = CurTime()
 	self.DeltaTime = math.min(1/30,self.CurrentTime - (self.PreviousTime or 0))
 	self.PreviousTime = self.CurrentTime
 
+	-- Draw GPU itself
+	self:DrawModel()
+  
 	local tone = render.GetToneMappingScaleLinear()
 	render.SetToneMappingScaleLinear(VECTOR_1_1_1)
 
@@ -460,7 +458,7 @@ function ENT:Draw(flags)
 			end
 		end
 	end
-
+  
 	render.SetToneMappingScaleLinear(tone)
 	Wire_Render(self)
 end

--- a/lua/entities/gmod_wire_graphics_tablet.lua
+++ b/lua/entities/gmod_wire_graphics_tablet.lua
@@ -33,10 +33,8 @@ if CLIENT then
 		return x,y,w,h
 	end
 
-	function ENT:Draw(flags)
-		self:DrawModel(flags)
-
-		if WireLib.IsDepthPass(flags) then return end
+	function ENT:Draw()
+		self:DrawModel()
 
 		local draw_background = self:GetDrawBackground()
 		self.GPU:RenderToWorld(nil, 512, function(x, y, w, h, monitor, pos, ang, res)

--- a/lua/entities/gmod_wire_hologram.lua
+++ b/lua/entities/gmod_wire_hologram.lua
@@ -114,7 +114,7 @@ if CLIENT then
 		render.EnableClipping(selfTbl.oldClipState)
 	end
 
-	function ENT:Draw(flags)
+	function ENT:Draw()
 		local selfTbl = EntityMeta.GetTable(self)
 		if selfTbl.blocked or selfTbl.notvisible then return end
 
@@ -130,12 +130,12 @@ if CLIENT then
 			render.CullMode(1)
 		end
 
-		if selfTbl.GetDisableShading(self) and not WireLib.IsDepthPass(flags) then
+		if selfTbl.GetDisableShading(self) then
 			render.SuppressEngineLighting(true)
-			EntityMeta.DrawModel(self, flags)
+			EntityMeta.DrawModel(self)
 			render.SuppressEngineLighting(false)
 		else
-			EntityMeta.DrawModel(self, flags)
+			EntityMeta.DrawModel(self)
 		end
 
 		if invert_model then

--- a/lua/entities/gmod_wire_keypad.lua
+++ b/lua/entities/gmod_wire_keypad.lua
@@ -46,10 +46,8 @@ if CLIENT then
 	local color_red = Color(255, 0, 0)
 	local color_green = Color(0, 255, 0)
 
-	function ENT:Draw(flags)
-		self:DrawModel(flags)
-
-		if WireLib.IsDepthPass(flags) then return end
+	function ENT:Draw()
+		self:DrawModel()
 
 		local entpos = self:GetPos()
 		if entpos:Distance(EyePos()) > 512 then return end

--- a/lua/entities/gmod_wire_oscilloscope.lua
+++ b/lua/entities/gmod_wire_oscilloscope.lua
@@ -78,10 +78,8 @@ if CLIENT then
 		end
 	end)
 
-	function ENT:Draw(flags)
-		self:DrawModel(flags)
-
-		if WireLib.IsDepthPass(flags) then return end
+	function ENT:Draw()
+		self:DrawModel()
 
 		local length = self:GetNWFloat("Length", 50)
 		local r,g,b = self:GetNWFloat("R"), self:GetNWFloat("G"), self:GetNWFloat("B")

--- a/lua/entities/gmod_wire_pixel.lua
+++ b/lua/entities/gmod_wire_pixel.lua
@@ -4,8 +4,8 @@ ENT.PrintName       = "Wire Pixel"
 ENT.WireDebugName	= "Pixel"
 
 if CLIENT then
-	function ENT:Draw(flags)
-		self:DrawModel(flags)
+	function ENT:Draw()
+		self:DrawModel()
 	end
 
 	return  -- No more client

--- a/lua/entities/gmod_wire_rt_screen.lua
+++ b/lua/entities/gmod_wire_rt_screen.lua
@@ -304,10 +304,8 @@ if CLIENT then
         cam.End3D2D()
     end
 
-    function ENT:Draw(flags)
-        self:DrawModel(flags)
-
-        if WireLib.IsDepthPass(flags) then return end
+    function ENT:Draw()
+        self:DrawModel()
 
         if self.MonitorDesc == nil then
             return

--- a/lua/entities/gmod_wire_screen.lua
+++ b/lua/entities/gmod_wire_screen.lua
@@ -87,10 +87,8 @@ if CLIENT then
 		surface.DrawText( value )
 	end
 
-	function ENT:Draw(flags)
-		self:DrawModel(flags)
-
-		if WireLib.IsDepthPass(flags) then return end
+	function ENT:Draw()
+		self:DrawModel()
 
 		self.GPU:RenderToWorld(nil, 188, function(x, y, w, h)
 			surface.SetDrawColor(0, 0, 0, 255)

--- a/lua/entities/gmod_wire_textscreen.lua
+++ b/lua/entities/gmod_wire_textscreen.lua
@@ -137,10 +137,8 @@ if CLIENT then
 		if fullUpdate then return end
 		self.GPU:Finalize()
 	end
-	function ENT:Draw(flags)
-		self:DrawModel(flags)
-
-		if WireLib.IsDepthPass(flags) then return end
+	function ENT:Draw()
+		self:DrawModel()
 
 		if self.NeedRefresh then
 			self.NeedRefresh = nil

--- a/lua/entities/gmod_wire_waypoint.lua
+++ b/lua/entities/gmod_wire_waypoint.lua
@@ -9,10 +9,8 @@ end
 
 if CLIENT then
 	local physBeamMat = Material("cable/physbeam")
-	function ENT:Draw(flags)
-		BaseClass.Draw(self, flags)
-
-		if WireLib.IsDepthPass(flags) then return end
+	function ENT:Draw()
+		BaseClass.Draw(self)
 
 		local nextWP = self:GetNextWaypoint()
 		if IsValid(nextWP) and (LocalPlayer():GetEyeTrace().Entity == self) and (EyePos():Distance(self:GetPos()) < 4096) then

--- a/lua/weapons/laserpointer/cl_init.lua
+++ b/lua/weapons/laserpointer/cl_init.lua
@@ -19,9 +19,7 @@ local function WorldToViewModel(point)
 	return point
 end
 
-function SWEP:PostDrawViewModel(vm, wep, ply, flags)
-	if WireLib.IsDepthPass(flags) then return end
-
+function SWEP:PostDrawViewModel(vm, wep, ply)
 	if self:GetLaserEnabled() then
 		local att = vm:GetAttachment(vm:LookupAttachment("muzzle") or 0)
 		if not att then return end

--- a/lua/wire/client/cl_wirelib.lua
+++ b/lua/wire/client/cl_wirelib.lua
@@ -245,10 +245,6 @@ function WireLib.hud_debug(text, oneframe)
 	end)
 end
 
-function WireLib.IsDepthPass(flags)
-	return bit.band(flags, STUDIO_SSAODEPTHTEXTURE) ~= 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) ~= 0
-end
-
 local old_renderhalos = WireLib.__old_renderhalos or hook.GetTable().PostDrawEffects.RenderHalos
 WireLib.__old_renderhalos = old_renderhalos
 if old_renderhalos ~= nil then


### PR DESCRIPTION
Many addons use wire rendering without specifying flags, and some addons can also detour wire rendering without specifying flags, which causes errors. AdvDupe2 as an example

I think this should be implemented more carefully