### PR TITLE
Add wire_digitalscreen_draw_rate and wire_digitalscreen_net_bandwidth convars

### DIFF
--- a/lua/entities/gmod_wire_digitalscreen/cl_init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/cl_init.lua
@@ -1,6 +1,6 @@
 include("shared.lua")
 
-local dsRate = GetConVar("wire_digitalscreen_rate")   
+local dsDrawRate = GetConVar("wire_digitalscreen_draw_rate")   
 
 function ENT:SendData()
 	net.Start("wire_interactiveprop_action")
@@ -143,7 +143,7 @@ end
 
 function ENT:Think()
 	if self.buffer[1] ~= nil then
-		local maxtime = SysTime() + RealFrameTime() * (0.05*dsRate:GetFloat()) -- do more depending on client FPS. Higher fps = more work
+		local maxtime = SysTime() + RealFrameTime() * (0.05*dsDrawRate:GetFloat()) -- do more depending on client FPS. Higher fps = more work
 
 		while SysTime() < maxtime and self.buffer[1] do
 			if not self.co or coroutine.status(self.co) == "dead" then
@@ -320,7 +320,7 @@ function ENT:Draw(flags)
 
 	if self.NeedRefresh then
 		self.NeedRefresh = false
-		local maxtime = SysTime() + RealFrameTime() * (0.01*dsRate:GetFloat())
+		local maxtime = SysTime() + RealFrameTime() * (0.01*dsDrawRate:GetFloat())
 
 		self.GPU:RenderToGPU(function()
 			local idx = 0

--- a/lua/entities/gmod_wire_digitalscreen/cl_init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/cl_init.lua
@@ -1,6 +1,6 @@
 include("shared.lua")
 
-
+local dsRate = GetConVar("wire_digitalscreen_rate")   
 
 function ENT:SendData()
 	net.Start("wire_interactiveprop_action")
@@ -143,7 +143,7 @@ end
 
 function ENT:Think()
 	if self.buffer[1] ~= nil then
-		local maxtime = SysTime() + RealFrameTime() * 0.05 -- do more depending on client FPS. Higher fps = more work
+		local maxtime = SysTime() + RealFrameTime() * (0.05*dsRate:GetFloat()) -- do more depending on client FPS. Higher fps = more work
 
 		while SysTime() < maxtime and self.buffer[1] do
 			if not self.co or coroutine.status(self.co) == "dead" then
@@ -320,7 +320,7 @@ function ENT:Draw(flags)
 
 	if self.NeedRefresh then
 		self.NeedRefresh = false
-		local maxtime = SysTime() + RealFrameTime() * 0.01
+		local maxtime = SysTime() + RealFrameTime() * (0.01*dsRate:GetFloat())
 
 		self.GPU:RenderToGPU(function()
 			local idx = 0

--- a/lua/entities/gmod_wire_digitalscreen/cl_init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/cl_init.lua
@@ -1,6 +1,6 @@
 include("shared.lua")
 
-local dsDrawRate = GetConVar("wire_digitalscreen_draw_rate")   
+local dsDrawRate = GetConVar("wire_digitalscreen_draw_rate")
 
 function ENT:SendData()
 	net.Start("wire_interactiveprop_action")

--- a/lua/entities/gmod_wire_digitalscreen/cl_init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/cl_init.lua
@@ -81,13 +81,17 @@ function ENT:OnRemove()
 end
 
 local function stringToNumber(index, str, bytes)
-	local newpos = index+bytes
-	str = str:sub(index,newpos-1)
 	local n = 0
-	for j=1,bytes do
-		n = n + str:byte(j)*(256^(j-1))
-    end
-	return n, newpos
+	local mult = 1
+
+	-- Read bytes directly from the original string using absolute offset (index + j).
+	-- This eliminates string allocations from str:sub() and prevents Garbage Collector spikes.
+	for j = 0, bytes - 1 do
+		n = n + str:byte(index + j) * mult
+		mult = mult * 256 -- Multiplication is faster than math.pow / exponentiation (256^j)
+	end
+
+	return n, index + bytes
 end
 
 local pixelbits = {3, 1, 3, 4, 1}

--- a/lua/entities/gmod_wire_digitalscreen/cl_init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/cl_init.lua
@@ -1,6 +1,6 @@
 include("shared.lua")
 
-local dsDrawRate = GetConVar("wire_digitalscreen_draw_rate")
+local dsDrawRate = CreateConVar("wire_digitalscreen_draw_rate", 1, { FCVAR_REPLICATED, FCVAR_ARCHIVE }, "Draw rate for digital screen", 0.1, 1000)
 
 function ENT:SendData()
 	net.Start("wire_interactiveprop_action")

--- a/lua/entities/gmod_wire_digitalscreen/init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/init.lua
@@ -6,7 +6,7 @@ DEFINE_BASECLASS( "base_wire_entity" )
 ENT.WireDebugName = "DigitalScreen"
 
 local dsDrawRate = CreateConVar("wire_digitalscreen_draw_rate", 1, { FCVAR_REPLICATED, FCVAR_ARCHIVE })
-local dsNetBandwidth = CreateConVar("wire_digitalscreen_net_bandwidth", 200000, { FCVAR_REPLICATED, FCVAR_ARCHIVE })
+local dsNetBandwidth = CreateConVar("wire_digitalscreen_net_bandwidth", 200000, { FCVAR_ARCHIVE })
 local dsNetBandwidthValue = dsNetBandwidth:GetInt()
 
 function ENT:InitInteractive()

--- a/lua/entities/gmod_wire_digitalscreen/init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/init.lua
@@ -5,9 +5,9 @@ DEFINE_BASECLASS( "base_wire_entity" )
 
 ENT.WireDebugName = "DigitalScreen"
 
-local dsDrawRate = CreateConVar("wire_digitalscreen_draw_rate", 1, { FCVAR_REPLICATED, FCVAR_ARCHIVE })
-local dsNetBandwidth = CreateConVar("wire_digitalscreen_net_bandwidth", 200000, { FCVAR_ARCHIVE })
-local dsNetBandwidthValue = math.Clamp(dsNetBandwidth:GetInt(),100,2000000)
+local dsDrawRate = CreateConVar("wire_digitalscreen_draw_rate", 1, { FCVAR_REPLICATED, FCVAR_ARCHIVE }, "Draw rate for digital screen", 0.1, 1000)
+local dsNetBandwidth = CreateConVar("wire_digitalscreen_net_bandwidth", 200000, { FCVAR_ARCHIVE }, "Net bandwidth limit for digital screen (20k default)", 1000, 2000000)
+local dsNetBandwidthValue = dsNetBandwidth:GetInt()
 
 function ENT:InitInteractive()
 	local model = self:GetModel()
@@ -181,7 +181,7 @@ local defaultMaxGlobalBandwidth = dsNetBandwidthValue -- 20k is a good global li
 local maxBandwidth = defaultMaxBandwidth
 
 local function updateBW()
-    dsNetBandwidthValue = math.Clamp(dsNetBandwidth:GetInt(),100,2000000)
+    dsNetBandwidthValue = dsNetBandwidth:GetInt()
 
     defaultMaxBandwidth = math.Round(dsNetBandwidthValue/2)
     defaultMaxGlobalBandwidth = dsNetBandwidthValue

--- a/lua/entities/gmod_wire_digitalscreen/init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/init.lua
@@ -5,8 +5,9 @@ DEFINE_BASECLASS( "base_wire_entity" )
 
 ENT.WireDebugName = "DigitalScreen"
 
-local dsRate = CreateConVar("wire_digitalscreen_rate", 1, { FCVAR_REPLICATED, FCVAR_ARCHIVE })
-local dsRateValue = dsRate:GetFloat()
+local dsDrawRate = CreateConVar("wire_digitalscreen_draw_rate", 1, { FCVAR_REPLICATED, FCVAR_ARCHIVE })
+local dsNetBandwidth = CreateConVar("wire_digitalscreen_net_bandwidth", 200000, { FCVAR_REPLICATED, FCVAR_ARCHIVE })
+local dsNetBandwidthValue = dsNetBandwidth:GetInt()
 
 function ENT:InitInteractive()
 	local model = self:GetModel()
@@ -129,8 +130,9 @@ end
 function ENT:ReadCell(Address)
 	Address = math.floor(Address)
 	if Address < 0 then return nil end
-	if Address >= 1048577 then return nil end
-    if (Address==1048576) then return dsRateValue end -- report its rate
+	if Address >= 1048578 then return nil end
+    if (Address==1048577) then return math.Round(dsNetBandwidthValue/2) end -- report its netbandwidth
+    if (Address==1048576) then return dsDrawRate:GetFloat() end -- report its draw rate
 
 	return self.Memory[Address] or 0
 end
@@ -174,17 +176,17 @@ end
 -- Processing limiters and global bandwidth limiters
 local maxProcessingTime = engine.TickInterval() * 0.9
 
-local defaultMaxBandwidth = 100000 * dsRateValue -- 10k per screen max limit - is arbitrary. needs to be smaller than the global limit.
-local defaultMaxGlobalBandwidth = 200000 * dsRateValue -- 20k is a good global limit in my testing. higher than that seems to cause issues
+local defaultMaxBandwidth = math.Round(dsNetBandwidthValue/2) -- 10k per screen max limit - is arbitrary. needs to be smaller than the global limit.
+local defaultMaxGlobalBandwidth = dsNetBandwidthValue -- 20k is a good global limit in my testing. higher than that seems to cause issues
 local maxBandwidth = defaultMaxBandwidth
 
 local function updateBW()
-    dsRateValue = dsRate:GetFloat()
+    dsNetBandwidthValue = dsNetBandwidth:GetInt()
 
-    defaultMaxBandwidth = 100000 * dsRateValue
-    defaultMaxGlobalBandwidth = 200000 * dsRateValue
+    defaultMaxBandwidth = math.Round(dsNetBandwidthValue/2) 
+    defaultMaxGlobalBandwidth = dsNetBandwidthValue
 end
-cvars.AddChangeCallback("wire_digitalscreen_rate", updateBW)
+cvars.AddChangeCallback("wire_digitalscreen_net_bandwidth", updateBW)
 
 local globalBandwidthLookup = {}
 local function calcGlobalBW()

--- a/lua/entities/gmod_wire_digitalscreen/init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/init.lua
@@ -7,7 +7,7 @@ ENT.WireDebugName = "DigitalScreen"
 
 local dsDrawRate = CreateConVar("wire_digitalscreen_draw_rate", 1, { FCVAR_REPLICATED, FCVAR_ARCHIVE })
 local dsNetBandwidth = CreateConVar("wire_digitalscreen_net_bandwidth", 200000, { FCVAR_ARCHIVE })
-local dsNetBandwidthValue = dsNetBandwidth:GetInt()
+local dsNetBandwidthValue = math.Clamp(dsNetBandwidth:GetInt(),100,2000000)
 
 function ENT:InitInteractive()
 	local model = self:GetModel()
@@ -181,7 +181,7 @@ local defaultMaxGlobalBandwidth = dsNetBandwidthValue -- 20k is a good global li
 local maxBandwidth = defaultMaxBandwidth
 
 local function updateBW()
-    dsNetBandwidthValue = dsNetBandwidth:GetInt()
+    dsNetBandwidthValue = math.Clamp(dsNetBandwidth:GetInt(),100,2000000)
 
     defaultMaxBandwidth = math.Round(dsNetBandwidthValue/2) 
     defaultMaxGlobalBandwidth = dsNetBandwidthValue

--- a/lua/entities/gmod_wire_digitalscreen/init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/init.lua
@@ -6,6 +6,7 @@ DEFINE_BASECLASS( "base_wire_entity" )
 ENT.WireDebugName = "DigitalScreen"
 
 local dsRate = CreateConVar("wire_digitalscreen_rate", 1, { FCVAR_REPLICATED, FCVAR_ARCHIVE })
+local dsRateValue = dsRate:GetFloat()
 
 function ENT:InitInteractive()
 	local model = self:GetModel()
@@ -129,6 +130,7 @@ function ENT:ReadCell(Address)
 	Address = math.floor(Address)
 	if Address < 0 then return nil end
 	if Address >= 1048577 then return nil end
+    if (Address==1048576) then return dsRateValue end -- report its rate
 
 	return self.Memory[Address] or 0
 end
@@ -172,13 +174,12 @@ end
 -- Processing limiters and global bandwidth limiters
 local maxProcessingTime = engine.TickInterval() * 0.9
 
-local dsRateValue = dsRate:GetFloat()
 local defaultMaxBandwidth = 100000 * dsRateValue -- 10k per screen max limit - is arbitrary. needs to be smaller than the global limit.
 local defaultMaxGlobalBandwidth = 200000 * dsRateValue -- 20k is a good global limit in my testing. higher than that seems to cause issues
 local maxBandwidth = defaultMaxBandwidth
 
 local function updateBW()
-    local dsRateValue = dsRate:GetFloat()
+    dsRateValue = dsRate:GetFloat()
 
     defaultMaxBandwidth = 100000 * dsRateValue
     defaultMaxGlobalBandwidth = 200000 * dsRateValue

--- a/lua/entities/gmod_wire_digitalscreen/init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/init.lua
@@ -5,6 +5,7 @@ DEFINE_BASECLASS( "base_wire_entity" )
 
 ENT.WireDebugName = "DigitalScreen"
 
+local dsRate = CreateConVar("wire_digitalscreen_rate", 1, { FCVAR_REPLICATED, FCVAR_ARCHIVE })
 
 function ENT:InitInteractive()
 	local model = self:GetModel()
@@ -170,9 +171,20 @@ end
 ----------------------------------------------------
 -- Processing limiters and global bandwidth limiters
 local maxProcessingTime = engine.TickInterval() * 0.9
-local defaultMaxBandwidth = 10000 -- 10k per screen max limit - is arbitrary. needs to be smaller than the global limit.
-local defaultMaxGlobalBandwidth = 20000 -- 20k is a good global limit in my testing. higher than that seems to cause issues
+
+local dsRateValue = dsRate:GetFloat()
+local defaultMaxBandwidth = 100000 * dsRateValue -- 10k per screen max limit - is arbitrary. needs to be smaller than the global limit.
+local defaultMaxGlobalBandwidth = 200000 * dsRateValue -- 20k is a good global limit in my testing. higher than that seems to cause issues
 local maxBandwidth = defaultMaxBandwidth
+
+local function updateBW()
+    local dsRateValue = dsRate:GetFloat()
+
+    defaultMaxBandwidth = 100000 * dsRateValue
+    defaultMaxGlobalBandwidth = 200000 * dsRateValue
+end
+cvars.AddChangeCallback("wire_digitalscreen_rate", updateBW)
+
 local globalBandwidthLookup = {}
 local function calcGlobalBW()
 	maxBandwidth = defaultMaxGlobalBandwidth

--- a/lua/entities/gmod_wire_digitalscreen/init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/init.lua
@@ -183,7 +183,7 @@ local maxBandwidth = defaultMaxBandwidth
 local function updateBW()
     dsNetBandwidthValue = math.Clamp(dsNetBandwidth:GetInt(),100,2000000)
 
-    defaultMaxBandwidth = math.Round(dsNetBandwidthValue/2) 
+    defaultMaxBandwidth = math.Round(dsNetBandwidthValue/2)
     defaultMaxGlobalBandwidth = dsNetBandwidthValue
 end
 cvars.AddChangeCallback("wire_digitalscreen_net_bandwidth", updateBW)

--- a/lua/entities/gmod_wire_digitalscreen/init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/init.lua
@@ -6,7 +6,7 @@ DEFINE_BASECLASS( "base_wire_entity" )
 ENT.WireDebugName = "DigitalScreen"
 
 local dsDrawRate = CreateConVar("wire_digitalscreen_draw_rate", 1, { FCVAR_REPLICATED, FCVAR_ARCHIVE }, "Draw rate for digital screen", 0.1, 1000)
-local dsNetBandwidth = CreateConVar("wire_digitalscreen_net_bandwidth", 20000, { FCVAR_ARCHIVE }, "Net bandwidth limit for digital screen (20k default)", 1000, 20000)
+local dsNetBandwidth = CreateConVar("wire_digitalscreen_net_bandwidth", 20000, { FCVAR_ARCHIVE }, "Net bandwidth limit for digital screen (20k default)", 1000, 200000)
 local dsNetBandwidthValue = dsNetBandwidth:GetInt()
 
 function ENT:InitInteractive()

--- a/lua/entities/gmod_wire_digitalscreen/init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/init.lua
@@ -6,7 +6,7 @@ DEFINE_BASECLASS( "base_wire_entity" )
 ENT.WireDebugName = "DigitalScreen"
 
 local dsDrawRate = CreateConVar("wire_digitalscreen_draw_rate", 1, { FCVAR_REPLICATED, FCVAR_ARCHIVE }, "Draw rate for digital screen", 0.1, 1000)
-local dsNetBandwidth = CreateConVar("wire_digitalscreen_net_bandwidth", 200000, { FCVAR_ARCHIVE }, "Net bandwidth limit for digital screen (20k default)", 1000, 2000000)
+local dsNetBandwidth = CreateConVar("wire_digitalscreen_net_bandwidth", 20000, { FCVAR_ARCHIVE }, "Net bandwidth limit for digital screen (20k default)", 1000, 20000)
 local dsNetBandwidthValue = dsNetBandwidth:GetInt()
 
 function ENT:InitInteractive()


### PR DESCRIPTION
This convar multiply all digital screen limits in sync, so wire_digitalscreen_rate 10 make it work exactly 10x faster. Fixes #3670