### PR TITLE
Add wire_digitalscreen_rate convar

### DIFF
--- a/lua/entities/gmod_wire_digitalscreen/cl_init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/cl_init.lua
@@ -1,6 +1,6 @@
 include("shared.lua")
 
-
+local dsRate = GetConVar("wire_digitalscreen_rate")   
 
 function ENT:SendData()
 	net.Start("wire_interactiveprop_action")
@@ -143,7 +143,7 @@ end
 
 function ENT:Think()
 	if self.buffer[1] ~= nil then
-		local maxtime = SysTime() + RealFrameTime() * 0.05 -- do more depending on client FPS. Higher fps = more work
+		local maxtime = SysTime() + RealFrameTime() * (0.05*dsRate:GetFloat()) -- do more depending on client FPS. Higher fps = more work
 
 		while SysTime() < maxtime and self.buffer[1] do
 			if not self.co or coroutine.status(self.co) == "dead" then
@@ -320,7 +320,7 @@ function ENT:Draw(flags)
 
 	if self.NeedRefresh then
 		self.NeedRefresh = false
-		local maxtime = SysTime() + RealFrameTime() * 0.01
+		local maxtime = SysTime() + RealFrameTime() * (0.01*dsRate:GetFloat())
 
 		self.GPU:RenderToGPU(function()
 			local idx = 0

--- a/lua/entities/gmod_wire_digitalscreen/init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/init.lua
@@ -5,6 +5,7 @@ DEFINE_BASECLASS( "base_wire_entity" )
 
 ENT.WireDebugName = "DigitalScreen"
 
+local dsRate = CreateConVar("wire_digitalscreen_rate", 1, { FCVAR_REPLICATED, FCVAR_ARCHIVE })
 
 function ENT:InitInteractive()
 	local model = self:GetModel()
@@ -170,9 +171,20 @@ end
 ----------------------------------------------------
 -- Processing limiters and global bandwidth limiters
 local maxProcessingTime = engine.TickInterval() * 0.9
-local defaultMaxBandwidth = 10000 -- 10k per screen max limit - is arbitrary. needs to be smaller than the global limit.
-local defaultMaxGlobalBandwidth = 20000 -- 20k is a good global limit in my testing. higher than that seems to cause issues
+
+local dsRateValue = dsRate:GetFloat()
+local defaultMaxBandwidth = 100000 * dsRateValue -- 10k per screen max limit - is arbitrary. needs to be smaller than the global limit.
+local defaultMaxGlobalBandwidth = 200000 * dsRateValue -- 20k is a good global limit in my testing. higher than that seems to cause issues
 local maxBandwidth = defaultMaxBandwidth
+
+local function updateBW()
+    local dsRateValue = dsRate:GetFloat()
+
+    defaultMaxBandwidth = 100000 * dsRateValue
+    defaultMaxGlobalBandwidth = 200000 * dsRateValue
+end
+cvars.AddChangeCallback("wire_digitalscreen_rate", updateBW)
+
 local globalBandwidthLookup = {}
 local function calcGlobalBW()
 	maxBandwidth = defaultMaxGlobalBandwidth


### PR DESCRIPTION
This convar multiply all digital screen limits in sync, so wire_digitalscreen_rate 10 make it work exactly 10x faster.