### PR TITLE
Fix vector and angle multiply methods

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/angle.lua
+++ b/lua/entities/gmod_wire_expression2/core/angle.lua
@@ -105,7 +105,10 @@ e2function angle operator-(angle rv1, angle rv2)
 end
 
 e2function angle operator*(angle rv1, angle rv2)
-	return rv1 * rv2
+	local rp1, ry1, rr1 = rv1:Unpack()
+	local rp2, ry2, rr2 = rv2:Unpack()
+
+	return Angle(rp1 * rp2, ry1 * ry2, rr1 * rr2)
 end
 
 e2function angle operator*(rv1, angle rv2)

--- a/lua/entities/gmod_wire_expression2/core/vector.lua
+++ b/lua/entities/gmod_wire_expression2/core/vector.lua
@@ -124,7 +124,10 @@ e2function vector operator*(vector lhs, rhs)
 end
 
 e2function vector operator*(vector lhs, vector rhs)
-	return lhs * rhs
+	local lx, ly, lz = lhs:Unpack()
+	local rx, ry, rz = rhs:Unpack()
+
+	return Vector(lx * rx, ly * ry, lz * rz)
 end
 
 -- Yes this needs to be in pure lua. Angle/Vector operations in reverse order act as Angle / Number rather than Number / Angle properly. Amazing.


### PR DESCRIPTION
Accidentally didn't take into account in #3658 that their __mul method doesn't support multiplication by other angles/vectors