### PR TITLE
wire EEPROM doesn't write last index from cache!

### DIFF
--- a/lua/entities/gmod_wire_hdd.lua
+++ b/lua/entities/gmod_wire_hdd.lua
@@ -127,7 +127,7 @@ end
 
 function ENT:MakeFloatTable(Table)
 	local text = ""
-	for i=0,#Table-1 do
+	for i=0,#Table do
 		--Clamp size to 24 chars
 		local floatstr = string.sub(tostring(Table[i]),1,24)
 		--Make a string, and append missing spaces


### PR DESCRIPTION
I found this bug while debugging why i have data loss in eeprom after paste it again. and found critical bug! in lua #table will return 31 for 0-based lua table, not 32, since we are starting from 0 it should NOT have -1 here!!! After this change finally there is no anymore data loss issues!