### PR TITLE
Fix lua error

### DIFF
--- a/lua/entities/gmod_wire_hudindicator/init.lua
+++ b/lua/entities/gmod_wire_hudindicator/init.lua
@@ -263,7 +263,7 @@ function ENT:SendHUDInfo(hidehud)
 	local pl = self:GetPlayer()
 
 	for index,rplayer in pairs(self.RegisteredPlayers) do
-		if (rplayer.ply) then
+		if (IsValid(rplayer.ply)) then
 			if rplayer.ply ~= pl or (self.ShowInHUD or self.PodPly == pl) then
 				umsg.Start("HUDIndicatorHideHUD", rplayer.ply)
 					umsg.Short(self:EntIndex())


### PR DESCRIPTION
Fixes:
```
- Wire error (Entity [770][gmod_wire_hudindicator]):
addons/wire/lua/entities/gmod_wire_hudindicator/init.lua:268: Tried to use a NULL entity!
stack traceback:
    [C]: in function 'Start'
    addons/wire/lua/entities/gmod_wire_hudindicator/init.lua:268: in function 'SendHUDInfo'
    addons/wire/lua/entities/gmod_wire_hudindicator/init.lua:229: in function <addons/wire/lua/entities/gmod_wire_hudindicator/init.lua:214>
    [C]: in function 'xpcall'
    addons/wire/lua/wire/server/wirelib.lua:87: in function 'TriggerInput'
```