### PR TITLE
Add cog icons for Options tab and some more icons for tools + speedup tools creation a bit

### DIFF
--- a/lua/wire/client/customspawnmenu.lua
+++ b/lua/wire/client/customspawnmenu.lua
@@ -565,13 +565,14 @@ function PANEL:AddCategory( Name, Label, tItems, CategoryID )
 		v.Category = Label
 		v.CategoryID = CategoryID
 
-		local icon = "icon16/wrench.png"
+		local icon = Label == "Options" and "icon16/cog.png" or "icon16/wrench.png"
 
 		if custom_icons:GetBool() then
-			local tooltbl = weapons.Get("gmod_tool").Tool[v.ItemName]
-			if tooltbl then
-				if tooltbl.Wire_ToolMenuIcon then
-					icon = tooltbl.Wire_ToolMenuIcon
+			local tool = weapons.GetStored("gmod_tool").Tool[v.ItemName]
+
+			if tool then
+				if tool.Wire_ToolMenuIcon then
+					icon = tool.Wire_ToolMenuIcon
 				end
 			end
 		end

--- a/lua/wire/stools/button.lua
+++ b/lua/wire/stools/button.lua
@@ -9,6 +9,8 @@ if CLIENT then
 	language.Add( "WireButtonTool_value_on", "Value On:" )
 	language.Add( "WireButtonTool_value_off", "Value Off:" )
 	TOOL.Information = { { name = "left", text = "Create/Update " .. TOOL.Name } }
+
+	WireToolSetup.setToolMenuIcon( "icon16/add.png" )
 end
 WireToolSetup.BaseLang()
 WireToolSetup.SetupMax( 20 )

--- a/lua/wire/stools/dynamic_button.lua
+++ b/lua/wire/stools/dynamic_button.lua
@@ -13,6 +13,8 @@ if CLIENT then
 	language.Add( "WireDynamicButtonTool_materials_off", "Material Off:" )
 	language.Add( "WireDynamicButtonTool_colour_on", "Color On:" )
 	language.Add( "WireDynamicButtonTool_colour_off", "Color Off:" )
+
+	WireToolSetup.setToolMenuIcon( "icon16/add.png" )
 end
 WireToolSetup.BaseLang()
 WireToolSetup.SetupMax( 20 )

--- a/lua/wire/stools/graphics_tablet.lua
+++ b/lua/wire/stools/graphics_tablet.lua
@@ -14,6 +14,8 @@ if ( CLIENT ) then
 	language.Add( "Tool_wire_graphics_tablet_draw_background", "Draw background" )
 	language.Add( "Tool_wire_graphics_tablet_createflat", "Create flat to surface" )
 	TOOL.Information = { { name = "left", text = "Create/Update " .. TOOL.Name } }
+
+	WireToolSetup.setToolMenuIcon( "icon16/television.png" )
 end
 WireToolSetup.BaseLang()
 WireToolSetup.SetupMax( 20 )

--- a/lua/wire/stools/interactiveprop.lua
+++ b/lua/wire/stools/interactiveprop.lua
@@ -6,6 +6,8 @@ if CLIENT then
 	language.Add("tool.wire_interactiveprop.name", "Wire Interactive Prop")
 	language.Add("tool.wire_interactiveprop.desc", "Opens a UI panel which controls outputs for use with wire system.")
 	TOOL.Information = { { name = "left", text = "Create/Update " .. TOOL.Name } }
+
+	WireToolSetup.setToolMenuIcon("icon16/plugin.png")
 end
 
 

--- a/lua/wire/stools/user.lua
+++ b/lua/wire/stools/user.lua
@@ -6,6 +6,8 @@ if CLIENT then
 	language.Add("tool.wire_user.desc", "Spawns a constant user prop for use with the wire system.")
 	language.Add("tool.wire_user.range", "Max Range:")
 	TOOL.Information = { { name = "left", text = "Create/Update " .. TOOL.Name } }
+
+	WireToolSetup.setToolMenuIcon( "icon16/user_add.png" )
 end
 
 WireToolSetup.BaseLang()


### PR DESCRIPTION
Adds a cog icon to all Options in the Wire tab + slightly speeds up tool loading by removing unnecessary table copying every time
<img width="201" height="77" alt="image" src="https://github.com/user-attachments/assets/79d663c4-a81b-4dd4-ac6f-569bbaed1429" />
<img width="172" height="159" alt="image" src="https://github.com/user-attachments/assets/b2e45441-80e1-4358-b4eb-fde0321ba765" />
