### PR TITLE
Fix/improve highspeed access in number/array plugs

### DIFF
--- a/lua/entities/gmod_wire_plug.lua
+++ b/lua/entities/gmod_wire_plug.lua
@@ -60,7 +60,7 @@ function ENT:Initialize()
 
 	self:SetLinked( false )
 
-	self.Memory = {}
+	self.Memory = nil
 end
 
 function ENT:Setup( ArrayInput )
@@ -83,6 +83,13 @@ end
 function ENT:TriggerInput( name, value )
 	if (self.Socket and self.Socket:IsValid()) then
 		self.Socket:SetValue( name, value )
+	end
+	if not self.ArrayInput then
+		if (self.Inputs['A'].Src and self.Inputs['A'].Src:IsValid()) then
+			self.Memory = self.Inputs['A'].Src
+		else
+			self.Memory = nil
+		end
 	end
 	self:ShowOutput()
 end
@@ -121,10 +128,20 @@ end
 -- Hi-speed support
 ------------------------------------------------------------
 function ENT:WriteCell( Address, Value, WriteToMe )
-	Address = math.floor(Address)
+	Address = math.floor(Address or 0)
 	if (WriteToMe) then
-		self.Memory[Address or 1] = Value or 0
-		return true
+		--this would allow the plug to work almost like a dhdd, which seems silly.
+		--[[if self.ArrayInput then
+			-- 256 KiB limit
+			if Address < 0 or Address >= 262144 then return false end
+			self.Inputs.In.Value[Address] = Value or 0
+			return true
+		end]]--
+		if (self.Memory and self.Memory.WriteCell) then
+			self.Memory:WriteCell(Address, Value)
+			return true
+		end
+		return false
 	else
 		if (self.Socket and self.Socket:IsValid()) then
 			self.Socket:WriteCell( Address, Value, true )
@@ -139,9 +156,23 @@ end
 -- ReadCell
 -- Hi-speed support
 ------------------------------------------------------------
-function ENT:ReadCell( Address )
-	Address = math.floor(Address)
-	return self.Memory[Address or 1] or 0
+function ENT:ReadCell( Address, ReadFromMe )
+	Address = math.floor(Address or 0)
+	if (ReadFromMe) then
+		if self.ArrayInput then
+			return self.Inputs.In.Value[Address] or 0
+		end
+		if (self.Memory and self.Memory.ReadCell) then
+			return self.Memory:ReadCell(Address)
+		end
+		return 0
+	else
+		if (self.Socket and self.Socket:IsValid()) then
+			return self.Socket:ReadCell( Address, true )
+		else
+			return 0
+		end
+	end
 end
 
 function ENT:Think()
@@ -157,7 +188,7 @@ function ENT:ResetValues()
 			WireLib.TriggerOutput( self, LETTERS[i], 0 )
 		end
 	end
-	self.Memory = {}
+	self.Memory = nil
 	self:ShowOutput()
 end
 

--- a/lua/entities/gmod_wire_socket.lua
+++ b/lua/entities/gmod_wire_socket.lua
@@ -110,7 +110,7 @@ function ENT:Initialize()
 
 	self:SetLinked( false )
 
-	self.Memory = {}
+	self.Memory = nil
 
 	self.DoNextThink = CurTime() + 5 -- wait 5 seconds
 end
@@ -139,6 +139,13 @@ end
 function ENT:TriggerInput( name, value )
 	if (self.Plug and self.Plug:IsValid()) then
 		self.Plug:SetValue( name, value )
+	end
+	if not self.ArrayInput then
+		if (self.Inputs['A'].Src and self.Inputs['A'].Src:IsValid()) then
+			self.Memory = self.Inputs['A'].Src
+		else
+			self.Memory = nil
+		end
 	end
 	self:ShowOutput()
 end
@@ -177,10 +184,20 @@ end
 -- Hi-speed support
 ------------------------------------------------------------
 function ENT:WriteCell( Address, Value, WriteToMe )
-	Address = math.floor(Address)
+	Address = math.floor(Address or 0)
 	if (WriteToMe) then
-		self.Memory[Address or 1] = Value or 0
-		return true
+		--this would allow the plug to work almost like a dhdd, which seems silly.
+		--[[if self.ArrayInput then
+			-- 256 KiB limit
+			if Address < 0 or Address >= 262144 then return false end
+			self.Inputs.In.Value[Address] = Value or 0
+			return true
+		end]]--
+		if (self.Memory and self.Memory.WriteCell) then
+			self.Memory:WriteCell(Address, Value)
+			return true
+		end
+		return false
 	else
 		if (self.Plug and self.Plug:IsValid()) then
 			self.Plug:WriteCell( Address, Value, true )
@@ -195,9 +212,23 @@ end
 -- ReadCell
 -- Hi-speed support
 ------------------------------------------------------------
-function ENT:ReadCell( Address )
-	Address = math.floor(Address)
-	return self.Memory[Address or 1] or 0
+function ENT:ReadCell( Address, ReadFromMe )
+	Address = math.floor(Address or 0)
+	if (ReadFromMe) then
+		if self.ArrayInput then
+			return self.Inputs.In.Value[Address] or 0
+		end
+		if (self.Memory and self.Memory.ReadCell) then
+			return self.Memory:ReadCell(Address)
+		end
+		return 0
+	else
+		if (self.Plug and self.Plug:IsValid()) then
+			return self.Plug:ReadCell( Address, true )
+		else
+			return 0
+		end
+	end
 end
 
 function ENT:ResetValues()
@@ -208,7 +239,7 @@ function ENT:ResetValues()
 			WireLib.TriggerOutput( self, LETTERS[i], 0 )
 		end
 	end
-	self.Memory = {}
+	self.Memory = nil
 	self:ShowOutput()
 end
 


### PR DESCRIPTION
Currently, the number/array plugs have a half baked highspeed implementation.

For some reason each entity has their own memory tables, and neither WriteCell or ReadCell clamp the address to anything besides flooring it, which allows them to store an unlimited amount of data. Values stored here don't even show up in the array or number outputs.

Instead of removing the highspeed interface from them, I took the opportunity to improve it to allow for a highspeed device to connect to a plug/socket in tandem with number/array values. Arrays are readable with highspeed but not writeable to prevent abuse.

The purpose of this is to overcome a shortcoming with the other type of plug/socket; they can send a highspeed signal, but you can't send anything else without mapping it into the same memory space. This requires extra complexity and entities, especially if the number(s) need to trigger something. The changes here entirely solve this problem.

While I'm here, doesn't it seem silly that we have 4 different entities (plug/socket, dataplug/datasocket) where any 2 do almost the exact same thing as each other (even now)? If these plugs were to be given an extra 'Memory' input in conjunction with some additional changes, they could entirely replace the other plug with a similar mechanism I used in #3654. The same mechanism could be improved to remove the need for separate plug/socket entities, thus reducing the count from 4 to 1 while maintaining full backwards compatibility with old dupes.