### PR TITLE
"New" counterstrike models for screens/keyboard

### DIFF
--- a/lua/wire/client/cl_modelplug.lua
+++ b/lua/wire/client/cl_modelplug.lua
@@ -145,7 +145,9 @@ ModelPlug.ListAddModels("WireScreenModels", {
 	"models/fasteroid/bull/lcd3.mdl",
 	"models/fasteroid/bull/lcd4.mdl",
 	"models/fasteroid/bull/lcd5.mdl",
-	"models/props_phx/construct/windows/window1x1.mdl"
+	"models/props_phx/construct/windows/window1x1.mdl",
+	"models/props/cs_militia/tv_console.mdl",
+	"models/props/cs_militia/television_console01.mdl"
 })
 
 --screens without a GPULib setup (for the tools wire_panel and wire_screen)
@@ -349,7 +351,8 @@ ModelPlug.ListAddModels("Wire_Light_Models", {
 ModelPlug.ListAddModels("Wire_Keyboard_Models",{
 	"models/beer/wiremod/keyboard.mdl",
 	"models/jaanus/wiretool/wiretool_input.mdl",
-	"models/props_c17/computer01_keyboard.mdl"
+	"models/props_c17/computer01_keyboard.mdl",
+	"models/props/cs_office/computer_keyboard.mdl"
 })
 
 ModelPlug.ListAddModels("Wire_Hydraulic_Models",{

--- a/lua/wire/wiremonitors.lua
+++ b/lua/wire/wiremonitors.lua
@@ -222,8 +222,8 @@ WireGPU_FromBox_Helper("16x4 LCD",         "models/fasteroid/bull/lcd3.mdl",    
 WireGPU_FromBox_Helper("40x4 LCD",         "models/fasteroid/bull/lcd4.mdl",         Vector(-4.91,-3.11,-3), Vector(26.22,1.02,0.8), Angle(0, 90, 0))
 WireGPU_FromBox_Helper("20x4 LCD",         "models/fasteroid/bull/lcd5.mdl",         Vector(-4.91,-3.11,-3), Vector(10.65,1.02,0.8), Angle(0, 90, 0))
 
-WireGPU_FromBox_Helper("TV Console",    "models/props/cs_militia/television_console01.mdl",   Vector(-55,-20,13.5), Vector(-23,20,13.5), Angle(90, 0, 0))
-WireGPU_FromBox_Helper("TV Console 2",    "models/props/cs_militia/tv_console.mdl",   Vector(-9.2,-9.2,-3), Vector(9.2,9.2,-0.3), Angle(0, -90, 0))
+WireGPU_FromBox_Helper("TV Console",    "models/props/cs_militia/television_console01.mdl",   Vector(-22,23,13.5), Vector(22,55,13.5), Angle(0,90,90))
+WireGPU_FromBox_Helper("TV Console 2",    "models/props/cs_militia/tv_console.mdl",           Vector(-22,11,21.5), Vector(22,42,21.5), Angle(0,90,90))
 
 -- Offset front, offset up, offset right, resolution/scale                                OF    OU     OR   SCALE   LOWX      HIGHX    LOWY     HIGHY   ROTATE90
 --WireGPU_AddMonitor("LED Board (1:1)",   "models/blacknecro/ledboard60.mdl",               6.1, 18.5 , 11 , 0.065 , -60     , 60     , -60    , 60    ) -- broken

--- a/lua/wire/wiremonitors.lua
+++ b/lua/wire/wiremonitors.lua
@@ -222,6 +222,9 @@ WireGPU_FromBox_Helper("16x4 LCD",         "models/fasteroid/bull/lcd3.mdl",    
 WireGPU_FromBox_Helper("40x4 LCD",         "models/fasteroid/bull/lcd4.mdl",         Vector(-4.91,-3.11,-3), Vector(26.22,1.02,0.8), Angle(0, 90, 0))
 WireGPU_FromBox_Helper("20x4 LCD",         "models/fasteroid/bull/lcd5.mdl",         Vector(-4.91,-3.11,-3), Vector(10.65,1.02,0.8), Angle(0, 90, 0))
 
+WireGPU_FromBox_Helper("TV Console",    "models/props/cs_militia/television_console01.mdl",   Vector(-55,-20,13.5), Vector(-23,20,13.5), Angle(90, 0, 0))
+WireGPU_FromBox_Helper("TV Console 2",    "models/props/cs_militia/tv_console.mdl",   Vector(-9.2,-9.2,-3), Vector(9.2,9.2,-0.3), Angle(0, -90, 0))
+
 -- Offset front, offset up, offset right, resolution/scale                                OF    OU     OR   SCALE   LOWX      HIGHX    LOWY     HIGHY   ROTATE90
 --WireGPU_AddMonitor("LED Board (1:1)",   "models/blacknecro/ledboard60.mdl",               6.1, 18.5 , 11 , 0.065 , -60     , 60     , -60    , 60    ) -- broken
 

--- a/lua/wire/wiremonitors.lua
+++ b/lua/wire/wiremonitors.lua
@@ -236,8 +236,6 @@ WireGPU_FromBox("TF2 Red vs Blue billboard", "models/props_mining/billboard002.m
 WireGPU_AddMonitor("Window", "models/props_phx/construct/windows/window1x1.mdl", 0, 1.7, 0, nil, -17.3, 17.3, -17.3, 17.3, true, true)
 
 --[[
-models/props/cs_militia/television_console01.mdl
-models/props/cs_militia/tv_console.mdl
 models/props_silo/silo_launchroom_monitor.mdl
 models/props_bts/glados_screenborder_curve.mdl
 models/props_spytech/tv001.mdl


### PR DESCRIPTION
Since these come with every copy of GMod now, there's no reason to not use them.

The keyboard comes from cs_office, and the TV sets come from cs_militia.

<img width="1280" height="720" alt="202903~1" src="https://github.com/user-attachments/assets/7546bd0c-7ba5-4807-ae5a-b540d734eada" />
