### PR TITLE
Fix digital screen color modes

### DIFF
--- a/lua/entities/gmod_wire_digitalscreen/cl_init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/cl_init.lua
@@ -240,25 +240,13 @@ transformcolor[0] = function(c) -- RGBXXX
 	local crgb = math.floor(c / 1000)
 	local cgray = c - math.floor(c / 1000)*1000
 
-	cb = cgray+28*math.fmod(crgb, 10)
-	cg = cgray+28*math.fmod(math.floor(crgb / 10), 10)
-	cr = cgray+28*math.fmod(math.floor(crgb / 100), 10)
-
-	return cr, cg, cb
+	return cgray+28*math.fmod(math.floor(crgb / 100), 10), cgray+28*math.fmod(math.floor(crgb / 10), 10), cgray+28*math.fmod(crgb, 10)
 end
 transformcolor[2] = function(c) -- 24 bit mode
-	cb = math.fmod(c, 256)
-	cg = math.fmod(math.floor(c / 256), 256)
-	cr = math.fmod(math.floor(c / 65536), 256)
-
-	return cr, cg, cb
+	return math.fmod(math.floor(c / 65536), 256), math.fmod(math.floor(c / 256), 256), math.fmod(c, 256)
 end
 transformcolor[3] = function(c) -- RRRGGGBBB
-	cb = math.fmod(c, 1000)
-	cg = math.fmod(math.floor(c / 1e3), 1000)
-	cr = math.fmod(math.floor(c / 1e6), 1000)
-
-	return cr, cg, cb
+	return math.fmod(math.floor(c / 1e6), 1000), math.fmod(math.floor(c / 1e3), 1000), math.fmod(c, 1000)
 end
 
 function ENT:RedrawPixel(a)

--- a/lua/entities/gmod_wire_digitalscreen/cl_init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/cl_init.lua
@@ -245,7 +245,6 @@ transformcolor[0] = function(c) -- RGBXXX
 	cr = cgray+28*math.fmod(math.floor(crgb / 100), 10)
 
 	return cr, cg, cb
-
 end
 transformcolor[2] = function(c) -- 24 bit mode
 	cb = math.fmod(c, 256)
@@ -253,7 +252,6 @@ transformcolor[2] = function(c) -- 24 bit mode
 	cr = math.fmod(math.floor(c / 65536), 256)
 
 	return cr, cg, cb
-
 end
 transformcolor[3] = function(c) -- RRRGGGBBB
 	cb = math.fmod(c, 1000)

--- a/lua/entities/gmod_wire_digitalscreen/cl_init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/cl_init.lua
@@ -248,6 +248,9 @@ end
 transformcolor[3] = function(c) -- RRRGGGBBB
 	return math.fmod(math.floor(c / 1e6), 1000), math.fmod(math.floor(c / 1e3), 1000), math.fmod(c, 1000)
 end
+transformcolor[4] = function(c) -- XXX
+	return c, c, c
+end
 
 function ENT:RedrawPixel(a)
 	if a >= self.ScreenWidth*self.ScreenHeight then return end

--- a/lua/entities/gmod_wire_digitalscreen/cl_init.lua
+++ b/lua/entities/gmod_wire_digitalscreen/cl_init.lua
@@ -240,16 +240,27 @@ transformcolor[0] = function(c) -- RGBXXX
 	local crgb = math.floor(c / 1000)
 	local cgray = c - math.floor(c / 1000)*1000
 
-	return cgray+28*math.fmod(crgb, 10), cgray+28*math.fmod(math.floor(crgb / 10), 10), cgray+28*math.fmod(math.floor(crgb / 100), 10)
+	cb = cgray+28*math.fmod(crgb, 10)
+	cg = cgray+28*math.fmod(math.floor(crgb / 10), 10)
+	cr = cgray+28*math.fmod(math.floor(crgb / 100), 10)
+
+	return cr, cg, cb
+
 end
 transformcolor[2] = function(c) -- 24 bit mode
-	return math.fmod(c, 256), math.fmod(math.floor(c / 256), 256), math.fmod(math.floor(c / 65536), 256)
+	cb = math.fmod(c, 256)
+	cg = math.fmod(math.floor(c / 256), 256)
+	cr = math.fmod(math.floor(c / 65536), 256)
+
+	return cr, cg, cb
+
 end
 transformcolor[3] = function(c) -- RRRGGGBBB
-	return math.fmod(c, 1000), math.fmod(math.floor(c / 1e3), 1000), math.fmod(math.floor(c / 1e6), 1000)
-end
-transformcolor[4] = function(c) -- XXX
-	return c, c, c
+	cb = math.fmod(c, 1000)
+	cg = math.fmod(math.floor(c / 1e3), 1000)
+	cr = math.fmod(math.floor(c / 1e6), 1000)
+
+	return cr, cg, cb
 end
 
 function ENT:RedrawPixel(a)


### PR DESCRIPTION
#3705 broke rendering with digital screens. This reverts those breaking changes.

Here is a screenshot of what the breaking changes do to images:
<img width="1669" height="1077" alt="image" src="https://github.com/user-attachments/assets/50ec0616-3e38-4887-930c-a250c7ddb9e2" />
