### PR TITLE
Fix table remove issues after chip restart, fixes #3487

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -1412,17 +1412,17 @@ local CompileVisitors = {
 			end
 
 			return function(state) ---@param state RuntimeContext
-				local array = {}
+				local array, arraytypes = {}, {}
 
 				for i = 1, len do
 					table_perf_inc(state)
-
 					array[i] = args[i](state)
+					arraytypes[i] = argtypes[i]
 				end
 
 				local ret = newE2Table()
 				ret.n = array
-				ret.ntypes = argtypes
+				ret.ntypes = arraytypes
 				ret.size = len
 				return ret
 			end, "t"


### PR DESCRIPTION
Fixes table issues with code like after chip restart, fixes #3487

```
function foo() { 

    local T = table( 
        table(0,"A"), 
        table(0,"B"),
        table(0,"C"), 
        table(0,"D") 
    ) 

    T:removeTable(1) 
    printTable(T[1,table]) 
    printTable(T[2,table]) 
    printTable(T[3,table]) 
    printTable(T[4,table]) 
    print("---") 

} 

foo()

```