### PR TITLE
Don't update renderbounds for Wire entities while they are dormant

### DIFF
--- a/lua/entities/base_wire_entity.lua
+++ b/lua/entities/base_wire_entity.lua
@@ -285,15 +285,14 @@ if CLIENT then
 	end
 
 	function ENT:Think()
-		local tab = self:GetTable()
+		if not EntityMeta.IsDormant(self) then
+			local tab = EntityMeta.GetTable(self)
 
-		if (CurTime() >= (tab.NextRBUpdate or 0)) then
-			-- We periodically update the render bounds every 10 seconds - the
-			-- reasons why are mostly anecdotal, but in some circumstances
-			-- entities might 'forget' their renderbounds. Nobody really knows
-			-- if this is still needed or not.
-			tab.NextRBUpdate = CurTime() + 10
-			Wire_UpdateRenderBounds(self)
+			if (CurTime() >= (tab.NextRBUpdate or 0)) then
+				-- Periodically update renderbounds to make connected wires visible when we're not looking at the entity
+				tab.NextRBUpdate = CurTime() + 10
+				Wire_UpdateRenderBounds(self)
+			end
 		end
 	end
 


### PR DESCRIPTION
When an entity is dormant, its ENT:Draw function will never be called, so periodically updating renderbounds is useless