### PR TITLE
Move chip cpu time calculation at the end of execution

### DIFF
--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -175,7 +175,6 @@ function ENT:Execute(script, context)
 		end
 	end
 
-	context.time = context.time + (SysTime() - bench)
 	context.stackdepth = context.stackdepth - 1
 
 	local forceTriggerOutputs = selfTbl.first or selfTbl.duped
@@ -206,6 +205,8 @@ function ENT:Execute(script, context)
 			globalScope[k] = fixDefault(wire_expression_types2[var.type][2])
 		end
 	end
+
+	context.time = context.time + (SysTime() - bench)
 
 	if context.prfcount + context.prf - e2_softquota > e2_hardquota then
 		local trace = context.trace

--- a/lua/entities/gmod_wire_expression2/init.lua
+++ b/lua/entities/gmod_wire_expression2/init.lua
@@ -230,6 +230,7 @@ function ENT:ExecuteEvent(evt, args)
 	local handlers = selfTbl.registered_events[evt]
 	if not handlers then return end
 
+	local bench = SysTime()
 	self:PCallHook("preexecute")
 
 	for name, handler in pairs(handlers) do
@@ -239,7 +240,6 @@ function ENT:ExecuteEvent(evt, args)
 			self:Error("Expression 2 (" .. selfTbl.name .. "): stack quota exceeded", "stack quota exceeded")
 		end
 
-		local bench = SysTime()
 		local ok, msg = pcall(handler, context, args)
 
 		if not ok then
@@ -259,7 +259,6 @@ function ENT:ExecuteEvent(evt, args)
 			end
 		end
 
-		context.time = context.time + (SysTime() - bench)
 		context.stackdepth = context.stackdepth - 1
 	end
 
@@ -276,6 +275,8 @@ function ENT:ExecuteEvent(evt, args)
 			globalScope[k] = fixDefault(wire_expression_types2[var.type][2])
 		end
 	end
+
+	context.time = context.time + (SysTime() - bench)
 
 	if context.prfcount + context.prf - e2_softquota > e2_hardquota then
 		local trace = context.trace


### PR DESCRIPTION
It seems that a significant part of lag from E2 chips is not tracked, this should make the CPU time calculation more accurate