### PR TITLE
Actually fix music sounds abuse

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/sound.lua
+++ b/lua/entities/gmod_wire_expression2/core/sound.lua
@@ -7,7 +7,7 @@ E2Lib.RegisterExtension("sound", true, "Allows E2s to play sounds.", "Sounds can
 local wire_expression2_maxsounds = CreateConVar( "wire_expression2_maxsounds", 16, {FCVAR_ARCHIVE} )
 local wire_expression2_sound_burst_max = CreateConVar( "wire_expression2_sound_burst_max", 8, {FCVAR_ARCHIVE} )
 local wire_expression2_sound_burst_rate = CreateConVar( "wire_expression2_sound_burst_rate", 0.1, {FCVAR_ARCHIVE} )
-local wire_sound_level_max = GetConVar( "wire_max_sound_level" )
+local wire_sound_max_level = GetConVar( "wire_sound_max_level" )
 
 ---------------------------------------------------------------
 -- Helper functions
@@ -240,7 +240,7 @@ e2function void soundLevel( index, level )
 	-- We need to set the level while the sound is stopped
 	sound:Stop()
 
-	local max_level = wire_sound_level_max:GetInt()
+	local max_level = wire_sound_max_level:GetInt()
 
 	-- 0 = play sound throughout the map
 	if max_level ~= -1 and (level == 0 or level > max_level) then
@@ -305,7 +305,7 @@ local function EmitSound(e2, ent, path, level, pitch, volume)
 	if not isOwner(e2, ent) then return e2:throw("You do not own this entity!", nil) end
 
 	if level then
-		local max_level = wire_sound_level_max:GetInt()
+		local max_level = wire_sound_max_level:GetInt()
 
 		-- 0 = play sound throughout the map
 		if max_level ~= -1 and (level == 0 or level > max_level) then

--- a/lua/entities/gmod_wire_expression2/core/sound.lua
+++ b/lua/entities/gmod_wire_expression2/core/sound.lua
@@ -7,9 +7,7 @@ E2Lib.RegisterExtension("sound", true, "Allows E2s to play sounds.", "Sounds can
 local wire_expression2_maxsounds = CreateConVar( "wire_expression2_maxsounds", 16, {FCVAR_ARCHIVE} )
 local wire_expression2_sound_burst_max = CreateConVar( "wire_expression2_sound_burst_max", 8, {FCVAR_ARCHIVE} )
 local wire_expression2_sound_burst_rate = CreateConVar( "wire_expression2_sound_burst_rate", 0.1, {FCVAR_ARCHIVE} )
-
--- _level_max: Sets the maximum soundLevel we can set on a sound. 140 is maximum to begin with, a more non-obnoxious level is maybe around 110.
-local wire_expression2_sound_level_max = CreateConVar( "wire_expression2_sound_level_max", 110, {FCVAR_ARCHIVE} )
+local wire_sound_level_max = GetConVar( "wire_max_sound_level" )
 
 ---------------------------------------------------------------
 -- Helper functions
@@ -238,9 +236,18 @@ e2function void soundDSP( string index, dsp ) = e2function void soundDSP( index,
 e2function void soundLevel( index, level )
 	local sound = getSound( self, index )
 	if not sound then return end
+
 	-- We need to set the level while the sound is stopped
 	sound:Stop()
-	sound:SetSoundLevel( math.Clamp( level, 0, wire_expression2_sound_level_max:GetInt() ) )
+
+	local max_level = wire_sound_level_max:GetInt()
+
+	-- 0 = play sound throughout the map
+	if max_level ~= -1 and (level == 0 or level > max_level) then
+		level = max_level
+	end
+
+	sound:SetSoundLevel(level)
 	sound:Play()
 end
 e2function void soundLevel( string index, level ) = e2function void soundLevel( index, level )
@@ -298,7 +305,7 @@ local function EmitSound(e2, ent, path, level, pitch, volume)
 	if not isOwner(e2, ent) then return e2:throw("You do not own this entity!", nil) end
 
 	if level then
-		local max_level = wire_expression2_sound_level_max:GetInt()
+		local max_level = wire_sound_level_max:GetInt()
 
 		-- 0 = play sound throughout the map
 		if max_level ~= -1 and (level == 0 or level > max_level) then

--- a/lua/entities/gmod_wire_soundemitter.lua
+++ b/lua/entities/gmod_wire_soundemitter.lua
@@ -32,7 +32,7 @@ function ENT:Initialize()
 	self.Volume = 100
 	self.Level = 80
 	self.Pitch = 100
-	self.sound = self.Samples[1]
+	self.sound = "synth/brown_noise.wav"
 	-- self.sound is a string, self.SoundObj is a CSoundPatch
 
 	self.NeedsRefresh = true

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1604,6 +1604,7 @@ function WireLib.SoundExists(path, ply)
 		if sound_data then
 			local sound_level = sound_data.level
 
+			-- 0 = play sound throughout the map
 			if sound_level <= 0 then
 				local sounds = sound_data.sound
 				path = istable(sounds) and sounds[math.random(#sounds)] or sounds

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1582,6 +1582,7 @@ end
 
 local uniqueSoundsTbl = setmetatable({}, {__index=function(t,k) local r={[1]=0} t[k]=r return r end})
 local maxUniqueSounds = CreateConVar("wire_sounds_unique_max", "200", FCVAR_ARCHIVE, "The maximum number of sound paths a player is allowed to cache")
+local maxSoundLevel = CreateConVar("wire_max_sound_level", "180", FCVAR_ARCHIVE, "The maximum sounds volume (-1 disable)")
 
 function WireLib.SoundExists(path, ply)
 	-- Limit length and remove invalid chars
@@ -1589,19 +1590,41 @@ function WireLib.SoundExists(path, ply)
 
 	-- Extract sound flags. See https://developer.valvesoftware.com/wiki/Soundscripts#Sound_characters
 	local flags, checkpath = string.match(path, "^([^%w_/%.]*)(.*)")
+
 	if #flags > 2 or string.match(flags, "[^#@<>%^%)}]") then
 		path = checkpath
+	end
+
+	-- Disallow too loud sounds
+	local max_level = maxSoundLevel:GetInt()
+
+	if max_level ~= -1 then
+		local sound_data = sound.GetProperties(checkpath)
+
+		if sound_data then
+			local sound_level = sound_data.level
+
+			if sound_level > max_level then
+				return
+			elseif sound_level <= 0 then
+				return
+			end
+		end
 	end
 
 	if ply then
 		-- A player can only use a certain number of unique sound paths
 		local playerSounds = uniqueSoundsTbl[ply:SteamID()]
+
 		if not playerSounds[checkpath] then
-			if playerSounds[1] >= maxUniqueSounds:GetInt() then return end
+			if playerSounds[1] >= maxUniqueSounds:GetInt() then
+				return
+			end
+
 			playerSounds[checkpath] = true
 			playerSounds[1] = playerSounds[1] + 1
 		end
-	elseif not (istable(sound.GetProperties(checkpath)) or file.Exists("sound/" .. checkpath, "GAME")) then
+	elseif not sound.GetProperties(checkpath) or not file.Exists("sound/" .. checkpath, "GAME") then
 		return
 	end
 

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1604,8 +1604,9 @@ function WireLib.SoundExists(path, ply)
 		if sound_data then
 			local sound_level = sound_data.level
 
-			if sound_level > max_level or sound_level <= 0 then
-				return
+			if sound_level <= 0 then
+				local sounds = sound_data.sound
+				path = istable(sounds) and sounds[math.random(#sounds)] or sounds
 			end
 		end
 	end

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1582,7 +1582,7 @@ end
 
 local uniqueSoundsTbl = setmetatable({}, {__index=function(t,k) local r={[1]=0} t[k]=r return r end})
 local maxUniqueSounds = CreateConVar("wire_sounds_unique_max", "200", FCVAR_ARCHIVE, "The maximum number of sound paths a player is allowed to cache")
-local maxSoundLevel = CreateConVar("wire_max_sound_level", "180", FCVAR_ARCHIVE, "The maximum sounds volume (-1 disable)")
+local maxSoundLevel = CreateConVar("wire_sound_max_level", "180", FCVAR_ARCHIVE, "The maximum sounds volume (-1 disable)")
 
 function WireLib.SoundExists(path, ply)
 	-- Limit length and remove invalid chars
@@ -1604,9 +1604,7 @@ function WireLib.SoundExists(path, ply)
 		if sound_data then
 			local sound_level = sound_data.level
 
-			if sound_level > max_level then
-				return
-			elseif sound_level <= 0 then
+			if sound_level > max_level or sound_level <= 0 then
 				return
 			end
 		end
@@ -1624,7 +1622,7 @@ function WireLib.SoundExists(path, ply)
 			playerSounds[checkpath] = true
 			playerSounds[1] = playerSounds[1] + 1
 		end
-	elseif not sound.GetProperties(checkpath) or not file.Exists("sound/" .. checkpath, "GAME") then
+	elseif not sound.GetProperties(checkpath) and not file.Exists("sound/" .. checkpath, "GAME") then
 		return
 	end
 


### PR DESCRIPTION
Added wire_sound_max_level convar
Uses regular versions of sounds that are typically played throughout the map
The default soundemmiter sound has been replaced with a more pleasant one