### PR TITLE
Fixed WMI being broken after engine savegame restore.

### DIFF
--- a/lua/entities/info_wiremapinterface/entitycontrol.lua
+++ b/lua/entities/info_wiremapinterface/entitycontrol.lua
@@ -88,7 +88,7 @@ function ENT:AddSingleEntity(wireEnt)
 
 	local isInList = IsValid(oldWireEnt) and oldWireEnt == wireEnt
 
-	if isInList and wireEnt._WireMapInterfaceEnt_HasPorts then
+	if isInList and wireEnt._WireMapInterfaceEnt_HasPorts and wireEnt._WMI_AddPorts then
 		return
 	end
 
@@ -96,7 +96,9 @@ function ENT:AddSingleEntity(wireEnt)
 		if not self.WireEntsUpdated then
 			self:TriggerHammerOutputSafe("OnWireEntsStartChanging", self)
 		end
+	end
 
+	if not isInList or not wireEnt._WMI_AddPorts then
 		self:OverrideEnt(wireEnt)
 	end
 

--- a/lua/entities/info_wiremapinterface/entityoverride.lua
+++ b/lua/entities/info_wiremapinterface/entityoverride.lua
@@ -654,7 +654,7 @@ function WIREENT:_WMI_AddPorts(wireInputRegister, wireOutputRegister)
 		return
 	end
 
-	if wireInputRegister and wireInputRegister:hasPorts() then
+	if wireInputRegister and wireInputRegister.hasPorts and wireInputRegister:hasPorts() then
 		local split = wireInputRegister.wire
 
 		wmidata.inputs = table.Copy(split)
@@ -670,7 +670,7 @@ function WIREENT:_WMI_AddPorts(wireInputRegister, wireOutputRegister)
 		self._WireMapInterfaceEnt_HasPorts = true
 	end
 
-	if wireOutputRegister and wireOutputRegister:hasPorts() then
+	if wireOutputRegister and wireOutputRegister.hasPorts and wireOutputRegister:hasPorts() then
 		local split = wireOutputRegister.wire
 
 		wmidata.outputs = table.Copy(split)
@@ -763,7 +763,7 @@ function ENT:OverrideEnt(wireEnt)
 		return
 	end
 
-	if not wireEnt._IsWireMapInterfaceSubEntity then
+	if not wireEnt._IsWireMapInterfaceSubEntity or not wireEnt._WMI_AddPorts then
 		WIREENT._WMI_OverrideEnt(wireEnt, self)
 	end
 
@@ -777,7 +777,7 @@ local function OverrideEntFromDupe(wireEnt, wireMapInterfaceEntDupeInfo, interfa
 		return
 	end
 
-	if wireEnt._IsWireMapInterfaceSubEntity then
+	if wireEnt._IsWireMapInterfaceSubEntity and wireEnt._WMI_AddPorts then
 		-- Already initialized
 		return
 	end

--- a/lua/entities/info_wiremapinterface/init.lua
+++ b/lua/entities/info_wiremapinterface/init.lua
@@ -272,11 +272,6 @@ function ENT:Initialize()
 
 	self.PortsUpdated = true
 
-	local recipientFilter = RecipientFilter()
-	recipientFilter:RemoveAllPlayers()
-
-	self.NetworkRecipientFilter = recipientFilter
-
 	self.NextNetworkTime = CurTime() + (1 + math.random() * 2) * (self.MIN_THINK_TIME * 4)
 
 	self:AddDupeHooks()
@@ -285,6 +280,19 @@ end
 
 function ENT:OnReloaded()
 	-- Easier for debugging.
+	self:RequestNetworkEntities()
+	self:AttachToSaveStateEntity()
+end
+
+function ENT:OnRestore()
+	-- Auto repair on engine savegame restore.
+
+	-- Repair wired entities by re-adding them.
+	self:AddEntitiesByTable(self:GetWiredEntities())
+	self.PortsUpdated = true
+
+	-- Make sure networking and hooks are triggered
+	self:AddDupeHooks()
 	self:RequestNetworkEntities()
 	self:AttachToSaveStateEntity()
 end

--- a/lua/entities/info_wiremapinterface/io.lua
+++ b/lua/entities/info_wiremapinterface/io.lua
@@ -179,7 +179,7 @@ function ENT:PrepairOutputGlobals(inputData, wireValue, wireEnt, wireDevice, own
 		return
 	end
 
-	-- This can be usefull if a lua_run entity is triggered
+	-- This can be useful if a lua_run entity is triggered
 	-- Because entity.Fire and entity.AcceptInput are not run synchronously in the same frame, we use them in a custom entity.AcceptInput detour.
 	-- So we store them for later use in a custom entity.AcceptInput detour.
 
@@ -207,7 +207,7 @@ function ENT:PrepairOutputGlobals(inputData, wireValue, wireEnt, wireDevice, own
 end
 
 function ENT:SetupOutputGlobals(globals)
-	-- This can be usefull if a lua_run entity is triggered
+	-- This can be useful if a lua_run entity is triggered
 
 	local G = _G
 

--- a/lua/entities/info_wiremapinterface/io.lua
+++ b/lua/entities/info_wiremapinterface/io.lua
@@ -100,7 +100,10 @@ end
 
 -- To cleanup and get the in-/outputs information.
 local function copyAndSanitizeToPortRegister(register, registerTmp)
-	register = register or newPortRegister()
+	if not register or not register.empty then
+	 	register = newPortRegister()
+	end
+
 	register:empty()
 
 	if not registerTmp then
@@ -130,7 +133,9 @@ function ENT:UpdatePorts()
 	local wireEnts = self:GetWiredEntities()
 
 	for key, wireEnt in ipairs(wireEnts) do
-		wireEnt:_WMI_AddPorts(self.WireInputRegister, self.WireOutputRegister)
+		if wireEnt._WMI_AddPorts then
+			wireEnt:_WMI_AddPorts(self.WireInputRegister, self.WireOutputRegister)
+		end
 	end
 end
 

--- a/lua/entities/info_wiremapinterface/networking.lua
+++ b/lua/entities/info_wiremapinterface/networking.lua
@@ -55,23 +55,24 @@ function ENT:RequestNetworkEntities(ply, networkAtTime)
 		self.NextNetworkTime = networkAtTime
 	end
 
-	local recipientFilter = self.NetworkRecipientFilter
-
 	if not IsValid(ply) then
-		recipientFilter:AddAllPlayers()
+		self.NetworkRecipients = player.GetHumans()
 		return
 	end
 
-	recipientFilter:AddPlayer(ply)
+	local networkRecipients = self.NetworkRecipients or {}
+	self.NetworkRecipients = networkRecipients
+
+	networkRecipients[#networkRecipients + 1] = ply
 end
 
 function ENT:NetworkWireEntities()
 	-- Network the list and properties of the wire entities.
 	-- We need we know about them on the client. For cable rendering, tools etc.
 
-	local recipientFilter = self.NetworkRecipientFilter
+	local networkRecipients = self.NetworkRecipients
 
- 	if recipientFilter:GetCount() <= 0 then
+	if not networkRecipients or #networkRecipients <= 0 then
 		return
 	end
 
@@ -89,8 +90,11 @@ function ENT:NetworkWireEntities()
 		net.WriteUInt(wireEnt:EntIndex(), MAX_EDICT_BITS)
 	end
 
+	local recipientFilter = RecipientFilter()
+	recipientFilter:AddPlayers(networkRecipients)
+
 	net.Send(recipientFilter)
 
-	recipientFilter:RemoveAllPlayers()
+	self.NetworkRecipients = nil
 end
 

--- a/wiremod.fgd
+++ b/wiremod.fgd
@@ -2,7 +2,7 @@
 	: "Creates an interface between the map and Wiremod."
 [
 	wire_entity_name(target_destination) : "Wire Entity" : "" : "The name of an entity or of the entities that will get wire ports."
-	min_trigger_time(float) : "Minimum Trigger Time" : "0.01" : "Set the minimum time in seconds between two Wiremod input triggers. It's usefull to prevent lags."
+	min_trigger_time(float) : "Minimum Trigger Time" : "0.01" : "Set the minimum time in seconds between two Wiremod input triggers. It's useful to prevent lags."
 
 	// Wire Inputs
 	input1_name(string) : "Wire Input 1 Name" : "" : "Sets the name of Wire Input 1."


### PR DESCRIPTION
## About

Turns out engine save games store the entire entity table, with no way to filter them before hand. This leads to partly applied entity states. Like that entities having certain values but not others such as functions or certain usertypes. It results in a broken override state. To fix this I changed the system to also check for certain functions to exist before (re-)applying the custom logic.

Fixed lua errors:
```
Can't save or load unknown type CRecipientFilter
    1. GetType - lua/includes/modules/saverestore.lua:94
        2. IsWritable - lua/includes/modules/saverestore.lua:120
            3. WritableKeysInTable - lua/includes/modules/saverestore.lua:137
                4. WriteTable - lua/includes/modules/saverestore.lua:245
                    5. unknown - lua/includes/modules/saverestore.lua:324
                    
[wire] addons/wire/lua/entities/info_wiremapinterface/networking.lua:65: attempt to index local 'recipientFilter' (a nil value)
    1. RequestNetworkEntities - addons/wire/lua/entities/info_wiremapinterface/networking.lua:65
        2. resetNetworking - addons/wire/lua/entities/info_wiremapinterface/networking.lua:12
            3. v - addons/wire/lua/entities/info_wiremapinterface/networking.lua:22
                4. unknown - lua/includes/modules/hook.lua:102
```


## Why does this need a fix?

It has been said that Wiremod does not support engine save games. But especially when mapping (important use case of the Wire Map Interface), the engine might create save games on multiple occurrences during map builds or tests. The WMI should still work in those cases, or at least do not throw Lua errors.

## Info about WMI
https://github.com/wiremod/wire/wiki/Wire-Map-Interface