### PR TITLE
Remove useless WireLib.ErrorNoHalt function + remove useless GMOD 13 check

### DIFF
--- a/lua/autorun/wire_load.lua
+++ b/lua/autorun/wire_load.lua
@@ -15,12 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ]]--
 
-if VERSION < 140403 and VERSION > 5 then
-	-- VERSION > 5 check added June 2013, to address issues regarding the Steampipe update sometimes setting VERSION to 1.
-	ErrorNoHalt("WireMod: This branch of wiremod only supports Gmod13+.\n")
-	return
-end
-
 if SERVER then
 	-- this file
 	AddCSLuaFile("autorun/wire_load.lua")

--- a/lua/entities/gmod_wire_expression2/core/extloader.lua
+++ b/lua/entities/gmod_wire_expression2/core/extloader.lua
@@ -114,7 +114,7 @@ local function e2_include_finalize()
 	for _, info in ipairs(included_files) do
 		local ok, message = pcall(e2_include_pass2, unpack(info))
 		if not ok then
-			WireLib.ErrorNoHalt(string.format("There was an error loading " ..
+			ErrorNoHalt(string.format("There was an error loading " ..
 			"the %s extension. Please report this to its developer.\n%s\n",
 			info[1], message))
 		end

--- a/lua/entities/gmod_wire_gpu/cl_init.lua
+++ b/lua/entities/gmod_wire_gpu/cl_init.lua
@@ -452,7 +452,7 @@ function ENT:Draw(flags)
 					self:RenderVertex(1024,1024*monitor.RatioX)
 					self:RenderMisc(pos, ang, res, 1/monitor.RatioX, monitor)
 					end, debug.traceback)
-					if not ok then WireLib.ErrorNoHalt(err) end
+					if not ok then ErrorNoHalt(err) end
 				if self.In3D2D then self.In3D2D = false cam.End3D2D() end
 				self.VertexCamSettings = nil
 			end

--- a/lua/wire/gpulib.lua
+++ b/lua/wire/gpulib.lua
@@ -299,7 +299,7 @@ if CLIENT then
 		render.SetViewPort(0, 0, 1024, 1024)
 		cam.Start2D()
 			local ok, err = xpcall(renderfunction, debug.traceback)
-			if not ok then WireLib.ErrorNoHalt(err) end
+			if not ok then ErrorNoHalt(err) end
 		cam.End2D()
 		render.SetViewPort(0, 0, oldw, oldh)
 		render.SetRenderTarget(OldRT)
@@ -326,7 +326,7 @@ if CLIENT then
 		local res = monitor.RS*1024/h
 		cam.Start3D2D(pos, ang, res)
 			local ok, err = xpcall(renderfunction, debug.traceback, x, y, w, h, monitor, pos, ang, res)
-			if not ok then WireLib.ErrorNoHalt(err) end
+			if not ok then ErrorNoHalt(err) end
 		cam.End3D2D()
 	end
 
@@ -371,7 +371,7 @@ if CLIENT then
 
 				if postrenderfunction then postrenderfunction(pos, ang, res, aspect, monitor) end
 			end, debug.traceback)
-			if not ok then WireLib.ErrorNoHalt(err) end
+			if not ok then ErrorNoHalt(err) end
 		cam.End3D2D()
 
 		WireGPU_matScreen:SetTexture("$basetexture", OldTex)

--- a/lua/wire/timedpairs.lua
+++ b/lua/wire/timedpairs.lua
@@ -52,7 +52,7 @@ local function Timedpairs()
 				local ok, err = xpcall( data.callback, debug.traceback, kv.key, kv.value, unpack(data.args) ) -- DO EET
 
 				if not ok then -- oh noes
-					WireLib.ErrorNoHalt( "Error in Timedpairs '" .. name .. "': " .. err )
+					ErrorNoHalt( "Error in Timedpairs '" .. name .. "': " .. err )
 					toremove[#toremove+1] = name
 					break
 				elseif err == false then -- They returned false inside the function
@@ -65,7 +65,7 @@ local function Timedpairs()
 					local ok, err = xpcall( data.endcallback, debug.traceback, kv.key, kv.value, unpack(data.args) )
 
 					if not ok then
-						WireLib.ErrorNoHalt( "Error in Timedpairs '" .. name .. "' (in end function): " .. err )
+						ErrorNoHalt( "Error in Timedpairs '" .. name .. "' (in end function): " .. err )
 					end
 				end
 				toremove[#toremove+1] = name

--- a/lua/wire/wireshared.lua
+++ b/lua/wire/wireshared.lua
@@ -407,13 +407,6 @@ WireLib.NetQueue = {
 setmetatable(WireLib.NetQueue, WireLib.NetQueue)
 end
 
-function WireLib.ErrorNoHalt(message)
-	-- ErrorNoHalt clips messages to 512 characters, so chain calls if necessary
-	for i=1,#message, 511 do
-		ErrorNoHalt(message:sub(i,i+510))
-	end
-end
-
 --- Generate a random version 4 UUID and return it as a string.
 function WireLib.GenerateUUID()
 	-- It would be easier to generate this by word rather than by byte, but


### PR DESCRIPTION
The limitation described in this function does not actually exist, which makes it completely useless (actual limit is 4096, i don't think something could exceed it)