### PR TITLE
Flags support for all Wire Render

### DIFF
--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -18,9 +18,9 @@ if CLIENT then
 		self.PlayerWasLookingAtMe = false
 	end
 
-	function ENT:Draw()
+	function ENT:Draw(flags)
 		local entsTbl = EntityMeta.GetTable( self )
-		entsTbl.DoNormalDraw( self )
+		entsTbl.DoNormalDraw( self, nil, nil, flags )
 		Wire_Render(self)
 		if entsTbl.GetBeamLength and (not entsTbl.GetShowBeam or entsTbl.GetShowBeam( self )) then
 			-- Every SENT that has GetBeamLength should draw a tracer. Some of them have the GetShowBeam boolean
@@ -270,15 +270,17 @@ if CLIENT then
 		end
 	end)
 
-	function ENT:DoNormalDraw(nohalo, notip)
-		if not nohalo and wire_drawoutline:GetBool() and looked_at == self then
-			self:DrawEntityOutline()
-			self:DrawModel()
-		else
-			self:DrawModel()
-		end
-		if not notip and looked_at == self then
-			self:AddWorldTip()
+	function ENT:DoNormalDraw(nohalo, notip, flags)
+		self:DrawModel(flags)
+
+		if looked_at == self then
+			if not nohalo and wire_drawoutline:GetBool() then
+				self:DrawEntityOutline()
+			end
+
+			if not notip then
+				self:AddWorldTip()
+			end
 		end
 	end
 

--- a/lua/entities/gmod_wire_button.lua
+++ b/lua/entities/gmod_wire_button.lua
@@ -18,8 +18,8 @@ if CLIENT then
 		baseclass.Get("gmod_button").UpdateLever(self)
 	end
 
-	function ENT:Draw()
-		self:DoNormalDraw(true,false)
+	function ENT:Draw(flags)
+		self:DoNormalDraw(true,false,flags)
 		if LocalPlayer():GetEyeTrace().Entity == self and EyePos():DistToSqr( self:GetPos() ) < 512^2 and GetConVarNumber("wire_drawoutline")~=0 then
 			if self:GetOn() then
 				halo_ent = self

--- a/lua/entities/gmod_wire_characterlcd/cl_init.lua
+++ b/lua/entities/gmod_wire_characterlcd/cl_init.lua
@@ -456,8 +456,8 @@ function ENT:DrawSpecialCharacter(c,x,y,w,h,r,g,b)
 end
 
 local VECTOR_1_1_1 = Vector(1, 1, 1)
-function ENT:Draw()
-	self:DrawModel()
+function ENT:Draw(flags)
+	self:DrawModel(flags)
 
 	local tone = render.GetToneMappingScaleLinear()
 	render.SetToneMappingScaleLinear(VECTOR_1_1_1)

--- a/lua/entities/gmod_wire_consolescreen/cl_init.lua
+++ b/lua/entities/gmod_wire_consolescreen/cl_init.lua
@@ -567,8 +567,8 @@ function ENT:DrawSpecialCharacter(c,x,y,w,h,r,g,b)
 end
 
 local VECTOR_1_1_1 = Vector(1, 1, 1)
-function ENT:Draw()
-	self:DrawModel()
+function ENT:Draw(flags)
+	self:DrawModel(flags)
 
 	local tone = render.GetToneMappingScaleLinear()
 	render.SetToneMappingScaleLinear(VECTOR_1_1_1)

--- a/lua/entities/gmod_wire_digitalscreen/cl_init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/cl_init.lua
@@ -312,8 +312,8 @@ function ENT:RedrawRow(y)
 end
 
 local VECTOR_1_1_1 = Vector(1, 1, 1)
-function ENT:Draw()
-	self:DrawModel()
+function ENT:Draw(flags)
+	self:DrawModel(flags)
 
 	local tone = render.GetToneMappingScaleLinear()
 	render.SetToneMappingScaleLinear(VECTOR_1_1_1)

--- a/lua/entities/gmod_wire_dynamic_button.lua
+++ b/lua/entities/gmod_wire_dynamic_button.lua
@@ -11,8 +11,8 @@ end
 if CLIENT then
 	local halo_ent, halo_blur
 
-	function ENT:Draw()
-		self:DoNormalDraw(true,false)
+	function ENT:Draw(flags)
+		self:DoNormalDraw(true,false,flags)
 		if LocalPlayer():GetEyeTrace().Entity == self and EyePos():Distance( self:GetPos() ) < 512 then
 			if self:GetOn() then
 				halo_ent = self

--- a/lua/entities/gmod_wire_egp/cl_init.lua
+++ b/lua/entities/gmod_wire_egp/cl_init.lua
@@ -33,8 +33,8 @@ end
 function ENT:DrawEntityOutline() end
 
 local VECTOR_1_1_1 = Vector(1, 1, 1)
-function ENT:Draw()
-	self:DrawModel()
+function ENT:Draw(flags)
+	self:DrawModel(flags)
 	Wire_Render(self)
 
 	local tone = render.GetToneMappingScaleLinear()

--- a/lua/entities/gmod_wire_egp_emitter.lua
+++ b/lua/entities/gmod_wire_egp_emitter.lua
@@ -151,11 +151,11 @@ if CLIENT then
 	 	end
 	end
 
-	function ENT:Draw()
+	function ENT:Draw(flags)
 		if self.GPU then -- if we're rendering on RT, use base EGP's draw function instead
-			BaseClass.Draw(self)
+			BaseClass.Draw(self, flags)
 		else
-			self:DrawModel()
+			self:DrawModel(flags)
 			self:DrawNoRT()
 			Wire_Render(self)
 		end

--- a/lua/entities/gmod_wire_egp_hud/cl_init.lua
+++ b/lua/entities/gmod_wire_egp_hud/cl_init.lua
@@ -20,7 +20,7 @@ function ENT:EGP_Update() end
 
 function ENT:DrawEntityOutline() end
 
-function ENT:Draw()
-	self:DrawModel()
+function ENT:Draw(flags)
+	self:DrawModel(flags)
 	Wire_Render(self)
 end

--- a/lua/entities/gmod_wire_gpu/cl_init.lua
+++ b/lua/entities/gmod_wire_gpu/cl_init.lua
@@ -366,15 +366,15 @@ end
 local VECTOR_1_1_1 = Vector(1, 1, 1)
 --------------------------------------------------------------------------------
 -- Entity drawing function
-function ENT:Draw()
+function ENT:Draw(flags)
 	-- Calculate time-related variables
 	self.CurrentTime = CurTime()
 	self.DeltaTime = math.min(1/30,self.CurrentTime - (self.PreviousTime or 0))
 	self.PreviousTime = self.CurrentTime
 
 	-- Draw GPU itself
-	self:DrawModel()
-  
+	self:DrawModel(flags)
+
 	local tone = render.GetToneMappingScaleLinear()
 	render.SetToneMappingScaleLinear(VECTOR_1_1_1)
 
@@ -458,7 +458,7 @@ function ENT:Draw()
 			end
 		end
 	end
-  
+
 	render.SetToneMappingScaleLinear(tone)
 	Wire_Render(self)
 end

--- a/lua/entities/gmod_wire_graphics_tablet.lua
+++ b/lua/entities/gmod_wire_graphics_tablet.lua
@@ -33,8 +33,8 @@ if CLIENT then
 		return x,y,w,h
 	end
 
-	function ENT:Draw()
-		self:DrawModel()
+	function ENT:Draw(flags)
+		self:DrawModel(flags)
 
 		local draw_background = self:GetDrawBackground()
 		self.GPU:RenderToWorld(nil, 512, function(x, y, w, h, monitor, pos, ang, res)

--- a/lua/entities/gmod_wire_hologram.lua
+++ b/lua/entities/gmod_wire_hologram.lua
@@ -114,7 +114,7 @@ if CLIENT then
 		render.EnableClipping(selfTbl.oldClipState)
 	end
 
-	function ENT:Draw()
+	function ENT:Draw(flags)
 		local selfTbl = EntityMeta.GetTable(self)
 		if selfTbl.blocked or selfTbl.notvisible then return end
 
@@ -132,10 +132,10 @@ if CLIENT then
 
 		if selfTbl.GetDisableShading(self) then
 			render.SuppressEngineLighting(true)
-			EntityMeta.DrawModel(self)
+			EntityMeta.DrawModel(self, flags)
 			render.SuppressEngineLighting(false)
 		else
-			EntityMeta.DrawModel(self)
+			EntityMeta.DrawModel(self, flags)
 		end
 
 		if invert_model then

--- a/lua/entities/gmod_wire_keypad.lua
+++ b/lua/entities/gmod_wire_keypad.lua
@@ -46,8 +46,8 @@ if CLIENT then
 	local color_red = Color(255, 0, 0)
 	local color_green = Color(0, 255, 0)
 
-	function ENT:Draw()
-		self:DrawModel()
+	function ENT:Draw(flags)
+		self:DrawModel(flags)
 
 		local entpos = self:GetPos()
 		if entpos:Distance(EyePos()) > 512 then return end

--- a/lua/entities/gmod_wire_oscilloscope.lua
+++ b/lua/entities/gmod_wire_oscilloscope.lua
@@ -78,8 +78,8 @@ if CLIENT then
 		end
 	end)
 
-	function ENT:Draw()
-		self:DrawModel()
+	function ENT:Draw(flags)
+		self:DrawModel(flags)
 
 		local length = self:GetNWFloat("Length", 50)
 		local r,g,b = self:GetNWFloat("R"), self:GetNWFloat("G"), self:GetNWFloat("B")

--- a/lua/entities/gmod_wire_pixel.lua
+++ b/lua/entities/gmod_wire_pixel.lua
@@ -4,8 +4,8 @@ ENT.PrintName       = "Wire Pixel"
 ENT.WireDebugName	= "Pixel"
 
 if CLIENT then
-	function ENT:Draw()
-		self:DrawModel()
+	function ENT:Draw(flags)
+		self:DrawModel(flags)
 	end
 
 	return  -- No more client

--- a/lua/entities/gmod_wire_rt_screen.lua
+++ b/lua/entities/gmod_wire_rt_screen.lua
@@ -304,8 +304,8 @@ if CLIENT then
         cam.End3D2D()
     end
 
-    function ENT:Draw()
-        self:DrawModel()
+    function ENT:Draw(flags)
+        self:DrawModel(flags)
 
         if self.MonitorDesc == nil then
             return

--- a/lua/entities/gmod_wire_screen.lua
+++ b/lua/entities/gmod_wire_screen.lua
@@ -87,8 +87,8 @@ if CLIENT then
 		surface.DrawText( value )
 	end
 
-	function ENT:Draw()
-		self:DrawModel()
+	function ENT:Draw(flags)
+		self:DrawModel(flags)
 
 		self.GPU:RenderToWorld(nil, 188, function(x, y, w, h)
 			surface.SetDrawColor(0, 0, 0, 255)

--- a/lua/entities/gmod_wire_textscreen.lua
+++ b/lua/entities/gmod_wire_textscreen.lua
@@ -137,8 +137,8 @@ if CLIENT then
 		if fullUpdate then return end
 		self.GPU:Finalize()
 	end
-	function ENT:Draw()
-		self:DrawModel()
+	function ENT:Draw(flags)
+		self:DrawModel(flags)
 
 		if self.NeedRefresh then
 			self.NeedRefresh = nil

--- a/lua/weapons/laserpointer/cl_init.lua
+++ b/lua/weapons/laserpointer/cl_init.lua
@@ -32,8 +32,8 @@ function SWEP:PostDrawViewModel(vm, wep, ply)
 	end
 end
 
-function SWEP:DrawWorldModel()
-	self:DrawModel()
+function SWEP:DrawWorldModel(flags)
+	self:DrawModel(flags)
 
 	if self:GetLaserEnabled() then
 		local att = self:GetAttachment(self:LookupAttachment("muzzle") or 0)


### PR DESCRIPTION
I noticed that many Wire parts don't specify flags when rendering via `ENT:DrawModel`. This can cause render issues in some cases. This PR fixes this by adding flags to each `ENT:DrawModel` and slightly optimizing `ENT:DoNormalDraw`

Attempt to implement #3614 more carefully