### PR TITLE
Some fixes about max volume clamping

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/sound.lua
+++ b/lua/entities/gmod_wire_expression2/core/sound.lua
@@ -298,7 +298,7 @@ local function EmitSound(e2, ent, path, level, pitch, volume)
 	path = WireLib.SoundExists(path)
 	if not path then return end
 
-	ent:EmitSound(path, WireLib.ClampSoundLevel(level), pitch, volume)
+	ent:EmitSound(path, WireLib.ClampSoundLevel(level or SNDLVL_75dB), pitch, volume)
 end
 
 __e2setcost(20)

--- a/lua/entities/gmod_wire_expression2/core/sound.lua
+++ b/lua/entities/gmod_wire_expression2/core/sound.lua
@@ -7,7 +7,6 @@ E2Lib.RegisterExtension("sound", true, "Allows E2s to play sounds.", "Sounds can
 local wire_expression2_maxsounds = CreateConVar( "wire_expression2_maxsounds", 16, {FCVAR_ARCHIVE} )
 local wire_expression2_sound_burst_max = CreateConVar( "wire_expression2_sound_burst_max", 8, {FCVAR_ARCHIVE} )
 local wire_expression2_sound_burst_rate = CreateConVar( "wire_expression2_sound_burst_rate", 0.1, {FCVAR_ARCHIVE} )
-local wire_sound_max_level = GetConVar( "wire_sound_max_level" )
 
 ---------------------------------------------------------------
 -- Helper functions
@@ -239,15 +238,7 @@ e2function void soundLevel( index, level )
 
 	-- We need to set the level while the sound is stopped
 	sound:Stop()
-
-	local max_level = wire_sound_max_level:GetInt()
-
-	-- 0 = play sound throughout the map
-	if max_level ~= -1 and (level == 0 or level > max_level) then
-		level = max_level
-	end
-
-	sound:SetSoundLevel(level)
+	sound:SetSoundLevel(WireLib.ClampSoundLevel(level))
 	sound:Play()
 end
 e2function void soundLevel( string index, level ) = e2function void soundLevel( index, level )
@@ -304,19 +295,10 @@ local function EmitSound(e2, ent, path, level, pitch, volume)
 	if not IsValid(ent) then return e2:throw("Invalid entity!", nil) end
 	if not isOwner(e2, ent) then return e2:throw("You do not own this entity!", nil) end
 
-	if level then
-		local max_level = wire_sound_max_level:GetInt()
-
-		-- 0 = play sound throughout the map
-		if max_level ~= -1 and (level == 0 or level > max_level) then
-			level = max_level
-		end
-	end
-
 	path = WireLib.SoundExists(path)
 	if not path then return end
 
-	ent:EmitSound(path, level, pitch, volume)
+	ent:EmitSound(path, WireLib.ClampSoundLevel(level), pitch, volume)
 end
 
 __e2setcost(20)

--- a/lua/entities/gmod_wire_soundemitter.lua
+++ b/lua/entities/gmod_wire_soundemitter.lua
@@ -157,9 +157,10 @@ function ENT:UpdateSound()
 
 		if self.Active then self:StartSounds() end
 	end
+
 	self.SoundObj:ChangePitch(math.Clamp(self.Pitch, 0, 255), 0)
 	self.SoundObj:ChangeVolume(math.Clamp(self.Volume / 100, 0, 1), 0)
-	self.SoundObj:SetSoundLevel(math.Clamp(self.Level, 55, 165))
+	self.SoundObj:SetSoundLevel(WireLib.ClampSoundLevel(self.Level))
 end
 
 function ENT:SetSound(soundName)

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1582,7 +1582,17 @@ end
 
 local uniqueSoundsTbl = setmetatable({}, {__index=function(t,k) local r={[1]=0} t[k]=r return r end})
 local maxUniqueSounds = CreateConVar("wire_sounds_unique_max", "200", FCVAR_ARCHIVE, "The maximum number of sound paths a player is allowed to cache")
-local maxSoundLevel = CreateConVar("wire_sound_max_level", "180", FCVAR_ARCHIVE, "The maximum sounds volume (-1 disable)")
+local maxSoundLevel = CreateConVar("wire_sound_max_level", "255", FCVAR_ARCHIVE, "The maximum sounds volume (0 to disable)")
+
+function WireLib.ClampSoundLevel(level)
+	local max_level = maxSoundLevel:GetInt()
+
+	if max_level > 0 then
+		return level <= 0 and max_level or math.min(level, max_level)
+	else
+		return level
+	end
+end
 
 function WireLib.SoundExists(path, ply)
 	-- Limit length and remove invalid chars
@@ -1598,14 +1608,14 @@ function WireLib.SoundExists(path, ply)
 	-- Disallow too loud sounds
 	local max_level = maxSoundLevel:GetInt()
 
-	if max_level ~= -1 then
+	if max_level > 0 then
 		local sound_data = sound.GetProperties(checkpath)
 
 		if sound_data then
 			local sound_level = sound_data.level
 
 			-- 0 = play sound throughout the map
-			if sound_level <= 0 then
+			if sound_level <= 0 or sound_level > max_level then
 				local sounds = sound_data.sound
 				path = istable(sounds) and sounds[math.random(#sounds)] or sounds
 			end

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1614,7 +1614,7 @@ function WireLib.SoundExists(path, ply)
 		if sound_data then
 			local sound_level = sound_data.level
 
-			-- 0 = play sound throughout the map
+			-- We can't clamp soundlevel of soundscript, take it's sound directly
 			if sound_level <= 0 or sound_level > max_level then
 				local sounds = sound_data.sound
 				path = istable(sounds) and sounds[math.random(#sounds)] or sounds

--- a/lua/wire/server/wirelib.lua
+++ b/lua/wire/server/wirelib.lua
@@ -1581,8 +1581,8 @@ if not WireLib.PatchedDuplicator then
 end
 
 local uniqueSoundsTbl = setmetatable({}, {__index=function(t,k) local r={[1]=0} t[k]=r return r end})
-local maxUniqueSounds = CreateConVar("wire_sounds_unique_max", "200", FCVAR_ARCHIVE, "The maximum number of sound paths a player is allowed to cache")
-local maxSoundLevel = CreateConVar("wire_sound_max_level", "255", FCVAR_ARCHIVE, "The maximum sounds volume (0 to disable)")
+local maxUniqueSounds = CreateConVar("wire_sounds_unique_max", "200", FCVAR_ARCHIVE, "The maximum number of sound paths a player is allowed to cache", 0)
+local maxSoundLevel = CreateConVar("wire_sound_max_level", "255", FCVAR_ARCHIVE, "The maximum sounds volume (0 to disable)", 0, 255)
 
 function WireLib.ClampSoundLevel(level)
 	local max_level = maxSoundLevel:GetInt()


### PR DESCRIPTION
Changed wire_sound_max_level default to 255 (to ONLY clamp sounds playing across entire map)
Fixed a bug where restrictions could be bypassed using negative values ​​or nan
Added universal function WireLib.ClampSoundLevel