### PR TITLE
Better wire errors stack

### DIFF
--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -84,14 +84,14 @@ function WireLib.TriggerInput(ent, name, value, ...)
 		input.TriggerLimit = input.TriggerLimit - 1
 	end
 
-	local ok, ret = xpcall(triggerInput, debug.traceback, ent, name, value, ...)
+	local ok = ProtectedCall(triggerInput, ent, name, value, ...)
+
 	if not ok then
 		local ply = WireLib.GetOwner(ent)
-		local validPly = IsValid(ply)
-		local owner_msg = validPly and (" by %s"):format(tostring(ply)) or ""
-		local message = ("Wire error (%s%s):\n%s\n"):format(tostring(ent), owner_msg, ret)
-		WireLib.ErrorNoHalt(message)
-		if validPly then WireLib.ClientError(message, ply) end
+
+		if IsValid(ply) then
+			WireLib.ClientError("Wire error (" .. tostring(ent) .. ")", ply)
+		end
 	end
 end
 


### PR DESCRIPTION
Replaces custom error messages from wire with default ones for a more understandable error stack
Now errors won't be sent to the entity owner, but i don't think this will do any harm