### PR TITLE
Add wirecd_large to cd disk stool model list

### DIFF
--- a/lua/wire/stools/cd_disk.lua
+++ b/lua/wire/stools/cd_disk.lua
@@ -8,6 +8,7 @@ if (CLIENT) then
 
 	list.Set( "Wire_Laser_Disk_Models", "models/venompapa/wirecd_small.mdl", true )
 	list.Set( "Wire_Laser_Disk_Models", "models/venompapa/wirecd_medium.mdl", true )
+	list.Set( "Wire_Laser_Disk_Models", "models/venompapa/wirecd_large.mdl", true )
 	list.Set( "Wire_Laser_Disk_Models", "models/venompapa/wirecd_huge.mdl", true )
 
 	TOOL.Information = {


### PR DESCRIPTION
Just like title said, not sure why i didn't added it earlier.