### PR TITLE
Fix lua error

### DIFF
--- a/lua/wire/stools/hydraulic.lua
+++ b/lua/wire/stools/hydraulic.lua
@@ -178,7 +178,7 @@ function TOOL:RightClick( trace )
 	end
 	local trace2 = util.TraceLine( tr )
 
-	if CLIENT or not WireLib.CanTool(self:GetOwner(), trace2.Entity, "wire_hydraulic") then return false end
+	if CLIENT or not trace2.Entity:IsValid() or not WireLib.CanTool(self:GetOwner(), trace2.Entity, "wire_hydraulic") then return false end
 
 	return self:LeftClick(trace) and self:LeftClick(trace2)
 end


### PR DESCRIPTION
Fixes:
```
- lua/autorun/server/sv_cpp.lua:7: attempt to index a nil value
1. GetOwner - lua/autorun/server/sv_cpp.lua:7
 2. CanTool - lua/autorun/sh_cpp.lua:5
  3. RightClick - addons/wire/lua/wire/stools/hydraulic.lua:181
   4. <unknown> - gamemodes/sandbox/entities/weapons/gmod_tool/shared.lua:273
```
Not prop protection issue, it's because WireLib.CanTool pushes NULL ent