### PR TITLE
Implement SteamID blocking for wire holograms

### DIFF
--- a/lua/entities/gmod_wire_hologram.lua
+++ b/lua/entities/gmod_wire_hologram.lua
@@ -362,7 +362,7 @@ if CLIENT then
 	
 	local blockfile = "wire_hologram_block.txt"
 	
-	local blocked = file.Exists(blockfile, "DATA")
+	blocked = file.Exists(blockfile, "DATA")
 		and util.JSONToTable(file.Read(blockfile, "DATA")) or {}
 
 	local function saveBlocked()

--- a/lua/entities/gmod_wire_hologram.lua
+++ b/lua/entities/gmod_wire_hologram.lua
@@ -402,6 +402,7 @@ if CLIENT then
 			if not blocked[toblock] then print("This steamid isn't blocked") return end
 
 			blocked[toblock] = nil
+			saveBlocked()
 			for _, ent in ipairs(ents.FindByClass("gmod_wire_hologram")) do
 				if ent.steamid == toblock then
 					ent.blocked = false

--- a/lua/entities/gmod_wire_hologram.lua
+++ b/lua/entities/gmod_wire_hologram.lua
@@ -359,9 +359,9 @@ if CLIENT then
 	local function checkSteamid(steamid)
 		return string.match(steamid, "STEAM_%d+:%d+:%d+")
 	end
-	
+
 	local blockfile = "wire_hologram_block.txt"
-	
+
 	blocked = file.Exists(blockfile, "DATA")
 		and util.JSONToTable(file.Read(blockfile, "DATA")) or {}
 
@@ -378,7 +378,7 @@ if CLIENT then
 
 			blocked[toblock] = true
 			saveBlocked()
-			
+
 			for _, ent in ipairs(ents.FindByClass("gmod_wire_hologram")) do
 				if ent.steamid == toblock then
 					ent.blocked = true

--- a/lua/entities/gmod_wire_hologram.lua
+++ b/lua/entities/gmod_wire_hologram.lua
@@ -359,6 +359,16 @@ if CLIENT then
 	local function checkSteamid(steamid)
 		return string.match(steamid, "STEAM_%d+:%d+:%d+")
 	end
+	
+	local blockfile = "wire_hologram_block.txt"
+	
+	local blocked = file.Exists(blockfile, "DATA")
+		and util.JSONToTable(file.Read(blockfile, "DATA")) or {}
+
+	local function saveBlocked()
+		file.Write(blockfile, util.TableToJSON(blocked))
+	end
+
 	concommand.Add("wire_holograms_block_client",
 		function(ply, command, args)
 			if not args[1] then print("Invalid steamid") return end
@@ -367,6 +377,8 @@ if CLIENT then
 			if not toblock then print("Invalid steamid") return end
 
 			blocked[toblock] = true
+			saveBlocked()
+			
 			for _, ent in ipairs(ents.FindByClass("gmod_wire_hologram")) do
 				if ent.steamid == toblock then
 					ent.blocked = true
@@ -379,7 +391,7 @@ if CLIENT then
 				table.insert(help, cmd.." \""..ply:SteamID().."\" // "..ply:Name())
 			end
 			return help
-		end)
+	end)
 
 	concommand.Add("wire_holograms_unblock_client",
 		function(ply, command, args)


### PR DESCRIPTION
Fix: save block list after unblocking hologram clients

Adds missing `saveBlocked()` call in `wire_holograms_unblock_client` so removed SteamIDs are also deleted from `wire_hologram_block.txt`.
