### PR TITLE
Disable sound emitter from playing sounds across the entire map

### DIFF
--- a/lua/entities/gmod_wire_soundemitter.lua
+++ b/lua/entities/gmod_wire_soundemitter.lua
@@ -119,7 +119,7 @@ function ENT:TriggerInput(iname, value)
 	elseif iname == "Volume" then
 		self.Volume = math.Clamp(math.floor(value*100), 0.0, 100.0)
 	elseif iname == "Level" then
-		self.Level = math.Clamp(value, 55.0, 165.0)
+		self.Level = value
 	elseif iname == "PitchRelative" then
 		self.Pitch = math.Clamp(math.floor(value*100), 0, 255)
 	elseif iname == "Sample" then
@@ -159,7 +159,7 @@ function ENT:UpdateSound()
 	end
 	self.SoundObj:ChangePitch(self.Pitch, 0)
 	self.SoundObj:ChangeVolume(self.Volume / 100.0, 0)
-	self.SoundObj:SetSoundLevel(self.Level)
+	self.SoundObj:SetSoundLevel(math.Clamp(self.Level, 55, 165))
 end
 
 function ENT:SetSound(soundName)

--- a/lua/entities/gmod_wire_soundemitter.lua
+++ b/lua/entities/gmod_wire_soundemitter.lua
@@ -117,11 +117,11 @@ function ENT:TriggerInput(iname, value)
 		self.Active = false
 		self:StopSounds()
 	elseif iname == "Volume" then
-		self.Volume = math.Clamp(math.floor(value*100), 0.0, 100.0)
+		self.Volume = math.floor(value * 100)
 	elseif iname == "Level" then
 		self.Level = value
 	elseif iname == "PitchRelative" then
-		self.Pitch = math.Clamp(math.floor(value*100), 0, 255)
+		self.Pitch = math.floor(value * 100)
 	elseif iname == "Sample" then
 		self:TriggerInput("SampleName", self.Samples[value] or self.Samples[1])
 	elseif iname == "SampleName" then
@@ -157,8 +157,8 @@ function ENT:UpdateSound()
 
 		if self.Active then self:StartSounds() end
 	end
-	self.SoundObj:ChangePitch(self.Pitch, 0)
-	self.SoundObj:ChangeVolume(self.Volume / 100.0, 0)
+	self.SoundObj:ChangePitch(math.Clamp(self.Pitch, 0, 255), 0)
+	self.SoundObj:ChangeVolume(math.Clamp(self.Volume / 100, 0, 1), 0)
 	self.SoundObj:SetSoundLevel(math.Clamp(self.Level, 55, 165))
 end
 


### PR DESCRIPTION
You can create a bad dupe that can have Level 0, causing the sound to play throughout the entire map
This is probably how all the mingery dupes that play HL2 music work