### PR TITLE
Fix lua error

### DIFF
--- a/lua/entities/gmod_wire_target_finder.lua
+++ b/lua/entities/gmod_wire_target_finder.lua
@@ -51,7 +51,7 @@ function ENT:Setup(maxrange, players, npcs, npcname, beacons, hoverballs, thrust
 		entity = entity,
 	})
 
-	tab.MaxRange = maxrange
+	tab.MaxRange = maxrange or 10
 	tab.MinRange = minrange or 1
 	tab.TargetPlayer = players
 	tab.NoTargetOwner = notargetowner


### PR DESCRIPTION
Fixes:
```
- addons/wire/lua/entities/gmod_wire_target_finder.lua:324: bad argument #2 to 'FindInSphere' (number expected, got boolean)
1. FindInSphere - [C]:-1
 2. <unknown> - addons/wire/lua/entities/gmod_wire_target_finder.lua:324
```
In the old version of target finder it did fallback to 10, probably for backward compatibility or something