### PR TITLE
Raise preprocessor timeout to 0.5 from 0.1 + minor changes

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/preprocessor.lua
+++ b/lua/entities/gmod_wire_expression2/base/preprocessor.lua
@@ -403,18 +403,18 @@ function PreProcessor:Process(buffer, directives, ent)
 		self.ignorestuff = true
 	end
 
-	-- to avoid hangs
+	-- to avoid big hangs, 2 regex changed from 500 to 10000, to avoid false positives
+	local regex_limits = {[0] = 50000000, 15000, 10000, 150, 70, 40}
 	local start_time = SysTime()
 
 	for i, line in ipairs(lines) do
 		self.readline = i
 
-		-- 2 regex changed from 500 to 10000, to avoid hangs
-		local ok = pcall(function() WireLib.CheckRegex(line, "^(.-)%s*$", {[0] = 50000000, 15000, 10000, 150, 70, 40}) end)
+		local ok = pcall(function() WireLib.CheckRegex(line, "^(.-)%s*$", regex_limits) end)
 		if not ok then self:Error("Line strip regex is too complex!") goto cont end
 
 		if SysTime() > start_time + 0.1 then
-			self:Error("Preprocessing take too long!")
+			self:Error("Preprocessing took too long!")
 			break
 		end
 

--- a/lua/entities/gmod_wire_expression2/base/preprocessor.lua
+++ b/lua/entities/gmod_wire_expression2/base/preprocessor.lua
@@ -403,9 +403,9 @@ function PreProcessor:Process(buffer, directives, ent)
 		self.ignorestuff = true
 	end
 
-	-- to avoid big hangs, 2 regex changed from 500 to 10000, to avoid false positives
+	-- to avoid big hangs, 2 regex changed from 500 to 10000 to avoid false positives
 	local regex_limits = {[0] = 50000000, 15000, 10000, 150, 70, 40}
-	local start_time = SysTime()
+	local timeout = SysTime() + 0.5
 
 	for i, line in ipairs(lines) do
 		self.readline = i
@@ -413,17 +413,16 @@ function PreProcessor:Process(buffer, directives, ent)
 		local ok = pcall(function() WireLib.CheckRegex(line, "^(.-)%s*$", regex_limits) end)
 		if not ok then self:Error("Line strip regex is too complex!") goto cont end
 
-		if SysTime() > start_time + 0.1 then
-			self:Error("Preprocessing took too long!")
-			break
-		end
-
 		line = string.TrimRight(line)
 		line = self:RemoveComments(line)
 		line = self:ParseDirectives(line)
-
 		lines[i] = line
 		::cont::
+
+		if SysTime() > timeout then
+			self:Error("Preprocessing took too long!")
+			break
+		end
 	end
 
 	-- convert description lookup table into an array that WireLib understands


### PR DESCRIPTION
It seems that some chips can falsely error if garbage collection occurs during preprocessing, so i think it's better to just increase the preprocessing time