### PR TITLE
backward compatibility with string calls and empty e2 return type

### DIFF
--- a/data_static/expression2/tests/regressions/2841.txt
+++ b/data_static/expression2/tests/regressions/2841.txt
@@ -1,0 +1,7 @@
+## SHOULD_PASS:EXECUTE
+
+function number test() {
+    return 1    
+}
+
+"test"()

--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -1832,7 +1832,7 @@ local CompileVisitors = {
 				local fn = state.funcs[sig] or state.funcs[meta_sig]
 				if fn then -- first check if user defined any functions that match signature
 					local r = state.funcs_ret[sig] or state.funcs_ret[meta_sig]
-					if r ~= ret_type then
+					if r ~= ret_type and not (ret_type == nil or r == "") then
 						state:forceThrow( "Mismatching return types. Got " .. (r or "void") .. ", expected " .. (ret_type or "void"))
 					end
 
@@ -1841,7 +1841,7 @@ local CompileVisitors = {
 					fn = wire_expression2_funcs[sig] or wire_expression2_funcs[meta_sig]
 					if fn then
 						local r = fn[2]
-						if r ~= ret_type and not (ret_type == nil and r == "") then
+						if r ~= ret_type and not (ret_type == nil or r == "") then
 							state:forceThrow( "Mismatching return types. Got " .. (r or "void") .. ", expected " .. (ret_type or "void"))
 						end
 


### PR DESCRIPTION
fix issue mention on https://github.com/wiremod/wire/issues/2841 - allow empty (void) return type when not required in non strict mode + fix check in other place, should be OR logic, not AND.

```
@name 
@inputs 
@outputs 
@persist 
@trigger 

function number test() {
    return 1    
}

"test"()
```