### PR TITLE
fix chip crashes after duplicated in big dupes with persist tables

### DIFF
--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -828,6 +828,11 @@ function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID, GetConstByID)
 				self.GlobalScope[k] = istable(v) and Angle(v[1], v[2], v[3]) or v
 			elseif vartype == "v" then
 				self.GlobalScope[k] = istable(v) and Vector(v[1], v[2], v[3]) or v
+            elseif vartype == "t" then 
+                if getmetatable(v) == nil then
+                    setmetatable(v, WireLib.E2Table)
+                end
+                self.GlobalScope[k] = v
 			else
 				self.GlobalScope[k] = v
 			end

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -829,7 +829,7 @@ function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID, GetConstByID)
 			elseif vartype == "v" then
 				self.GlobalScope[k] = istable(v) and Vector(v[1], v[2], v[3]) or v
 			elseif vartype == "t" then
-				if getmetatable(v) == nil then
+				if istable(v) and getmetatable(v) == nil then
 					setmetatable(v, WireLib.E2Table)
 				end
 				self.GlobalScope[k] = v

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -828,7 +828,7 @@ function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID, GetConstByID)
 				self.GlobalScope[k] = istable(v) and Angle(v[1], v[2], v[3]) or v
 			elseif vartype == "v" then
 				self.GlobalScope[k] = istable(v) and Vector(v[1], v[2], v[3]) or v
-			elseif vartype == "t" then 
+			elseif vartype == "t" then
 				if getmetatable(v) == nil then
 					setmetatable(v, WireLib.E2Table)
 				end

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -828,11 +828,11 @@ function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID, GetConstByID)
 				self.GlobalScope[k] = istable(v) and Angle(v[1], v[2], v[3]) or v
 			elseif vartype == "v" then
 				self.GlobalScope[k] = istable(v) and Vector(v[1], v[2], v[3]) or v
-            elseif vartype == "t" then 
-                if getmetatable(v) == nil then
-                    setmetatable(v, WireLib.E2Table)
-                end
-                self.GlobalScope[k] = v
+			elseif vartype == "t" then 
+				if getmetatable(v) == nil then
+					setmetatable(v, WireLib.E2Table)
+				end
+				self.GlobalScope[k] = v
 			else
 				self.GlobalScope[k] = v
 			end


### PR DESCRIPTION
I found issue with my ALX PC chips crashing after paste duplication. Its a huge duplication so it has a big delay for paste, and something goes wrong during that.

then when i run almost any chip - it crash due to table.remove is nil or table.unset is nil in all chips. While debugging i found that persist table variables missing metadata after paste, so e2 functions crashing because of that like:

```
sv: Expression 2 (Internet Connector): Runtime error 'entities/gmod_wire_expression2/core/table.lua:536: attempt to call method 'Unset' (a nil value)' at line -1, char -1
```
It is just a `@persist NWData:table` and other tables

with this change it completely fixes this issue. But have no idea if thats correct way. Correct me if i'm wrong.

and i cannot provide easy steps to reproduce, unless share big duplication i have so you can test manually what i mean.

Thanks.